### PR TITLE
Add browser field and remove withAuth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ yarn add @auth0/nextjs-auth0
 
 ## Getting Started
 
-### Build Time Configuration
-
-Create a `next.config.js` file in which you load the Auth0 plugin:
-
-```js
-const { withAuth0 } = require('@auth0/nextjs-auth0');
-
-module.exports = withAuth0({
-  webpack(config, options) {
-    return config
-  }
-})
-```
-
 ### Runtime Configuration
 
 And then create an instance of the Auth0 plugin (eg: under `/utils/auth0.js`):
@@ -221,7 +207,7 @@ import auth0 from '../../utils/auth0';
 export default async function getCustomers(req, res) {
   try {
     const { accessToken } = await auth0.getSession(req);
-    
+
     const apiClient = new MyApiClient(accessToken);
     return apiClient.getCustomers();
   } catch(error) {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-plugin-import": "^2.18.2",
     "jest": "^24.9.0",
+    "next": "^9.0.5",
     "nock": "^11.3.3",
     "prettier": "^1.18.2",
     "request": "^2.88.0",
@@ -66,10 +67,10 @@
     "@hapi/iron": "^5.1.1",
     "base64url": "^3.0.1",
     "cookie": "^0.4.0",
-    "next": "^9.0.5",
-    "openid-client": "^3.6.2",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "openid-client": "^3.6.2"
+  },
+  "peerDependencies": {
+    "next": "^9.0.5"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Next.js SDK for signing in with Auth0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/instance.browser.js",
+  "browser": "dist/index.browser.js",
   "directories": {
     "test": "tests"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Next.js SDK for signing in with Auth0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "browser": "dist/instance.browser.js",
   "directories": {
     "test": "tests"
   },

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,0 +1,7 @@
+/* eslint-disable */
+import IAuth0Settings from './settings';
+import { ISignInWithAuth0 } from './instance';
+
+export function useAuth0(settings: IAuth0Settings): ISignInWithAuth0 {
+  return require('./instance.browser').default(settings);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,3 @@ export function useAuth0(settings: IAuth0Settings): ISignInWithAuth0 {
 
   return require('./instance.node').default(settings);
 };
-
-/**
- * @deprecated this is now a no-op and is no longer required
- */
-// @ts-ignore un-used options (left for backwards compatibility)
-export function withAuth0(nextConfig: any = {}, options: any = {}): any {
-  return nextConfig
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,18 +11,10 @@ export function useAuth0(settings: IAuth0Settings): ISignInWithAuth0 {
   return require('./instance.node').default(settings);
 };
 
+/**
+ * @deprecated this is now a no-op and is no longer required
+ */
+// @ts-ignore un-used options (left for backwards compatibility)
 export function withAuth0(nextConfig: any = {}, options: any = {}): any {
-  return Object.assign({}, nextConfig, {
-    webpack(config: any, { isServer }: { isServer: boolean }): any {
-      if (!isServer) {
-        config.externals = ['openid-client'];
-      }
-
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(config, options)
-      }
-
-      return config;
-    }
-  });
+  return nextConfig
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,0 @@
-import { withAuth0 } from '../src';
-
-describe('withAuth0', () => {
-  test('should be exported correctly in node', async () => {
-    expect(withAuth0).toBeInstanceOf(Function);
-  });
-});


### PR DESCRIPTION
### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

This PR adds usage of the `browser` field to `package.json` to allow using the `instance.browser.js` for browser builds. This removes the need for `withAuth0` build time configuration. It also moves `next` as a `peerDependency`/`devDependency` and removes `react` and `react-dom` as dependencies since they are not needed

> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.

No breaking changes as the `withAuth0` method has been left as a no-op with a deprecated comment. 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Remove `withAuth0` from a Next.js application using `@auth0/nextjs-auth0` and see that it works without.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
