### PR TITLE
Add support to store the refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ export default useAuth0({
     // Store the id_token in the session. Defaults to false.
     storeIdToken: false,
     // Store the access_token in the session. Defaults to false.
-    storeAccessToken: false
+    storeAccessToken: false,
+    // Store the refresh_token in the session. Defaults to false.
+    storeRefreshToken: false
   },
   httpClient: {
     // Optionally configure the timeout for the HTTP client.

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -66,6 +66,7 @@ export default function callbackHandler(
       },
       idToken: tokenSet.id_token,
       accessToken: tokenSet.access_token,
+      refreshToken: tokenSet.refresh_token,
       createdAt: Date.now()
     };
 

--- a/src/session/cookie-store/index.ts
+++ b/src/session/cookie-store/index.ts
@@ -44,7 +44,7 @@ export default class CookieSessionStore implements ISessionStore {
     } = this.settings;
 
     const {
-      idToken, accessToken, user, createdAt
+      idToken, accessToken, refreshToken, user, createdAt
     } = session;
     const persistedSession = new Session(user, createdAt);
 
@@ -54,6 +54,10 @@ export default class CookieSessionStore implements ISessionStore {
 
     if (this.settings.storeAccessToken && accessToken) {
       persistedSession.accessToken = accessToken;
+    }
+
+    if (this.settings.storeRefreshToken && refreshToken) {
+      persistedSession.refreshToken = refreshToken;
     }
 
     const encryptedSession = await Iron.seal(persistedSession, cookieSecret, Iron.defaults);

--- a/src/session/cookie-store/settings.ts
+++ b/src/session/cookie-store/settings.ts
@@ -33,6 +33,12 @@ export interface ICookieSessionStoreSettings {
    * Defaults to 'false'
    */
   storeAccessToken?: boolean;
+
+  /**
+   * Save the refresh_token in the cookie.
+   * Defaults to 'false'
+   */
+  storeRefreshToken?: boolean;
 }
 
 export default class CookieSessionStoreSettings {
@@ -47,6 +53,8 @@ export default class CookieSessionStoreSettings {
   readonly storeIdToken: boolean;
 
   readonly storeAccessToken: boolean;
+
+  readonly storeRefreshToken: boolean;
 
   constructor(settings: ICookieSessionStoreSettings) {
     this.cookieSecret = settings.cookieSecret;
@@ -72,5 +80,6 @@ export default class CookieSessionStoreSettings {
 
     this.storeIdToken = settings.storeIdToken || false;
     this.storeAccessToken = settings.storeAccessToken || false;
+    this.storeRefreshToken = settings.storeRefreshToken || false;
   }
 }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -15,6 +15,11 @@ export interface ISession {
   readonly accessToken?: string | undefined;
 
   /**
+   * The refresh token.
+   */
+  readonly refreshToken?: string | undefined;
+
+  /**
    * The time on which the session was created.
    */
   readonly createdAt: number;
@@ -33,6 +38,8 @@ export default class Session implements ISession {
   idToken?: string | undefined;
 
   accessToken?: string | undefined;
+
+  refreshToken?: string | undefined;
 
   createdAt: number;
 

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -49,6 +49,7 @@ describe('profile handler', () => {
       },
       idToken: 'my-id-token',
       accessToken: 'my-access-token',
+      refreshToken: 'my-refresh-token',
       createdAt: Date.now()
     });
 

--- a/tests/handlers/session.test.ts
+++ b/tests/handlers/session.test.ts
@@ -15,7 +15,8 @@ describe('session handler', () => {
             sub: '123'
           },
           createdAt: now,
-          idToken: 'my-id-token'
+          idToken: 'my-id-token',
+          refreshToken: 'my-refresh-token'
         });
       },
       save(): Promise<void> {
@@ -28,7 +29,8 @@ describe('session handler', () => {
     expect(session).toEqual({
       user: { sub: '123' },
       createdAt: now,
-      idToken: 'my-id-token'
+      idToken: 'my-id-token',
+      refreshToken: 'my-refresh-token'
     });
   });
 });

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -122,7 +122,7 @@ describe('cookie store', () => {
   });
 
   describe('with storeIdToken', () => {
-    describe('configured', () => {
+    describe('not configured', () => {
       const store = getStore({});
 
       test('should not store the id_token', async () => {
@@ -150,7 +150,7 @@ describe('cookie store', () => {
       });
     });
 
-    describe('not configured', () => {
+    describe('configured', () => {
       const store = getStore({
         storeIdToken: true
       });
@@ -176,6 +176,69 @@ describe('cookie store', () => {
         expect(session).toEqual({
           createdAt: now,
           idToken: 'my-id-token',
+          user: { sub: '123' }
+        });
+      });
+    });
+  });
+
+  describe('with storeRefreshToken', () => {
+    describe('not configured', () => {
+      const store = getStore({});
+
+      test('should not store the refresh_token', async () => {
+        const { req, res, setHeaderFn } = getRequestResponse();
+        const now = Date.now();
+
+        await store.save(req, res, {
+          user: {
+            sub: '123'
+          },
+          createdAt: now,
+          idToken: 'my-id-token',
+          refreshToken: 'my-refresh-token'
+        });
+
+        const [, cookie] = setHeaderFn.mock.calls[0];
+        req.headers = {
+          cookie: `a0:session=${parse(cookie)['a0:session']}`
+        };
+
+        const session = await store.read(req);
+        expect(session).toEqual({
+          createdAt: now,
+          user: { sub: '123' }
+        });
+      });
+    });
+
+    describe('configured', () => {
+      const store = getStore({
+        storeRefreshToken: true
+      });
+
+      test('should store the refresh_token', async () => {
+        const { req, res, setHeaderFn } = getRequestResponse();
+        const now = Date.now();
+
+        await store.save(req, res, {
+          user: {
+            sub: '123'
+          },
+          createdAt: now,
+          idToken: 'my-id-token',
+          refreshToken: 'my-refresh-token'
+        });
+
+        const [, cookie] = setHeaderFn.mock.calls[0];
+        req.headers = {
+          cookie: `a0:session=${parse(cookie)['a0:session']}`
+        };
+
+        const session = await store.read(req);
+        expect(session).toEqual({
+          createdAt: now,
+          refreshToken: 'my-refresh-token',
           user: { sub: '123' }
         });
       });


### PR DESCRIPTION
### Description

The goal of this PR is to store the `refresh_token` in the session, in addition to the `access_token` and `id_token`

### References

https://github.com/auth0/nextjs-auth0/issues/4
https://github.com/auth0/nextjs-auth0/issues/7
