### PR TITLE
Add audience to login parameters

### DIFF
--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -36,7 +36,8 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
     const authorizationUrl = client.authorizationUrl({
       redirect_uri: settings.redirectUri,
       scope: settings.scope,
-      response_type: 'code'
+      response_type: 'code',
+      audience: settings.audience
     });
 
     // Set the necessary cookies

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -7,7 +7,7 @@ import getClient from '../../src/utils/oidc-client';
 
 import HttpServer from '../helpers/server';
 import { discovery } from '../helpers/oidc-nocks';
-import { withoutApi } from '../helpers/default-settings';
+import { withoutApi, withApi } from '../helpers/default-settings';
 
 const [getAsync] = [request.get].map(promisify);
 
@@ -48,5 +48,47 @@ describe('login handler', () => {
         + `client_id=${withoutApi.clientId}&scope=${encodeURIComponent(withoutApi.scope)}`
         + `&response_type=code&redirect_uri=${encodeURIComponent(withoutApi.redirectUri)}`
         + `&state=${state['a0:state']}`);
+  });
+});
+
+describe('withApi login handler', () => {
+  let httpServer: HttpServer;
+
+  beforeAll(done => {
+    discovery(withApi);
+    httpServer = new HttpServer(login(withApi, getClient(withApi)));
+    httpServer.start(done);
+  });
+
+  afterAll(done => {
+    httpServer.stop(done);
+  });
+
+  test('should create a state', async () => {
+    const { headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+
+    const state = parse(headers['set-cookie'][0]);
+    expect(state).toBeTruthy();
+  });
+
+  test('should redirect to the identity provider', async () => {
+    const { statusCode, headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+
+    expect(statusCode).toBe(302);
+
+    const state = parse(headers['set-cookie'][0]);
+    expect(headers.location).toContain(
+      `https://${withApi.domain}/authorize?` +
+        `client_id=${withApi.clientId}&scope=${encodeURIComponent(withApi.scope)}` +
+        `&response_type=code&redirect_uri=${encodeURIComponent(withApi.redirectUri)}` +
+        `&audience=${encodeURIComponent(withApi.audience)}` +
+        `&state=${state['a0:state']}`
+    );
   });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Adds `audience` to login parameters, as described on issue #12, so it can return a JWT. 

No breaking changes to the existing flow. If you do not set an audience everything remains the same.

### References
Issue #12 

### Testing
I added a separate test.

If you want to test manually:
1. Configure an `audience` parameter when initializing `useAuth0`. Eg:
```
export default useAuth0({
  domain: process.env.AUTH0_DOMAIN,
  clientId: process.env.AUTH0_CLIENT_ID,
  clientSecret: process.env.AUTH0_CLIENT_SECRET,
  scope: 'openid profile email offline',
  audience: process.env.AUTH0_AUDIENCE,
  redirectUri: process.env.AUTH0_REDIRECT_URL,
  postLogoutRedirectUri: process.env.AUTH0_POST_LOGOUT_REDIRECT_URL,
  session: {
    cookieSecret: process.env.COOKIE_SECRET,
    cookieLifetime: 60 * 60 * 8,
    storeAccessToken: true,
  },
  httpClient: {
    timeout: 2500
  }
});
```

2. Somewhere in your code try doing 
```
const { accessToken } = await auth0.getSession(req);
console.log(accessToken)
```

3. The token should now be a JWT 😎 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
