### PR TITLE
Support sending custom params

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ export default async function callback(req, res) {
 }
 ```
 
+You can optionally send extra parameters to Auth0 to influence the transaction, for example:
+
+- Showing the login page
+- Filling in the user's email address
+- Exposing information to the custom login page (eg: to show the signup tab)
+
+```js
+import auth0 from '../../utils/auth0';
+
+export default async function login(req, res) {
+  try {
+    await auth0.handleLogin(req, res, {
+      authParams: {
+        login_hint: 'foo@acme.com',
+        ui_locales: 'nl',
+        scope: 'some other scope',
+        foo: 'bar'
+      }
+    });
+  } catch(error) {
+    console.error(error)
+    res.status(error.status || 400).end(error.message)
+  }
+}
+```
+
 ### Logout
 
 For signing the user out we'll also need a logout link:

--- a/src/handlers/callback-options.ts
+++ b/src/handlers/callback-options.ts
@@ -1,3 +1,0 @@
-export type CallbackOptions = {
-  redirectTo?: string;
-};

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -5,7 +5,10 @@ import { ISession } from '../session/session';
 import { parseCookies } from '../utils/cookies';
 import { ISessionStore } from '../session/store';
 import { IOidcClientFactory } from '../utils/oidc-client';
-import { CallbackOptions } from './callback-options';
+
+export type CallbackOptions = {
+  redirectTo?: string;
+};
 
 export default function callbackHandler(
   settings: IAuth0Settings,

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -2,25 +2,29 @@ import request from 'request';
 import { parse } from 'cookie';
 import { promisify } from 'util';
 
-import login from '../../src/handlers/login';
-import getClient from '../../src/utils/oidc-client';
-
 import HttpServer from '../helpers/server';
 import { discovery } from '../helpers/oidc-nocks';
+import getClient from '../../src/utils/oidc-client';
 import { withoutApi, withApi } from '../helpers/default-settings';
+import login, { LoginOptions } from '../../src/handlers/login';
+
 
 const [getAsync] = [request.get].map(promisify);
 
 describe('login handler', () => {
   let httpServer: HttpServer;
+  let loginHandler: any;
+  let loginOptions: LoginOptions | null;
 
-  beforeAll((done) => {
+  beforeEach((done) => {
     discovery(withoutApi);
-    httpServer = new HttpServer(login(withoutApi, getClient(withoutApi)));
+    loginOptions = null;
+    loginHandler = login(withoutApi, getClient(withoutApi));
+    httpServer = new HttpServer((req, res) => loginHandler(req, res, loginOptions));
     httpServer.start(done);
   });
 
-  afterAll((done) => {
+  afterEach((done) => {
     httpServer.stop(done);
   });
 
@@ -49,18 +53,52 @@ describe('login handler', () => {
         + `&response_type=code&redirect_uri=${encodeURIComponent(withoutApi.redirectUri)}`
         + `&state=${state['a0:state']}`);
   });
+
+  test('should contain the telemetry querystring', async () => {
+    const { statusCode, headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+    expect(statusCode).toBe(302);
+    expect(headers.location)
+      .toContain('&auth0Client=');
+  });
+
+  test('should allow sending custom parameters to the authorization server', async () => {
+    loginOptions = {
+      authParams: {
+        max_age: '123',
+        login_hint: 'foo@acme.com',
+        ui_locales: 'nl',
+        scope: 'some other scope',
+        foo: 'bar'
+      }
+    };
+    const { statusCode, headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+
+    expect(statusCode).toBe(302);
+    expect(headers.location)
+      .toContain(`https://${withoutApi.domain}/authorize?`
+        + `client_id=${withoutApi.clientId}&scope=${encodeURIComponent(withoutApi.scope)}`
+        + `&response_type=code&redirect_uri=${encodeURIComponent(withoutApi.redirectUri)}`);
+    expect(headers.location)
+      .toContain('&max_age=123&foo=bar');
+  });
 });
 
 describe('withApi login handler', () => {
   let httpServer: HttpServer;
 
-  beforeAll(done => {
+  beforeAll((done) => {
     discovery(withApi);
     httpServer = new HttpServer(login(withApi, getClient(withApi)));
     httpServer.start(done);
   });
 
-  afterAll(done => {
+  afterAll((done) => {
     httpServer.stop(done);
   });
 
@@ -84,11 +122,11 @@ describe('withApi login handler', () => {
 
     const state = parse(headers['set-cookie'][0]);
     expect(headers.location).toContain(
-      `https://${withApi.domain}/authorize?` +
-        `client_id=${withApi.clientId}&scope=${encodeURIComponent(withApi.scope)}` +
-        `&response_type=code&redirect_uri=${encodeURIComponent(withApi.redirectUri)}` +
-        `&audience=${encodeURIComponent(withApi.audience)}` +
-        `&state=${state['a0:state']}`
+      `https://${withApi.domain}/authorize?`
+      + `client_id=${withApi.clientId}&scope=${encodeURIComponent(withApi.scope)}`
+      + `&response_type=code&redirect_uri=${encodeURIComponent(withApi.redirectUri)}`
+      + `&audience=${encodeURIComponent(withApi.audience)}`
+      + `&state=${state['a0:state']}`
     );
   });
 });


### PR DESCRIPTION
### Description

This change allows you to send custom parameters to Auth0 as part of the login transaction:

```js
import auth0 from '../../utils/auth0';

export default async function login(req, res) {
  try {
    await auth0.handleLogin(req, res, {
      authParams: {
        login_hint: 'foo@acme.com',
        ui_locales: 'nl',
        scope: 'some other scope',
        foo: 'bar'
      }
    });
  } catch(error) {
    console.error(error)
    res.status(error.status || 400).end(error.message)
  }
}
```