### PR TITLE
Add 'cookieDomain' setting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ export default initAuth0({
     cookieSecret: '<RANDOMLY_GENERATED_SECRET>',
     // The cookie lifetime (expiration) in seconds. Set to 8 hours by default.
     cookieLifetime: 60 * 60 * 8,
+    // The cookie domain this should run on. Leave it blank to restrict it to your domain.
+    cookieDomain: "your-domain.com",
     // Store the id_token in the session. Defaults to false.
     storeIdToken: false,
     // Store the access_token in the session. Defaults to false.
@@ -242,6 +244,7 @@ export default initAuth0({
   session: {
     cookieSecret: '<RANDOMLY_GENERATED_SECRET>',
     cookieLifetime: 60 * 60 * 8,
+    cookieDomain: 'https://mycompany.com',
     storeAccessToken: true
   }
 });

--- a/src/session/cookie-store/index.ts
+++ b/src/session/cookie-store/index.ts
@@ -40,7 +40,7 @@ export default class CookieSessionStore implements ISessionStore {
    */
   async save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<void> {
     const {
-      cookieSecret, cookieName, cookiePath, cookieLifetime
+      cookieSecret, cookieName, cookiePath, cookieLifetime, cookieDomain
     } = this.settings;
 
     const {
@@ -65,7 +65,8 @@ export default class CookieSessionStore implements ISessionStore {
       name: cookieName,
       value: encryptedSession,
       path: cookiePath,
-      maxAge: cookieLifetime
+      maxAge: cookieLifetime,
+      domain: cookieDomain
     });
   }
 }

--- a/src/session/cookie-store/settings.ts
+++ b/src/session/cookie-store/settings.ts
@@ -23,6 +23,13 @@ export interface ICookieSessionStoreSettings {
   cookiePath?: string;
 
   /**
+   * The Domain option to set on the cookie.
+   * Defaults to omitting the option, which restricts the cookie
+   * to the host of the current document URL, not including subdomains.
+   */
+  cookieDomain?: string;
+
+  /**
    * Save the id_token in the cookie.
    * Defaults to 'false'
    */
@@ -50,6 +57,8 @@ export default class CookieSessionStoreSettings {
 
   readonly cookiePath: string;
 
+  readonly cookieDomain: string;
+
   readonly storeIdToken: boolean;
 
   readonly storeAccessToken: boolean;
@@ -72,6 +81,8 @@ export default class CookieSessionStoreSettings {
     }
 
     this.cookieLifetime = settings.cookieLifetime || 60 * 60 * 8;
+
+    this.cookieDomain = settings.cookieDomain || "";
 
     this.cookiePath = settings.cookiePath || '/';
     if (!this.cookiePath || !this.cookiePath.length) {

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -26,6 +26,11 @@ interface ICookie {
    * The path of the cookie
    */
   path?: string;
+
+  /**
+   * The domain of the cookie
+   */
+  domain?: string;
 }
 
 /**
@@ -76,7 +81,8 @@ function serializeCookie(cookie: ICookie, secure: boolean): string {
     expires: new Date(Date.now() + cookie.maxAge * 1000),
     httpOnly: true,
     secure,
-    path: cookie.path
+    path: cookie.path,
+    domain: cookie.domain
   });
 }
 

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -47,6 +47,40 @@ describe('cookie store', () => {
     });
   });
 
+  describe('with cookie domain', () => {
+    describe('configured', () => {
+      const store = getStore({
+        cookieDomain: ".quirk.fyi",
+      })
+
+      test('should set cookie domain', async () => {
+        const { req, res, setHeaderFn } = getRequestResponse();
+        await store.save(req, res, {
+          user: { sub: '123' },
+          createdAt: Date.now()
+        });
+
+        const [, cookie] = setHeaderFn.mock.calls[0];
+        expect(parse(cookie).Domain).toBe(".quirk.fyi")
+      })
+    }),
+
+    describe('not configured', () => {
+      const store = getStore({})
+
+      test('should set cookie domain', async () => {
+        const { req, res, setHeaderFn } = getRequestResponse();
+        await store.save(req, res, {
+          user: { sub: '123' },
+          createdAt: Date.now()
+        });
+
+        const [, cookie] = setHeaderFn.mock.calls[0];
+        expect(parse(cookie).Domain).toBeUndefined()
+      })
+    })
+  })
+
   describe('with storeAccessToken', () => {
     describe('configured', () => {
       const store = getStore({});


### PR DESCRIPTION
### Description

This PR adds the `domain` option in cookies. See #30 for more details. 

### Testing

I added new test coverage to cover the feature. I also have it working in production at https://junelark.com/. 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
