### PR TITLE
Refresh token automatically

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
 import IAuth0Settings from '../settings';
-import { ISession } from '../session/session';
+import getSessionFromTokenSet from '../utils/session';
 import { parseCookies } from '../utils/cookies';
 import { ISessionStore } from '../session/store';
 import { IOidcClientFactory } from '../utils/oidc-client';
@@ -40,34 +40,7 @@ export default function callbackHandler(
       state
     });
 
-    // Get the claims without any OIDC specific claim.
-    const claims = tokenSet.claims();
-    if (claims.aud) {
-      delete claims.aud;
-    }
-
-    if (claims.exp) {
-      delete claims.exp;
-    }
-
-    if (claims.iat) {
-      delete claims.iat;
-    }
-
-    if (claims.iss) {
-      delete claims.iss;
-    }
-
-    // Create the session.
-    const session: ISession = {
-      user: {
-        ...claims
-      },
-      idToken: tokenSet.id_token,
-      accessToken: tokenSet.access_token,
-      refreshToken: tokenSet.refresh_token,
-      createdAt: Date.now()
-    };
+    const session = getSessionFromTokenSet(tokenSet);
 
     // Create the session.
     await sessionStore.save(req, res, session);

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -6,9 +6,9 @@ import CookieSessionStoreSettings from '../session/cookie-store/settings';
 
 function createLogoutUrl(settings: IAuth0Settings): string {
   return (
-    `https://${settings.domain}/v2/logout?`
-    + `client_id=${settings.clientId}`
-    + `&returnTo=${encodeURIComponent(settings.postLogoutRedirectUri)}`
+    `https://${settings.domain}/v2/logout?` +
+    `client_id=${settings.clientId}` +
+    `&returnTo=${encodeURIComponent(settings.postLogoutRedirectUri)}`
   );
 }
 

--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -12,7 +12,7 @@ export default function profileHandler(sessionStore: ISessionStore) {
       throw new Error('Response is not available');
     }
 
-    const session = await sessionStore.read(req);
+    const session = await sessionStore.read(req, res);
     if (!session || !session.user) {
       res.status(401).json({
         error: 'not_authenticated',

--- a/src/handlers/require-authentication.ts
+++ b/src/handlers/require-authentication.ts
@@ -16,7 +16,7 @@ export default function requireAuthentication(sessionStore: ISessionStore) {
       throw new Error('Response is not available');
     }
 
-    const session = await sessionStore.read(req);
+    const session = await sessionStore.read(req, res);
     if (!session || !session.user) {
       res.status(401).json({
         error: 'not_authenticated',

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1,14 +1,14 @@
-import { IncomingMessage } from 'http';
+import { NextApiResponse, NextApiRequest } from 'next';
 
 import { ISession } from '../session/session';
 import { ISessionStore } from '../session/store';
 
 export default function sessionHandler(sessionStore: ISessionStore) {
-  return (req: IncomingMessage): Promise<ISession | null | undefined> => {
+  return (req: NextApiRequest, res: NextApiResponse): Promise<ISession | null | undefined> => {
     if (!req) {
       throw new Error('Request is not available');
     }
 
-    return sessionStore.read(req);
+    return sessionStore.read(req, res);
   };
 }

--- a/src/instance.node.ts
+++ b/src/instance.node.ts
@@ -16,7 +16,7 @@ export default function createInstance(settings: IAuth0Settings): ISignInWithAut
   const clientProvider = getClient(settings);
 
   const sessionSettings = new CookieSessionStoreSettings(settings.session);
-  const store: ISessionStore = new CookieSessionStore(sessionSettings);
+  const store: ISessionStore = new CookieSessionStore(sessionSettings, clientProvider);
 
   return {
     handleLogin: handlers.LoginHandler(settings, clientProvider),

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -29,7 +29,7 @@ export interface ISignInWithAuth0 {
   /**
    * Session handler which returns the current session
    */
-  getSession: (req: IncomingMessage) => Promise<ISession | null | undefined>;
+  getSession: (req: NextApiRequest, res: NextApiResponse) => Promise<ISession | null | undefined>;
 
   /**
    * Handle to require authentication for an API route.

--- a/src/session/cookie-store/index.ts
+++ b/src/session/cookie-store/index.ts
@@ -5,19 +5,24 @@ import { ISessionStore } from '../store';
 import Session, { ISession } from '../session';
 import CookieSessionStoreSettings from './settings';
 import { setCookie, parseCookies } from '../../utils/cookies';
+import { IOidcClientFactory } from '../../utils/oidc-client';
+import getSessionFromTokenSet from '../../utils/session';
 
 export default class CookieSessionStore implements ISessionStore {
   private settings: CookieSessionStoreSettings;
 
-  constructor(settings: CookieSessionStoreSettings) {
+  private clientProvider: IOidcClientFactory;
+
+  constructor(settings: CookieSessionStoreSettings, clientProvider: IOidcClientFactory) {
     this.settings = settings;
+    this.clientProvider = clientProvider;
   }
 
   /**
    * Read the session from the cookie.
    * @param req HTTP request
    */
-  async read(req: IncomingMessage): Promise<ISession | null> {
+  async read(req: IncomingMessage, res: ServerResponse): Promise<ISession | null> {
     const { cookieSecret, cookieName } = this.settings;
 
     const cookies = parseCookies(req);
@@ -31,6 +36,25 @@ export default class CookieSessionStore implements ISessionStore {
       return null;
     }
 
+    const { expiresAt, refreshToken } = unsealed as ISession;
+
+    // Check if the token has expired
+    if (refreshToken && expiresAt && expiresAt * 1000 < Date.now()) {
+      const client = await this.clientProvider();
+
+      // Refresh the token
+      const tokenSet = await client.refresh(refreshToken);
+
+      // It doesn't return a new refresh token, so we have to keep the old one
+      const session = {
+        ...getSessionFromTokenSet(tokenSet),
+        refreshToken
+      };
+
+      // Save the new session
+      return this.save(req, res, session);
+    }
+
     return unsealed as ISession;
   }
 
@@ -38,14 +62,10 @@ export default class CookieSessionStore implements ISessionStore {
    * Write the session to the cookie.
    * @param req HTTP request
    */
-  async save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<void> {
-    const {
-      cookieSecret, cookieName, cookiePath, cookieLifetime
-    } = this.settings;
+  async save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<ISession> {
+    const { cookieSecret, cookieName, cookiePath, cookieLifetime } = this.settings;
 
-    const {
-      idToken, accessToken, refreshToken, user, createdAt
-    } = session;
+    const { idToken, accessToken, refreshToken, user, createdAt, expiresAt } = session;
     const persistedSession = new Session(user, createdAt);
 
     if (this.settings.storeIdToken && idToken) {
@@ -60,6 +80,10 @@ export default class CookieSessionStore implements ISessionStore {
       persistedSession.refreshToken = refreshToken;
     }
 
+    if (this.settings.storeRefreshToken && refreshToken && expiresAt) {
+      persistedSession.expiresAt = expiresAt;
+    }
+
     const encryptedSession = await Iron.seal(persistedSession, cookieSecret, Iron.defaults);
     setCookie(req, res, {
       name: cookieName,
@@ -67,5 +91,6 @@ export default class CookieSessionStore implements ISessionStore {
       path: cookiePath,
       maxAge: cookieLifetime
     });
+    return persistedSession;
   }
 }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -23,6 +23,11 @@ export interface ISession {
    * The time on which the session was created.
    */
   readonly createdAt: number;
+
+  /**
+   * The time on which the accessToken will expire
+   */
+  readonly expiresAt?: number;
 }
 
 /**
@@ -42,6 +47,8 @@ export default class Session implements ISession {
   refreshToken?: string | undefined;
 
   createdAt: number;
+
+  expiresAt?: number;
 
   constructor(user: IClaims, createdAt?: number) {
     this.user = user;

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -7,7 +7,7 @@ export interface ISessionStore {
    * Read the session.
    * @param req The HTTP Request.
    */
-  read(req: IncomingMessage): Promise<ISession | null | undefined>;
+  read(req: IncomingMessage, res: ServerResponse): Promise<ISession | null | undefined>;
 
   /**
    * Persist the session.
@@ -15,5 +15,5 @@ export interface ISessionStore {
    * @param res The HTTP response.
    * @param session The session to persist.
    */
-  save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<void>;
+  save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<ISession>;
 }

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -85,7 +85,7 @@ function serializeCookie(cookie: ICookie, secure: boolean): string {
  * @param res The HTTP response on which the cookie will be set.
  */
 export function setCookies(req: IncomingMessage, res: ServerResponse, cookies: Array<ICookie>): void {
-  res.setHeader('Set-Cookie', cookies.map((c) => serializeCookie(c, isSecureEnvironment(req))));
+  res.setHeader('Set-Cookie', cookies.map(c => serializeCookie(c, isSecureEnvironment(req))));
 }
 
 /**

--- a/src/utils/oidc-client.ts
+++ b/src/utils/oidc-client.ts
@@ -1,8 +1,4 @@
-import {
-  Issuer,
-  custom,
-  Client
-} from 'openid-client';
+import { Issuer, custom, Client } from 'openid-client';
 
 import IAuth0Settings from '../settings';
 import OidcClientSettings from '../oidc-client-settings';

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,34 @@
+import { TokenSet } from 'openid-client';
+import { ISession } from '../session/session';
+
+export default function getSessionFromTokenSet(tokenSet: TokenSet): ISession {
+  // Get the claims without any OIDC specific claim.
+  const claims = tokenSet.claims();
+  if (claims.aud) {
+    delete claims.aud;
+  }
+
+  if (claims.exp) {
+    delete claims.exp;
+  }
+
+  if (claims.iat) {
+    delete claims.iat;
+  }
+
+  if (claims.iss) {
+    delete claims.iss;
+  }
+
+  // Create the session.
+  return {
+    user: {
+      ...claims
+    },
+    idToken: tokenSet.id_token,
+    accessToken: tokenSet.access_token,
+    refreshToken: tokenSet.refresh_token,
+    expiresAt: tokenSet.expires_at,
+    createdAt: Date.now()
+  };
+}

--- a/tests/handlers/callback.test.ts
+++ b/tests/handlers/callback.test.ts
@@ -27,7 +27,8 @@ describe('callback handler', () => {
       new CookieSessionStoreSettings({
         cookieSecret: 'keyboardcat-keyboardcat-keyboardcat-keyboardcat',
         cookieLifetime: 60 * 60
-      })
+      }),
+      getClient(withoutApi)
     );
     return keystore.generate('RSA');
   });
@@ -208,12 +209,12 @@ describe('callback handler', () => {
       expect(responseStatus).toBe(302);
       expect(responseHeaders['set-cookie'][0]).toContain('a0:session');
 
-      const { req } = getRequestResponse();
+      const { req, res } = getRequestResponse();
       req.headers = {
         cookie: `a0:session=${parse(responseHeaders['set-cookie'][0])['a0:session']}`
       };
 
-      const session = await store.read(req);
+      const session = await store.read(req, res);
       expect(session).toStrictEqual({
         createdAt: time.getTime(),
         user: {

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -1,3 +1,4 @@
+import { NextApiRequest, NextApiResponse } from 'next';
 import handlers from '../../src/handlers';
 import { ISession } from '../../src/session/session';
 import { ISessionStore } from '../../src/session/store';
@@ -9,8 +10,8 @@ describe('profile handler', () => {
       read(): Promise<ISession | null | undefined> {
         return Promise.resolve(session);
       },
-      save(): Promise<void> {
-        return Promise.resolve();
+      save(_req: NextApiRequest, _res: NextApiResponse, session: ISession): Promise<ISession> {
+        return Promise.resolve(session);
       }
     };
     return store;

--- a/tests/handlers/require-authentication.test.ts
+++ b/tests/handlers/require-authentication.test.ts
@@ -18,8 +18,8 @@ describe('require authentication handle handler', () => {
       read(): Promise<ISession | null | undefined> {
         return Promise.resolve(session);
       },
-      save(): Promise<void> {
-        return Promise.resolve();
+      save(_req: NextApiRequest, _res: NextApiResponse, session: ISession): Promise<ISession> {
+        return Promise.resolve(session);
       }
     };
     return store;

--- a/tests/handlers/session.test.ts
+++ b/tests/handlers/session.test.ts
@@ -1,3 +1,4 @@
+import { NextApiRequest, NextApiResponse } from 'next';
 import handlers from '../../src/handlers';
 import { ISession } from '../../src/session/session';
 import { ISessionStore } from '../../src/session/store';
@@ -6,7 +7,7 @@ import getRequestResponse from '../helpers/http';
 describe('session handler', () => {
   test('should return the session', async () => {
     const now = Date.now();
-    const { req } = getRequestResponse();
+    const { req, res } = getRequestResponse();
 
     const store: ISessionStore = {
       read(): Promise<ISession | null> {
@@ -19,13 +20,13 @@ describe('session handler', () => {
           refreshToken: 'my-refresh-token'
         });
       },
-      save(): Promise<void> {
-        return Promise.resolve();
+      save(_req: NextApiRequest, _res: NextApiResponse, session: ISession): Promise<ISession> {
+        return Promise.resolve(session);
       }
     };
 
     const sessionHandler = handlers.SessionHandler(store);
-    const session = await sessionHandler(req);
+    const session = await sessionHandler(req, res);
     expect(session).toEqual({
       user: { sub: '123' },
       createdAt: now,

--- a/tests/helpers/oidc-nocks.ts
+++ b/tests/helpers/oidc-nocks.ts
@@ -149,3 +149,28 @@ export function codeExchangeWithAccessToken(
       token_type: 'Bearer'
     });
 }
+
+export function refreshToken(
+  settings: IAuth0Settings,
+  refreshToken: string,
+  key: JWK.Key,
+  payload: object,
+  newToken?: string
+): nock.Scope {
+  const idToken = createToken(key, {
+    iss: `https://${settings.domain}/`,
+    aud: settings.clientId,
+    ...payload
+  });
+
+  return nock(`https://${settings.domain}`)
+    .post('/oauth/token',
+      `grant_type=refresh_token&refresh_token=${refreshToken}`)
+    .reply(200, {
+      access_token: newToken || 'eyJz93a...k4laUWw',
+      refresh_token: 'GEbRxBN...edjnXbL',
+      id_token: idToken,
+      token_type: 'Bearer',
+      expires_at: Date.now() / 1000
+    });
+}

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -1,16 +1,28 @@
 import { parse } from 'cookie';
-
+import jose from '@panva/jose';
 import getRequestResponse from '../helpers/http';
+import timekeeper from 'timekeeper';
 import CookieStore from '../../src/session/cookie-store';
 import CookieSessionStoreSettings from '../../src/session/cookie-store/settings';
+import { withoutApi } from '../helpers/default-settings';
+import getClient from '../../src/utils/oidc-client';
+import { discovery, jwksEndpoint, refreshToken } from '../helpers/oidc-nocks';
 
 describe('cookie store', () => {
+  let keystore: jose.JWKS.KeyStore;
+
+  beforeAll(() => {
+    keystore = new jose.JWKS.KeyStore();
+    return keystore.generate('RSA');
+  });
+
   const getStore = (settings = {}): CookieStore => {
     const store = new CookieStore(
       new CookieSessionStoreSettings({
         cookieSecret: 'keyboardcat.keyboardcat.keyboardcat.keyboardcat.keyboardcat.keyboardcat.keyboardcat.keyboardcat',
         ...settings
-      })
+      }),
+      getClient(withoutApi)
     );
     return store;
   };
@@ -66,7 +78,7 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           user: { sub: '123' },
           createdAt: now
@@ -94,7 +106,7 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           user: { sub: '123' },
           createdAt: now,
@@ -125,7 +137,7 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           createdAt: now,
           user: { sub: '123' }
@@ -155,7 +167,7 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           createdAt: now,
           idToken: 'my-id-token',
@@ -169,7 +181,7 @@ describe('cookie store', () => {
     describe('not configured', () => {
       const store = getStore({});
 
-      test('should not store the refresh_token', async () => {
+      test('should not store the refresh_token or expires_at', async () => {
         const { req, res, setHeaderFn } = getRequestResponse();
         const now = Date.now();
 
@@ -179,7 +191,8 @@ describe('cookie store', () => {
           },
           createdAt: now,
           idToken: 'my-id-token',
-          refreshToken: 'my-refresh-token'
+          refreshToken: 'my-refresh-token',
+          expiresAt: Date.now()
         });
 
         const [, cookie] = setHeaderFn.mock.calls[0];
@@ -187,7 +200,7 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           createdAt: now,
           user: { sub: '123' }
@@ -197,10 +210,11 @@ describe('cookie store', () => {
 
     describe('configured', () => {
       const store = getStore({
-        storeRefreshToken: true
+        storeRefreshToken: true,
+        storeAccessToken: true
       });
 
-      test('should store the refresh_token', async () => {
+      test('should store the refresh_token and expires_at', async () => {
         const { req, res, setHeaderFn } = getRequestResponse();
         const now = Date.now();
 
@@ -210,7 +224,8 @@ describe('cookie store', () => {
           },
           createdAt: now,
           idToken: 'my-id-token',
-          refreshToken: 'my-refresh-token'
+          refreshToken: 'my-refresh-token',
+          expiresAt: now
         });
 
         const [, cookie] = setHeaderFn.mock.calls[0];
@@ -218,13 +233,57 @@ describe('cookie store', () => {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 
-        const session = await store.read(req);
+        const session = await store.read(req, res);
         expect(session).toEqual({
           createdAt: now,
           refreshToken: 'my-refresh-token',
-          user: { sub: '123' }
+          user: { sub: '123' },
+          expiresAt: now
         });
       });
+
+      test('should refresh the token when it expires', async () => {
+        const time = new Date();
+        timekeeper.freeze(time);
+
+        discovery(withoutApi);
+        jwksEndpoint(withoutApi, keystore.toJWKS());
+        refreshToken(withoutApi, 'my-refresh-token', keystore.get(), {
+          sub: '123'
+        }, 'new-token');
+
+        const { req, res, setHeaderFn } = getRequestResponse();
+        const now = Date.now();
+
+        await store.save(req, res, {
+          user: {
+            sub: '123'
+          },
+          createdAt: now,
+          idToken: 'my-id-token',
+          refreshToken: 'my-refresh-token',
+          accessToken: 'my-access-token',
+          // expires_at is in seconds
+          expiresAt: (now / 1000) - 1
+        });
+
+        const [, cookie] = setHeaderFn.mock.calls[0];
+        req.headers = {
+          ...req.headers,
+          cookie: `a0:session=${parse(cookie)['a0:session']}`
+        };
+
+        const session = await store.read(req, res);
+        expect(session).toEqual({
+          createdAt: now,
+          refreshToken: 'my-refresh-token',
+          accessToken: 'new-token',
+          user: { sub: '123' },
+          expiresAt: now / 1000
+        });
+
+        timekeeper.reset();
+      })
     });
   });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes #7 (part of it)

When the refresh_token is saved in the session, at any point we try to read the session from the cookie, if the token has expired (also saving expires_at), we refresh the token, save the new session and return it.

The rest of the code doesn't need to have any idea of what happened


#### Parts that weren't implemented:

>  If the token is missing a scope, return null. If the token is for an other audience, return null.

I only focused on the refresh token functionality, no scope/audience checks

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`


----

I haven't added doc changes yet. I'm not sure if this needs its own setting (`autoRefresh`?) or if it's just something built in.

There wasn't much discussion on the issue, so I'll make the doc updates when I hear more here