### PR TITLE
User permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "@hapi/iron": "^5.1.4",
     "base64url": "^3.0.1",
     "cookie": "^0.4.0",
+    "jsonwebtoken": "^8.5.1",
+    "jwks-rsa": "^1.6.0",
     "openid-client": "^3.7.4"
   },
   "peerDependencies": {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -4,6 +4,7 @@ import CallbackHandler from './callback';
 import ProfileHandler from './profile';
 import SessionHandler from './session';
 import RequireAuthentication from './require-authentication';
+import RequirePermissions from './require-permissions';
 
 export default {
   CallbackHandler,
@@ -11,5 +12,6 @@ export default {
   LogoutHandler,
   ProfileHandler,
   SessionHandler,
-  RequireAuthentication
+  RequireAuthentication,
+  RequirePermissions
 };

--- a/src/handlers/require-permissions.ts
+++ b/src/handlers/require-permissions.ts
@@ -1,0 +1,83 @@
+import { promisify } from 'util';
+import { NextApiResponse, NextApiRequest } from 'next';
+import jwt from 'jsonwebtoken';
+import jwksClient, { CertSigningKey, RsaSigningKey } from 'jwks-rsa';
+import { URL } from 'url';
+
+import { ISessionStore } from '../session/store';
+import IAuth0Settings from '../settings';
+
+export interface IApiRoute {
+  (req: NextApiRequest, res: NextApiResponse): Promise<void>;
+}
+
+export default function requirePermissions(settings: IAuth0Settings, sessionStore: ISessionStore) {
+  return (
+    apiRoute: IApiRoute,
+    expectedScopes: string[],
+    options = {
+      checkAllScopes: false
+    }
+  ): IApiRoute => async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    if (!req) {
+      throw new Error('Request is not available');
+    }
+
+    if (!res) {
+      throw new Error('Response is not available');
+    }
+
+    if (!settings.audience) {
+      throw new Error('Missing audience');
+    }
+
+    if (!Array.isArray(expectedScopes)) {
+      throw new Error('Parameter expectedScopes must be an array of strings representing the scsopes of the endpoint');
+    }
+
+
+    const session = await sessionStore.read(req);
+    if (!session || !session.user) {
+      res.status(401).json({
+        error: 'not_authenticated',
+        description: 'The user does not have an active session or is not authenticated'
+      });
+      return;
+    }
+
+    if (!session.accessToken) {
+      throw new Error('The access token needs to be saved in the session in order to check permissions');
+    }
+
+    const decodedToken = (jwt.decode(session.accessToken, {complete: true}) as {[key: string]: any}) || {};
+    const secret = await promisify(jwksClient({
+      jwksUri: `https://${settings.domain}/.well-known/jwks.json`,
+    }).getSigningKey)(decodedToken.header.kid);
+
+    const {permissions = [], scope = []} = jwt.verify(
+      session.accessToken,
+      (secret as CertSigningKey).publicKey || (secret as RsaSigningKey).rsaPublicKey, {
+        audience: settings.audience,
+        issuer: new URL(`https://${settings.domain}`).href,
+        algorithms: ['RS256']
+      }
+    ) as { permissions?: string[], scope?: string | string[]};
+
+    const userScopes = [...(Array.isArray(scope) ? scope : scope.split(' ')), ...permissions];
+
+    const allowed = expectedScopes[options.checkAllScopes ? 'every' : 'some'](
+      scope => userScopes.includes(scope)
+    );
+
+    if (!allowed) {
+      res.setHeader('WWW-Authenticate', `Bearer scope="${expectedScopes.join(' ')}", error="Insufficient scope"`);
+      res.status(403).json({
+        error: 'insufficient_scope',
+        description: 'Insufficient scope'
+      });
+      return;
+    }
+
+    await apiRoute(req, res);
+  };
+}

--- a/src/instance.browser.ts
+++ b/src/instance.browser.ts
@@ -21,6 +21,9 @@ export default function createDummyBrowserInstance(): ISignInWithAuth0 & { isBro
     },
     requireAuthentication: () => (): Promise<void> => {
       throw new Error('The requireAuthentication method can only be used from the server side');
+    },
+    requirePermissions: () => (): Promise<void> => {
+      throw new Error('The requirePermissions method can only be used from the server side');
     }
   };
 }

--- a/src/instance.node.ts
+++ b/src/instance.node.ts
@@ -24,6 +24,7 @@ export default function createInstance(settings: IAuth0Settings): ISignInWithAut
     handleCallback: handlers.CallbackHandler(settings, clientProvider, store),
     handleProfile: handlers.ProfileHandler(store),
     getSession: handlers.SessionHandler(store),
-    requireAuthentication: handlers.RequireAuthentication(store)
+    requireAuthentication: handlers.RequireAuthentication(store),
+    requirePermissions: handlers.RequirePermissions(settings, store)
   };
 }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -35,4 +35,9 @@ export interface ISignInWithAuth0 {
    * Handle to require authentication for an API route.
    */
   requireAuthentication: (apiRoute: IApiRoute) => IApiRoute;
+
+  /**
+   * Handle to require permissions for an API route.
+   */
+  requirePermissions: (apiRoute: IApiRoute, expectedScopes: string[], options: { checkAllScopes: boolean }) => IApiRoute;
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes #29 

Adds a handler similar to `requireAthentication`: `requirePermissions`.

```js
export default requirePermissions(
	(req, res) => {...},
	['create:posts', 'edit:posts'],
	{ checkAllScopes: true }
);
```

Haven't used Auth0 scopes before, but when I created some roles and decoded the token it looks like it has two relevant fields:

```
{
	// ...
	scope: 'openid profile some:permission',
	permissions: ['some:permission', 'some:otherpermission']
}
```

Looks like the ones in the scope are the ones requested through the config, but the `permissions` field contains all the permissions included that user's role.

I saw that this package: https://github.com/Aulos/micro-jwt-authz used `scope`, so I used it here as well, but added the permissions as well.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

Haven't added tests yet. Waiting to see if this implementation is acceptable, and when it's agreed upon, I'll add the tests

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`

Waiting for some discussion/approval on the implementation before I add the docs as well