### PR TITLE
Support sending custom `state` via login handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can optionally send extra parameters to Auth0 to influence the transaction, 
 - Showing the login page
 - Filling in the user's email address
 - Exposing information to the custom login page (eg: to show the signup tab)
+- Using a custom `state`
 
 ```js
 import auth0 from '../../utils/auth0';
@@ -140,6 +141,7 @@ export default async function login(req, res) {
         login_hint: 'foo@acme.com',
         ui_locales: 'nl',
         scope: 'some other scope',
+        state: 'a custom state',
         foo: 'bar'
       }
     });

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -30,6 +30,7 @@ export interface AuthorizationParameters {
   max_age?: string;
   prompt?: string;
   scope?: string;
+  state?: string;
   ui_locales?: string;
   [key: string]: unknown;
 }
@@ -44,12 +45,10 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
       throw new Error('Response is not available');
     }
 
-    // Generate the state
-    const state = base64url(randomBytes(48));
+    const { state = base64url(randomBytes(48)), ...authParams } = (options && options.authParams) || {};
 
     // Create the authorization url.
     const client = await clientProvider();
-    const authParams = (options && options.authParams) || {};
     const authorizationUrl = client.authorizationUrl({
       redirect_uri: settings.redirectUri,
       scope: settings.scope,

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -87,6 +87,22 @@ describe('login handler', () => {
     expect(headers.location)
       .toContain('&max_age=123&login_hint=foo%40acme.com&ui_locales=nl&foo=bar');
   });
+
+  test('should allow sending custom state to the authorization server', async () => {
+    loginOptions = {
+      authParams: {
+        state: 'custom-state',
+      }
+    };
+    const { statusCode, headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+
+    expect(statusCode).toBe(302);
+    expect(headers.location)
+      .toContain('&state=custom-state');
+  });
 });
 
 describe('withApi login handler', () => {


### PR DESCRIPTION
### Description

Fixes #36 

This PR enables sending a custom `state` to the auth server. This way a redirect url can be stored as described in https://auth0.com/docs/protocols/oauth2/redirect-users and then retrieved in the callback handler in order to redirect users back to the originating url.

Previously, the state was created inside the login handler, with no possibility to access it from the outside. Now, the state can optionally be passed via `authParams`.

```js
import auth0 from '../../utils/auth0';
export default async function login(req, res) {
  try {
    await auth0.handleLogin(req, res, {
      authParams: {
        state: 'a custom state'
      }
    });
  } catch(error) {
    console.error(error)
    res.status(error.status || 400).end(error.message)
  }
}
```

Code in this PR has no breaking changes.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality (see `'should allow sending custom state to the authorization server'` in `login.test.ts`)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (see `README.md`)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
