### PR TITLE
Updating settings types.

### DIFF
--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -6,9 +6,9 @@ import CookieSessionStoreSettings from '../session/cookie-store/settings';
 
 function createLogoutUrl(settings: IAuth0Settings): string {
   return (
-    `https://${settings.domain}/v2/logout?`
-    + `client_id=${settings.clientId}`
-    + `&returnTo=${encodeURIComponent(settings.postLogoutRedirectUri)}`
+    `https://${settings.domain}/v2/logout?` +
+    `client_id=${settings.clientId}` +
+    `&returnTo=${encodeURIComponent(settings.postLogoutRedirectUri)}`
   );
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,7 +15,7 @@ export default interface IAuth0Settings {
   /**
    * Auth0 client secret.
    */
-  clientSecret: string;
+  clientSecret?: string;
 
   /**
    * Url to redirect to after the user has signed in.
@@ -40,7 +40,7 @@ export default interface IAuth0Settings {
   /**
    * Settings related to the session.
    */
-  session: ICookieSessionStoreSettings;
+  session?: ICookieSessionStoreSettings;
 
   /**
    * Settings for the OIDC Client which performs the code exchange.

--- a/src/utils/oidc-client.ts
+++ b/src/utils/oidc-client.ts
@@ -1,8 +1,4 @@
-import {
-  Issuer,
-  custom,
-  Client
-} from 'openid-client';
+import { Issuer, custom, Client } from 'openid-client';
 
 import IAuth0Settings from '../settings';
 import OidcClientSettings from '../oidc-client-settings';


### PR DESCRIPTION
### Description

Correct the type warnings caused by https://github.com/zeit/next.js/pull/9778.

Cutting the client settings and server settings will cause warnings in `IAuth0Settings` when used with typescript.

### References

https://github.com/zeit/next.js/pull/9778

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
