### PR TITLE
Refretch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ export default async function me(req, res) {
 }
 ```
 
+If you need to refetch the user from the server, you can pass an extra parameter, which will also update it in the session:
+
+```js
+import auth0 from '../../utils/auth0';
+
+export default async function me(req, res) {
+  try {
+    await auth0.handleProfile(req, res, { refetch: true });
+  } catch (error) {
+    console.error(error);
+    res.status(error.status || 500).end(error.message);
+  }
+}
+```
+
 You can then load the user after the page has been rendered on the server:
 
 ```js

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -41,6 +41,10 @@ export interface LoginOptions {
 
 export default function loginHandler(settings: IAuth0Settings, clientProvider: IOidcClientFactory) {
   return async (req: IncomingMessage, res: ServerResponse, options?: LoginOptions): Promise<void> => {
+    if (!req) {
+      throw new Error('Request is not available');
+    }
+
     if (!res) {
       throw new Error('Response is not available');
     }

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -14,6 +14,10 @@ function createLogoutUrl(settings: IAuth0Settings): string {
 
 export default function logoutHandler(settings: IAuth0Settings, sessionSettings: CookieSessionStoreSettings) {
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (!req) {
+      throw new Error('Request is not available');
+    }
+
     if (!res) {
       throw new Error('Response is not available');
     }

--- a/src/instance.node.ts
+++ b/src/instance.node.ts
@@ -1,3 +1,4 @@
+import { ITokenCache } from './tokens/token-cache';
 import handlers from './handlers';
 import getClient from './utils/oidc-client';
 import IAuth0Settings from './settings';
@@ -36,7 +37,7 @@ export default function createInstance(settings: IAuth0Settings): ISignInWithAut
     handleLogin: handlers.LoginHandler(settings, clientProvider),
     handleLogout: handlers.LogoutHandler(settings, sessionSettings),
     handleCallback: handlers.CallbackHandler(settings, clientProvider, store),
-    handleProfile: handlers.ProfileHandler(store),
+    handleProfile: handlers.ProfileHandler(store, clientProvider),
     getSession: handlers.SessionHandler(store),
     requireAuthentication: handlers.RequireAuthentication(store),
     tokenCache: handlers.TokenCache(clientProvider, store)

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -5,6 +5,7 @@ import { ISession } from './session/session';
 import { LoginOptions } from './handlers/login';
 import { ITokenCache } from './tokens/token-cache';
 import { CallbackOptions } from './handlers/callback';
+import { ProfileOptions } from './handlers/profile';
 import { IApiRoute } from './handlers/require-authentication';
 
 export interface ISignInWithAuth0 {
@@ -26,7 +27,7 @@ export interface ISignInWithAuth0 {
   /**
    * Profile handler which return profile information about the user.
    */
-  handleProfile: (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
+  handleProfile: (req: NextApiRequest, res: NextApiResponse, options: ProfileOptions) => Promise<void>;
 
   /**
    * Session handler which returns the current session

--- a/src/session/cookie-store/index.ts
+++ b/src/session/cookie-store/index.ts
@@ -18,6 +18,10 @@ export default class CookieSessionStore implements ISessionStore {
    * @param req HTTP request
    */
   async read(req: IncomingMessage): Promise<ISession | null> {
+    if (!req) {
+      throw new Error('Request is not available');
+    }
+
     const { cookieSecret, cookieName } = this.settings;
 
     const cookies = parseCookies(req);
@@ -39,6 +43,14 @@ export default class CookieSessionStore implements ISessionStore {
    * @param req HTTP request
    */
   async save(req: IncomingMessage, res: ServerResponse, session: ISession): Promise<ISession | null> {
+    if (!res) {
+      throw new Error('Response is not available');
+    }
+
+    if (!req) {
+      throw new Error('Request is not available');
+    }
+
     const { cookieSecret, cookieName, cookiePath, cookieLifetime, cookieDomain, cookieSameSite } = this.settings;
 
     const { idToken, accessToken, accessTokenExpiresAt, accessTokenScope, refreshToken, user, createdAt } = session;

--- a/src/tokens/session-token-cache.ts
+++ b/src/tokens/session-token-cache.ts
@@ -29,6 +29,10 @@ export default class SessionTokenCache implements ITokenCache {
       throw new AccessTokenError('invalid_session', 'The user does not have a valid session.');
     }
 
+    if (!session.accessToken && !session.refreshToken) {
+      throw new AccessTokenError('invalid_session', 'The user does not have a valid access token.');
+    }
+
     if (!session.accessTokenExpiresAt) {
       throw new AccessTokenError(
         'access_token_expired',

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -1,10 +1,13 @@
+import { withoutApi } from '../helpers/default-settings';
 import handlers from '../../src/handlers';
 import { ISession } from '../../src/session/session';
 import { ISessionStore } from '../../src/session/store';
 import getRequestResponse from '../helpers/http';
+import getClient from '../../src/utils/oidc-client';
+import { userInfo, discovery } from '../helpers/oidc-nocks';
 
 describe('profile handler', () => {
-  const getStore = (session?: ISession): ISessionStore => {
+  const getStore = (session?: ISession, saveStore?: jest.Mock): ISessionStore => {
     const store: ISessionStore = {
       read(): Promise<ISession | null | undefined> {
         return Promise.resolve(session);
@@ -13,13 +16,18 @@ describe('profile handler', () => {
         return Promise.resolve(session);
       }
     };
+
+    if (saveStore) {
+      store.save = saveStore;
+    }
+
     return store;
   };
 
   describe('when the call is invalid', () => {
     test('should throw an error if the request is null', async () => {
       const store = getStore();
-      const profileHandler = handlers.ProfileHandler(store);
+      const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
 
       const req: any = null;
       const { res } = getRequestResponse();
@@ -29,7 +37,7 @@ describe('profile handler', () => {
 
     test('should throw an error if the response is null', async () => {
       const store = getStore();
-      const profileHandler = handlers.ProfileHandler(store);
+      const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
 
       const { req } = getRequestResponse();
       const res: any = null;
@@ -39,24 +47,87 @@ describe('profile handler', () => {
   });
 
   describe('when signed in', () => {
-    const store = getStore({
-      user: {
-        sub: '123'
-      },
-      idToken: 'my-id-token',
-      accessToken: 'my-access-token',
-      refreshToken: 'my-refresh-token',
-      createdAt: Date.now()
+    describe('when not asked to refetch', () => {
+      const store = getStore({
+        user: {
+          sub: '123'
+        },
+        idToken: 'my-id-token',
+        accessToken: 'my-access-token',
+        refreshToken: 'my-refresh-token',
+        createdAt: Date.now()
+      });
+
+      const { req, res, jsonFn } = getRequestResponse();
+
+      test('should return the profile without any tokens', async () => {
+        const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
+        await profileHandler(req, res);
+
+        expect(jsonFn).toBeCalledWith({
+          sub: '123'
+        });
+      });
     });
 
-    const { req, res, jsonFn } = getRequestResponse();
+    describe('when asked to refetch', () => {
+      test('should throw an error if the accessToken is missing', async () => {
+        const store = getStore({
+          user: {
+            sub: '123'
+          },
+          createdAt: Date.now()
+        });
 
-    test('should return the profile without any tokens', async () => {
-      const profileHandler = handlers.ProfileHandler(store);
-      await profileHandler(req, res);
+        const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
+        const { req, res } = getRequestResponse();
 
-      expect(jsonFn).toBeCalledWith({
-        sub: '123'
+        return expect(profileHandler(req, res, { refetch: true })).rejects.toEqual(
+          new Error('The access token needs to be saved in the session for the user to be fetched')
+        );
+      });
+
+      test('should refetch the user and update the session', async () => {
+        const now = Date.now();
+        const saveStore = jest.fn();
+        const store = getStore(
+          {
+            user: {
+              sub: '123',
+              email_verified: false
+            },
+            accessToken: 'my-access-token',
+            createdAt: now
+          },
+          saveStore
+        );
+
+        userInfo(withoutApi, 'my-access-token', {
+          sub: '123',
+          email_verified: true
+        });
+        oauthAuthorizationServer(withoutApi);
+        discovery(withoutApi);
+
+        const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
+        const { req, res, jsonFn } = getRequestResponse();
+        await profileHandler(req, res, { refetch: true });
+
+        // Saves the new user in the session
+        expect(saveStore.mock.calls[0][2]).toEqual({
+          user: {
+            sub: '123',
+            email_verified: true
+          },
+          accessToken: 'my-access-token',
+          createdAt: now
+        });
+
+        // Returns the new user
+        expect(jsonFn).toBeCalledWith({
+          sub: '123',
+          email_verified: true
+        });
       });
     });
   });
@@ -66,7 +137,7 @@ describe('profile handler', () => {
     const { req, res, jsonFn, statusFn } = getRequestResponse();
 
     test('should return not authenticated', async () => {
-      const profileHandler = handlers.ProfileHandler(store);
+      const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
       await profileHandler(req, res);
 
       expect(statusFn).toBeCalledWith(401);

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -83,7 +83,7 @@ describe('profile handler', () => {
         const { req, res } = getRequestResponse();
 
         return expect(profileHandler(req, res, { refetch: true })).rejects.toEqual(
-          new Error('The access token needs to be saved in the session for the user to be fetched')
+          new Error('The user does not have a valid access token.')
         );
       });
 
@@ -97,6 +97,7 @@ describe('profile handler', () => {
               email_verified: false
             },
             accessToken: 'my-access-token',
+            accessTokenExpiresAt: now + 60 * 1000,
             createdAt: now
           },
           saveStore
@@ -106,7 +107,7 @@ describe('profile handler', () => {
           sub: '123',
           email_verified: true
         });
-        oauthAuthorizationServer(withoutApi);
+
         discovery(withoutApi);
 
         const profileHandler = handlers.ProfileHandler(store, getClient(withoutApi));
@@ -120,6 +121,7 @@ describe('profile handler', () => {
             email_verified: true
           },
           accessToken: 'my-access-token',
+          accessTokenExpiresAt: now + 60 * 1000,
           createdAt: now
         });
 

--- a/tests/helpers/oidc-nocks.ts
+++ b/tests/helpers/oidc-nocks.ts
@@ -210,3 +210,13 @@ export function refreshTokenRotationExchange(
       scope: 'read:foo write:foo'
     });
 }
+
+export function userInfo(settings: IAuth0Settings, token: string, payload: object): nock.Scope {
+  return nock(`https://${settings.domain}`, {
+    reqheaders: {
+      authorization: `Bearer ${token}`
+    }
+  })
+    .get('/userinfo')
+    .reply(200, payload);
+}

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -305,6 +305,7 @@ describe('CookieStore', () => {
 
         const [, cookie] = setHeaderFn.mock.calls[0];
         req.headers = {
+          ...req.headers,
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
 

--- a/tests/tokens/session-token-cache.test.ts
+++ b/tests/tokens/session-token-cache.test.ts
@@ -57,14 +57,14 @@ describe('SessionTokenCache', () => {
       }
     });
 
-    test('should fail if accessTokenExpiresAt is missing', async () => {
+    test('should fail if access_token and refresh_token are missing', async () => {
       expect.assertions(1);
 
       try {
         const { cache } = getTokenCache();
         await cache.getAccessToken();
       } catch (e) {
-        expect(e.code).toMatch('access_token_expired');
+        expect(e.code).toMatch('invalid_session');
       }
     });
 
@@ -73,6 +73,7 @@ describe('SessionTokenCache', () => {
 
       try {
         const { cache } = getTokenCache({
+          accessToken: 'foo',
           expiresIn: -60
         });
         await cache.getAccessToken();


### PR DESCRIPTION
### Description

This PR allows you to refetch the user profile from the `/userinfo` endpoint. This allows you to receive updates like when the user verifies their email address.


### References

https://github.com/auth0/nextjs-auth0/pull/56
https://github.com/auth0/nextjs-auth0/pull/38

### Testing

Tests have been added to verify that this functionality works.