### PR TITLE
chore: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,27 +358,6 @@ All cookies will be set as `HttpOnly, SameSite=Lax` cookies and will be forced t
 
 The `HttpOnly` setting will make sure that client-side javascript is unabled to access the cookie to reduce the attack surface of XSS attacks while `SameSite=Lax` will help mitigate CSRF attacks. Read more about SameSite [here](https://auth0.com/blog/browser-behavior-changes-what-developers-need-to-know/).
 
-## Troubleshooting
-
-### Error `id_token issued in the future, now 1570650460, iat 1570650461`
-
-Increase the clock tolerance for id_token validation:
-
-```js
-import { initAuth0 } from '@auth0/nextjs-auth0';
-
-export default initAuth0({
-  ...
-  session: {
-    ...
-  },
-  oidcClient: {
-    // Eg: increase the tolerance to 10 seconds.
-    clockTolerance: 10000
-  }
-});
-```
-
 ## Contributing
 
 Run NPM install first to install the dependencies of this project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,15 +1249,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@panva/jose": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@panva/jose/-/jose-1.9.2.tgz",
-      "integrity": "sha512-Uw/ggY8nlemS23Sec1ud6A09I0x6Hji7Ma2xe+EMP2FbkWRt1IAhoK0lBMmMsrsOLVXV/6udcq11MDaeef9jRA==",
-      "dev": true,
-      "requires": {
-        "asn1.js": "^5.1.1"
-      }
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1330,6 +1321,28 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/got": {
+      "version": "9.6.9",
+      "resolved": "https://registry.npmjs.org/@types/got/-/got-9.6.9.tgz",
+      "integrity": "sha512-w+ZE+Ovp6fM+1sHwJB7RN3f3pTJHZkyABuULqbtknqezQyWadFEp5BzOXaZzRqAw2md6/d3ybxQJt+BNgpvzOg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/hapi__iron": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/hapi__iron/-/hapi__iron-5.1.0.tgz",
@@ -1391,20 +1404,10 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/jsonwebtoken": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.4.tgz",
-      "integrity": "sha512-R0eiYPpbo6Jl/XtGwpg7vQlapd7D38gp0g9WMKOSFr/e2NUTN9Udd3ty7n+2yUpmHr2Fti+/BSc+KSQ8zPN+vg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "12.7.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
-      "dev": true
+      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -1465,8 +1468,7 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/yargs": {
       "version": "13.0.2",
@@ -2134,13 +2136,14 @@
       }
     },
     "asn1.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
-      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+      "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "assert": {
@@ -2230,8 +2233,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -3264,7 +3266,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3836,9 +3837,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+      "integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -3907,8 +3908,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -7004,11 +7004,11 @@
       }
     },
     "jose": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-1.10.1.tgz",
-      "integrity": "sha512-E6ev76KFgNT/+qN/owc7EYG7M3nJGSLguF7Jr2bpImUTpIwZS5ALsZA7l5/MOlVm52Kc+lcM/FeOfg3i/VG7qA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.20.0.tgz",
+      "integrity": "sha512-z38qBpt4+BkdmP38kxEwF1W2hvLrXWx3uNsxMoshd43e7C02RLF8+iMcnJITSDGEv2gg718GUCEu26zgMDhHFA==",
       "requires": {
-        "asn1.js": "^5.2.0"
+        "asn1.js": "^5.3.0"
       }
     },
     "js-levenshtein": {
@@ -7486,14 +7486,12 @@
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -8056,9 +8054,9 @@
       }
     },
     "object-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
-      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -8307,9 +8305,9 @@
       }
     },
     "oidc-token-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-3.0.2.tgz",
-      "integrity": "sha512-dTzp80/y/da+um+i+sOucNqiPpwRL7M/xPwj7pH1TFA2/bqQ+OK2sJahSXbemEoLtPkHcFLyhLhLWZa9yW5+RA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.0.tgz",
+      "integrity": "sha512-8Yr4CZSv+Tn8ZkN3iN2i2w2G92mUKClp4z7EGUfdsERiYSbj7P4i/NHm72ft+aUdsiFx9UdIPSTwbyzQ6C4URg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -8344,18 +8342,19 @@
       }
     },
     "openid-client": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.7.4.tgz",
-      "integrity": "sha512-Wjo16utg8GjSqWOBsXzoURp8IVbI7Is6/gZ5M7O94tMFcITIAfwXQSTFdJ6WtizBCc2kEb7klOMA/vjtn2yeZw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.11.0.tgz",
+      "integrity": "sha512-0ADlGIwSdeDhySMzUtnmfBFmqb22XTMaSH97QLNQWfxw6YwPJ8rU6m58AsRJ62bPVRnHZxmOPuxIS3obN2jSVQ==",
       "requires": {
+        "@types/got": "^9.6.9",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
-        "jose": "^1.10.1",
-        "lodash": "^4.17.13",
+        "jose": "^1.18.1",
+        "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "make-error": "^1.3.5",
-        "object-hash": "^2.0.0",
-        "oidc-token-hash": "^3.0.2",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.0",
         "p-any": "^2.1.0"
       }
     },
@@ -9938,8 +9937,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,9 @@
   },
   "homepage": "https://github.com/auth0/nextjs-auth0#readme",
   "devDependencies": {
-    "@panva/jose": "^1.9.2",
     "@types/cookie": "^0.3.3",
     "@types/hapi__iron": "^5.1.0",
     "@types/jest": "^24.0.18",
-    "@types/jsonwebtoken": "^8.3.4",
     "@types/node": "^12.7.12",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
@@ -62,6 +60,7 @@
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^24.9.0",
+    "jose": "^1.20.0",
     "next": "^9.1.1",
     "nock": "^11.6.0",
     "prettier": "^1.19.1",
@@ -74,7 +73,7 @@
     "@hapi/iron": "^5.1.4",
     "base64url": "^3.0.1",
     "cookie": "^0.4.0",
-    "openid-client": "^3.7.4"
+    "openid-client": "^3.11.0"
   },
   "peerDependencies": {
     "next": "^9.0.5"

--- a/tests/handlers/callback.test.ts
+++ b/tests/handlers/callback.test.ts
@@ -1,4 +1,4 @@
-import jose from '@panva/jose';
+import jose from 'jose';
 import request from 'request';
 import { parse } from 'cookie';
 import { promisify } from 'util';
@@ -130,73 +130,6 @@ describe('callback handler', () => {
 
       expect(statusCode).toBe(500);
       expect(body).toEqual('unexpected iss value, expected https://acme.auth0.local/, got: other-issuer');
-    });
-
-    test('should validate the issued at', async () => {
-      const overrides = {
-        iat: Math.floor(new Date(new Date().getTime() + 50 * 1000).getTime() / 1000)
-      };
-
-      codeExchange(
-        withoutApi,
-        'with-expiration',
-        keystore.get(),
-        {
-          name: 'john doe',
-          email: 'john@test.com',
-          sub: '123'
-        },
-        overrides
-      );
-
-      const { statusCode, body } = await getAsync({
-        url: `${httpServer.getUrl()}?state=foo&code=with-expiration`,
-        followRedirect: false,
-        headers: {
-          cookie: 'a0:state=foo;'
-        }
-      });
-
-      expect(statusCode).toBe(500);
-      expect(body).toContain('id_token issued in the future');
-    });
-
-    describe('when oidcClient.clockTolerance is configured', () => {
-      test('should allow id_tokens to be set in the future', async () => {
-        const overrides = {
-          iat: Math.floor(new Date(new Date().getTime() + 10 * 1000).getTime() / 1000)
-        };
-
-        const options = {
-          ...withoutApi,
-          oidcClient: {
-            clockTolerance: 12000
-          }
-        };
-
-        codeExchange(
-          withoutApi,
-          'with-clock-skew',
-          keystore.get(),
-          {
-            name: 'john doe',
-            email: 'john@test.com',
-            sub: '123'
-          },
-          overrides
-        );
-
-        httpServer.setHandler(callback(withoutApi, getClient(options), store));
-        const { statusCode } = await getAsync({
-          url: `${httpServer.getUrl()}?state=foo&code=with-clock-skew`,
-          followRedirect: false,
-          headers: {
-            cookie: 'a0:state=foo;'
-          }
-        });
-
-        expect(statusCode).toBe(302);
-      });
     });
 
     describe('when signing in the user', () => {

--- a/tests/helpers/oidc-nocks.ts
+++ b/tests/helpers/oidc-nocks.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { JSONWebKeySet, JWK } from '@panva/jose';
+import { JSONWebKeySet, JWK } from 'jose';
 
 import createToken from './tokens';
 import IAuth0Settings from '../../src/settings';

--- a/tests/helpers/tokens.ts
+++ b/tests/helpers/tokens.ts
@@ -1,4 +1,4 @@
-import { JWS, JWK } from '@panva/jose';
+import { JWS, JWK } from 'jose';
 
 export default function createToken(key: JWK.Key, payload: object): string {
   const now = (): number => Math.floor(Date.now() / 1000);

--- a/tests/tokens/session-token-cache.test.ts
+++ b/tests/tokens/session-token-cache.test.ts
@@ -1,4 +1,4 @@
-import jose from '@panva/jose';
+import jose from 'jose';
 
 import getRequestResponse from '../helpers/http';
 import getClient from '../../src/utils/oidc-client';


### PR DESCRIPTION
### Description

This PR updates some of the dependencies

1) it updates the development dependency use of `@panva/jose` to just `jose` (package got renamed)
2) it updates the minimal required version of `openid-client` to 3.11.0 ([changelog](https://github.com/panva/node-openid-client/compare/v3.7.4...v3.11.0)), the importance of this update is that ID Token's `iat` is no longer being checked to be in the past, this is unnecessary for an ID Token profile.

cc @sandrinodimattia 