### PR TITLE
Add domain when clearing cookie

### DIFF
--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -33,7 +33,8 @@ export default function logoutHandler(settings: IAuth0Settings, sessionSettings:
         name: sessionSettings.cookieName,
         value: '',
         maxAge: -1,
-        path: sessionSettings.cookiePath
+        path: sessionSettings.cookiePath,
+        domain: sessionSettings.cookieDomain
       }
     ]);
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I ran into a problem when setting the `cookieDomain` option in the session config. The cookie is set correctly when logging in, but because the domain is missing when clearing the cookie in the logout handler it seems that the cookie is not cleared and I remain logged in. Although if I try logging in again Auth0 presents me with the login page.

It looks like an easy fix to add the `cookieDomain` when clearing the cookie, but I'm not sure if this is the right approach.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
