### PR TITLE
Add redirectTo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can optionally send extra parameters to Auth0 to influence the transaction, 
 - Filling in the user's email address
 - Exposing information to the custom login page (eg: to show the signup tab)
 - Using a custom `state`
+- Redirecting the user to a `redirectTo` url after the transaction is finished
 
 ```js
 import auth0 from '../../utils/auth0';
@@ -148,7 +149,8 @@ export default async function login(req, res) {
         scope: 'some other scope',
         state: 'a custom state',
         foo: 'bar'
-      }
+      },
+      redirectTo: '/custom-url'
     });
   } catch (error) {
     console.error(error);

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -46,8 +46,8 @@ export default function callbackHandler(
     // Create the session.
     await sessionStore.save(req, res, session);
 
-    // Redirect to the homepage.
-    const redirectTo = (options && options.redirectTo) || '/';
+    // Redirect to the homepage or custom url.
+    const redirectTo = (options && options.redirectTo) || cookies['a0:redirectTo'] || '/';
     res.writeHead(302, {
       Location: redirectTo
     });

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -73,7 +73,11 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
         value: state,
         maxAge: 60 * 60
       },
-      ...(redirectTo ? [{ name: 'a0:redirectTo', value: redirectTo, maxAge: 60 * 60 }] : [])
+      {
+        name: 'a0:redirectTo',
+        value: redirectTo || '/',
+        maxAge: 60 * 60
+      }
     ]);
 
     // Redirect to the authorize endpoint.

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -37,6 +37,7 @@ export interface AuthorizationParameters {
 
 export interface LoginOptions {
   authParams?: AuthorizationParameters;
+  redirectTo?: string;
 }
 
 export default function loginHandler(settings: IAuth0Settings, clientProvider: IOidcClientFactory) {
@@ -51,6 +52,7 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
 
     const opt = options || {};
     const { state = base64url(randomBytes(48)), ...authParams } = (opt && opt.authParams) || {};
+    const { redirectTo } = opt;
 
     // Create the authorization url.
     const client = await clientProvider();
@@ -70,7 +72,8 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
         name: 'a0:state',
         value: state,
         maxAge: 60 * 60
-      }
+      },
+      ...(redirectTo ? [{ name: 'a0:redirectTo', value: redirectTo, maxAge: 60 * 60 }] : [])
     ]);
 
     // Redirect to the authorize endpoint.

--- a/tests/handlers/callback.test.ts
+++ b/tests/handlers/callback.test.ts
@@ -220,7 +220,7 @@ describe('callback handler', () => {
           url: `${httpServer.getUrl()}?state=foo&code=bar`,
           followRedirect: false,
           headers: {
-            cookie: 'a0:state=foo;'
+            cookie: 'a0:state=foo;a0:redirectTo=/custom-url;'
           }
         });
 
@@ -259,6 +259,11 @@ describe('callback handler', () => {
         const cookie = parse(responseHeaders['set-cookie'][0]);
         expect(cookie['Max-Age']).toBe('3600');
         expect(cookie.Expires).toBe(new Date(time.getTime() + 3600 * 1000).toUTCString());
+      });
+
+      test('should redirect to cookie url', async () => {
+        expect(responseStatus).toBe(302);
+        expect(responseHeaders.location).toBe('/custom-url');
       });
     });
   });

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -17,7 +17,7 @@ describe('login handler', () => {
 
   beforeEach(done => {
     discovery(withoutApi);
-    loginOptions = null;
+    loginOptions = { redirectTo: '/custom-url' };
     loginHandler = login(withoutApi, getClient(withoutApi));
     httpServer = new HttpServer((req, res) => loginHandler(req, res, loginOptions));
     httpServer.start(done);
@@ -35,6 +35,18 @@ describe('login handler', () => {
 
     const state = parse(headers['set-cookie'][0]);
     expect(state).toBeTruthy();
+  });
+
+  test('should create a redirectTo cookie', async () => {
+    const { headers } = await getAsync({
+      url: httpServer.getUrl(),
+      followRedirect: false
+    });
+
+    const state = parse(headers['set-cookie'][0]);
+    const redirectTo = parse(headers['set-cookie'][1]);
+    expect(state).toBeTruthy();
+    expect(redirectTo['a0:redirectTo']).toEqual('/custom-url');
   });
 
   test('should redirect to the identity provider', async () => {


### PR DESCRIPTION
### Description
Adds support for custom redirect url at the beginning of the login transaction.

The `handleLogin` method now receives an optional `redirectTo` parameter and writes it to an `a0:redirectTo` cookie in the same way as `state` is written. Then, if the `handleCallback` method doesn't receive a `redirectTo` parameter directly, it will redirect to the value stored in the `a0:redirectTo` cookie.

#### Previously evaluated alternatives 
- Write the cookie outside of the SDK: this is not possible since the SDK sets the `Set-Cookie` header and overrides any previously set value.
- Use state to encode redirect url: this is non-trivial to do for users

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
