### PR TITLE
Automatically redirect to redirectTo in login request

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can optionally send extra parameters to Auth0 to influence the transaction, 
 - Filling in the user's email address
 - Exposing information to the custom login page (eg: to show the signup tab)
 - Using a custom `state`
-- Redirecting the user to a `redirectTo` url after the transaction is finished
+- Redirecting the user to a `redirectTo` url after the transaction is finished (`redirectTo` is infered from `req` by default. If not present there either, the default is `'/'`.)
 
 ```js
 import auth0 from '../../utils/auth0';

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -1,6 +1,6 @@
 import base64url from 'base64url';
 import { randomBytes } from 'crypto';
-import { IncomingMessage, ServerResponse } from 'http';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import version from '../version';
 import IAuth0Settings from '../settings';
@@ -41,7 +41,7 @@ export interface LoginOptions {
 }
 
 export default function loginHandler(settings: IAuth0Settings, clientProvider: IOidcClientFactory) {
-  return async (req: IncomingMessage, res: ServerResponse, options?: LoginOptions): Promise<void> => {
+  return async (req: NextApiRequest, res: NextApiResponse, options?: LoginOptions): Promise<void> => {
     if (!req) {
       throw new Error('Request is not available');
     }
@@ -75,7 +75,7 @@ export default function loginHandler(settings: IAuth0Settings, clientProvider: I
       },
       {
         name: 'a0:redirectTo',
-        value: redirectTo || '/',
+        value: redirectTo || req.query.redirectTo as string || '/',
         maxAge: 60 * 60
       }
     ]);


### PR DESCRIPTION
### Description
The `redirectTo` query string param from `req` is automatically infered, so this:

```js
auth0.handleLogin(req, res, {
    redirectTo: req.query.redirectTo
})
```

Can become this:

```js
auth0.handleLogin(req, res)
```

### References

This is supposed to be an improvement on #81.

### Testing

I can try adding a test for this, if necessary.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
