### PR TITLE
Updated README to match session guards in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,16 +232,15 @@ If you need to access the user's session from within an API route or a Server-re
 ```js
 Profile.getInitialProps = async ({ req, res }) => {
   if (typeof window === 'undefined') {
-    const { user } = await auth0.getSession(req);
-    if (!user) {
+    const session = await auth0.getSession(req);
+    if (!session || !session.user) {
       res.writeHead(302, {
         Location: '/api/login'
       });
       res.end();
       return;
     }
-
-    return { user };
+    return { user: session.user };
   }
 };
 ```


### PR DESCRIPTION
### Description

Just an update to the README.

The current example in README does not have sufficient guards on calls to `auth0.getSession()`. I assumed it was copy/pasta code, but it can produce an error out of the box when `getSession()` [returns null](https://github.com/auth0/nextjs-auth0/blob/e724719f7be191e122ba664b16d07926aa18d980/src/session/cookie-store/index.ts#L30). I just matched the README to what is in the example projects, which _does_ use a guard.