### PR TITLE
Fix #100 - Use end_session_endpoint if available from issuer

### DIFF
--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -2,7 +2,9 @@ import { IncomingMessage, ServerResponse } from 'http';
 
 import IAuth0Settings from '../settings';
 import { setCookies } from '../utils/cookies';
+import { IOidcClientFactory } from '../utils/oidc-client';
 import CookieSessionStoreSettings from '../session/cookie-store/settings';
+import { ISessionStore } from '../session/store';
 
 function createLogoutUrl(settings: IAuth0Settings): string {
   return (
@@ -12,7 +14,12 @@ function createLogoutUrl(settings: IAuth0Settings): string {
   );
 }
 
-export default function logoutHandler(settings: IAuth0Settings, sessionSettings: CookieSessionStoreSettings) {
+export default function logoutHandler(
+  settings: IAuth0Settings,
+  sessionSettings: CookieSessionStoreSettings,
+  clientProvider: IOidcClientFactory,
+  store: ISessionStore
+) {
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (!req) {
       throw new Error('Request is not available');
@@ -20,6 +27,24 @@ export default function logoutHandler(settings: IAuth0Settings, sessionSettings:
 
     if (!res) {
       throw new Error('Response is not available');
+    }
+
+    const session = await store.read(req);
+    let endSessionUrl = undefined;
+
+    try {
+      const client = await clientProvider();
+      endSessionUrl = client.endSessionUrl({
+        id_token_hint: session ? session.idToken : undefined,
+        post_logout_redirect_uri: encodeURIComponent(settings.postLogoutRedirectUri)
+      });
+    } catch (err) {
+      if (/end_session_endpoint must be configured/.exec(err)) {
+        // Use default url if end_session_endpoint is not configured
+        endSessionUrl = createLogoutUrl(settings);
+      } else {
+        throw err;
+      }
     }
 
     // Remove the cookies
@@ -40,7 +65,7 @@ export default function logoutHandler(settings: IAuth0Settings, sessionSettings:
 
     // Redirect to the logout endpoint.
     res.writeHead(302, {
-      Location: createLogoutUrl(settings)
+      Location: endSessionUrl
     });
     res.end();
   };

--- a/src/instance.node.ts
+++ b/src/instance.node.ts
@@ -34,7 +34,7 @@ export default function createInstance(settings: IAuth0Settings): ISignInWithAut
 
   return {
     handleLogin: handlers.LoginHandler(settings, clientProvider),
-    handleLogout: handlers.LogoutHandler(settings, sessionSettings),
+    handleLogout: handlers.LogoutHandler(settings, sessionSettings, clientProvider, store),
     handleCallback: handlers.CallbackHandler(settings, clientProvider, store),
     handleProfile: handlers.ProfileHandler(store, clientProvider),
     getSession: handlers.SessionHandler(store),


### PR DESCRIPTION
### Description

Solves the problem described in #100.

This PR enhance `auth0.handleLogout(req, res)` behavior by using the `end_session_endpoint` from discovery endpoint if available. This still falls back to use the default Auth0 logout URL, thus existing behavior is not broken.

### References

- https://openid.net/specs/openid-connect-session-1_0.html#RPLogout
