### PR TITLE
getSession from NextPageRequest works too

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1,10 +1,10 @@
-import { NextApiRequest } from 'next';
+import { IncomingMessage } from 'http';
 
 import { ISession } from '../session/session';
 import { ISessionStore } from '../session/store';
 
 export default function sessionHandler(sessionStore: ISessionStore) {
-  return (req: NextApiRequest): Promise<ISession | null | undefined> => {
+  return (req: IncomingMessage): Promise<ISession | null | undefined> => {
     if (!req) {
       throw new Error('Request is not available');
     }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-
+import { IncomingMessage } from 'http';
 import { ISession } from './session/session';
 import { LoginOptions } from './handlers/login';
 import { ITokenCache } from './tokens/token-cache';
@@ -31,7 +31,7 @@ export interface ISignInWithAuth0 {
   /**
    * Session handler which returns the current session
    */
-  getSession: (req: NextApiRequest) => Promise<ISession | null | undefined>;
+  getSession: (req: IncomingMessage) => Promise<ISession | null | undefined>;
 
   /**
    * Handle to require authentication for an API route.


### PR DESCRIPTION
It should be possible to call `getSession` from a NextJS page as well as a NextJS API handler. This PR ensures you can from a TypeScript perspective.