### PR TITLE
Refresh token with accessTokenRequest scopes

### DIFF
--- a/src/tokens/session-token-cache.ts
+++ b/src/tokens/session-token-cache.ts
@@ -75,7 +75,8 @@ export default class SessionTokenCache implements ITokenCache {
     // Adding a skew of 1 minute to compensate.
     if (session.refreshToken && session.accessTokenExpiresAt * 1000 - 60000 < Date.now()) {
       const client = await this.clientProvider();
-      const tokenSet = await client.refresh(session.refreshToken);
+      const extras = accessTokenRequest ? { exchangeBody: { scope: accessTokenRequest.scopes?.join(" ") } } : undefined;
+      const tokenSet = await client.refresh(session.refreshToken, extras);
 
       // Update the session.
       const newSession = getSessionFromTokenSet(tokenSet);

--- a/tests/helpers/oidc-nocks.ts
+++ b/tests/helpers/oidc-nocks.ts
@@ -166,7 +166,8 @@ export function refreshTokenExchange(
   refreshToken: string,
   key: JWK.Key,
   payload: object,
-  newToken?: string
+  newToken?: string,
+  newScopes?: string[],
 ): nock.Scope {
   const idToken = createToken(key, {
     iss: `https://${settings.domain}/`,
@@ -174,14 +175,17 @@ export function refreshTokenExchange(
     ...payload
   });
 
+  // Encode scopes for application/x-www-form-urlencoded.
+  const scope = newScopes ? `scope=${newScopes.map(encodeURIComponent).join("+")}&` : "";
+
   return nock(`https://${settings.domain}`)
-    .post('/oauth/token', `grant_type=refresh_token&refresh_token=${refreshToken}`)
+    .post('/oauth/token', `${scope}grant_type=refresh_token&refresh_token=${refreshToken}`)
     .reply(200, {
       access_token: newToken || 'eyJz93a...k4laUWw',
       id_token: idToken,
       token_type: 'Bearer',
       expires_in: 750,
-      scope: 'read:foo write:foo'
+      scope: newScopes ? newScopes.join(" ") : 'read:foo write:foo'
     });
 }
 


### PR DESCRIPTION
### Description

Adds support for requesting different scopes during a refresh token request, as supported by Auth0's Authentication API: https://auth0.com/docs/api/authentication#refresh-token.

This seems to be a missing feature of the library, and I need it for my project, so I thought I'd contribute. Let me know if any issues.

For example:

Given the client requested scopes `read:foo write:foo delete:foo` on login
When the client performs a refresh token request and requests only `read:foo write:foo`
Then the refresh token request should include the new scopes, so that the access_token / id_token returned only includes the new scopes as requested

It is already possible to specify a set of required scopes when getting the accessToken from the `TokenCache` (see below), so this is not an interface change. If no scopes are specified, the behaviour is the same as before.

```typescript
auth0.tokenCache(req, res).getAccessToken({ scope: ["read:foo", "write:foo"] });
```

Also note that `getAccessToken()` already enforces the constraint that you may only request a subset of the scopes requested during initial login.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
(Not sure this is needed, since it's not a change to the interface)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
