### PR TITLE
fix for encodeing postLogoutRedirectUri twice

### DIFF
--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -36,7 +36,7 @@ export default function logoutHandler(
       const client = await clientProvider();
       endSessionUrl = client.endSessionUrl({
         id_token_hint: session ? session.idToken : undefined,
-        post_logout_redirect_uri: encodeURIComponent(settings.postLogoutRedirectUri)
+        post_logout_redirect_uri: settings.postLogoutRedirectUri
       });
     } catch (err) {
       if (/end_session_endpoint must be configured/.exec(err)) {

--- a/tests/handlers/logout.test.ts
+++ b/tests/handlers/logout.test.ts
@@ -73,7 +73,7 @@ describe('logout handler', () => {
     expect(statusCode).toBe(302);
     expect(headers.location).toBe(
       `https://my-end-session-endpoint/logout` +
-        `?id_token_hint=my-id-token&post_logout_redirect_uri=https%253A%252F%252Fwww.acme.com`
+        `?id_token_hint=my-id-token&post_logout_redirect_uri=https%3A%2F%2Fwww.acme.com`
     );
   });
 


### PR DESCRIPTION

This pr fixes an issue in auth0.handleLogout(req, res) where the post redirect url was encoded twice causing issues logging out on identity. This still falls back to use the default Auth0 logout URL, thus existing behavior is not broken.

### References
Solves the problem described in #126 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
