### PR TITLE
Keeps previously set cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ export default async function callback(req, res) {
 }
 ```
 
+The `handleCallback` function ends the request and sends the response (the redirect), so if you need to set any other cookies, do it before calling the said function and they will kept in the final response.
+
 You can optionally send extra parameters to Auth0 to influence the transaction, for example:
 
 - Showing the login page

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -95,18 +95,26 @@ function serializeCookie(cookie: ICookie, secure: boolean): string {
 /**
  * Set one or more cookies.
  * @param res The HTTP response on which the cookie will be set.
+ * @returns {void}
  */
 export function setCookies(req: IncomingMessage, res: ServerResponse, cookies: Array<ICookie>): void {
-  res.setHeader(
-    'Set-Cookie',
-    cookies.map((c) => serializeCookie(c, isSecureEnvironment(req)))
-  );
+  const strCookies = cookies.map((c) => serializeCookie(c, isSecureEnvironment(req)));
+  const previousCookies = res.getHeader('Set-Cookie');
+  if (previousCookies) {
+    if (previousCookies instanceof Array) {
+      Array.prototype.push.apply(strCookies, previousCookies);
+    } else if (typeof previousCookies === 'string') {
+      strCookies.push(previousCookies);
+    }
+  }
+  res.setHeader('Set-Cookie', strCookies);
 }
 
 /**
  * Set one or more cookies.
  * @param res The HTTP response on which the cookie will be set.
+ * @returns {void}
  */
 export function setCookie(req: IncomingMessage, res: ServerResponse, cookie: ICookie): void {
-  res.setHeader('Set-Cookie', serializeCookie(cookie, isSecureEnvironment(req)));
+  setCookies(req, res, [cookie]);
 }

--- a/tests/helpers/http.ts
+++ b/tests/helpers/http.ts
@@ -17,6 +17,7 @@ export default function getRequestResponse(): IHttpHelpers {
 
   const res: any = new ServerResponse(req);
   res.setHeader = jest.fn();
+  res.getHeader = jest.fn();
   res.json = jest.fn();
   res.status = jest.fn(() => res);
 

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -28,7 +28,10 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', expect.stringMatching('my-cookie='));
+        expect(res.setHeader).toHaveBeenCalledWith(
+          'Set-Cookie',
+          expect.arrayContaining([expect.stringMatching('my-cookie=')])
+        );
       });
     });
 
@@ -42,7 +45,10 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', expect.stringMatching('a0:session='));
+        expect(res.setHeader).toHaveBeenCalledWith(
+          'Set-Cookie',
+          expect.arrayContaining([expect.stringMatching('a0:session=')])
+        );
       });
     });
   });
@@ -60,7 +66,7 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         expect(parse(cookie).Domain).toBe('.quirk.fyi');
       });
     });
@@ -75,7 +81,7 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         expect(parse(cookie).Domain).toBeUndefined();
       });
     });
@@ -94,7 +100,7 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         expect(parse(cookie).SameSite).toBe('Strict');
       });
     });
@@ -109,7 +115,7 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         expect(parse(cookie).SameSite).toBe('Lax');
       });
     });
@@ -125,7 +131,7 @@ describe('CookieStore', () => {
           createdAt: Date.now()
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         expect(parse(cookie).SameSite).toBeUndefined();
       });
     });
@@ -147,7 +153,7 @@ describe('CookieStore', () => {
           accessTokenExpiresAt: 500
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
@@ -177,7 +183,7 @@ describe('CookieStore', () => {
           accessTokenExpiresAt: 500
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
@@ -210,7 +216,7 @@ describe('CookieStore', () => {
           idToken: 'my-id-token'
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
@@ -240,7 +246,7 @@ describe('CookieStore', () => {
           idToken: 'my-id-token'
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
@@ -272,7 +278,7 @@ describe('CookieStore', () => {
           refreshToken: 'my-refresh-token'
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           cookie: `a0:session=${parse(cookie)['a0:session']}`
         };
@@ -303,7 +309,7 @@ describe('CookieStore', () => {
           refreshToken: 'my-refresh-token'
         });
 
-        const [, cookie] = setHeaderFn.mock.calls[0];
+        const [, [cookie]] = setHeaderFn.mock.calls[0];
         req.headers = {
           ...req.headers,
           cookie: `a0:session=${parse(cookie)['a0:session']}`

--- a/tests/utils/cookies.test.ts
+++ b/tests/utils/cookies.test.ts
@@ -1,4 +1,5 @@
 import timekeeper from 'timekeeper';
+import { serialize } from 'cookie';
 
 import getRequestResponse from '../helpers/http';
 import { setCookie } from '../../src/utils/cookies';
@@ -33,7 +34,55 @@ describe('cookies', () => {
       });
 
       expect(res.setHeader.mock.calls).toEqual([
-        ['Set-Cookie', `foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]
+        ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
+      ]);
+    });
+
+    test('should keep the previously set cookie on the response', () => {
+      const { req, res } = getRequestResponse();
+      const previousCookie = serialize('previous', 'value');
+      res.getHeader.mockReturnValueOnce([previousCookie]);
+      setCookie(req, res, {
+        name: 'foo',
+        value: 'bar',
+        maxAge: 1000,
+        path: '/'
+      });
+
+      expect(res.setHeader.mock.calls).toEqual([
+        ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`, previousCookie]]
+      ]);
+    });
+
+    test('should keep the previously set single string cookie on the response', () => {
+      const { req, res } = getRequestResponse();
+      const previousCookie = serialize('previous', 'value');
+      res.getHeader.mockReturnValueOnce(previousCookie);
+      setCookie(req, res, {
+        name: 'foo',
+        value: 'bar',
+        maxAge: 1000,
+        path: '/'
+      });
+
+      expect(res.setHeader.mock.calls).toEqual([
+        ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`, previousCookie]]
+      ]);
+    });
+
+    test('should keep multiple previously set cookies on the response', () => {
+      const { req, res } = getRequestResponse();
+      const previousCookies = [serialize('previous', 'value'), serialize('lady', 'gaga')];
+      res.getHeader.mockReturnValueOnce(previousCookies);
+      setCookie(req, res, {
+        name: 'foo',
+        value: 'bar',
+        maxAge: 1000,
+        path: '/'
+      });
+
+      expect(res.setHeader.mock.calls).toEqual([
+        ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`, ...previousCookies]]
       ]);
     });
 
@@ -50,7 +99,7 @@ describe('cookies', () => {
         });
 
         expect(res.setHeader.mock.calls).toEqual([
-          ['Set-Cookie', `foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]
+          ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
         ]);
       });
     });
@@ -68,7 +117,7 @@ describe('cookies', () => {
         });
 
         expect(res.setHeader.mock.calls).toEqual([
-          ['Set-Cookie', `foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]
+          ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
         ]);
       });
 
@@ -85,7 +134,7 @@ describe('cookies', () => {
           });
 
           expect(res.setHeader.mock.calls).toEqual([
-            ['Set-Cookie', `foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly; Secure`]
+            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly; Secure`]]
           ]);
         });
       });


### PR DESCRIPTION
### Description

Keeps any previously set cookies on the cookies helper in order to allow more cookies to be set other than the session one, e.g. on the callback route

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
