### PR TITLE
Allow force refreshing of the access token

### DIFF
--- a/src/tokens/session-token-cache.ts
+++ b/src/tokens/session-token-cache.ts
@@ -73,7 +73,10 @@ export default class SessionTokenCache implements ITokenCache {
     // Check if the token has expired.
     // There is an edge case where we might have some clock skew where our code assumes the token is still valid.
     // Adding a skew of 1 minute to compensate.
-    if (session.refreshToken && session.accessTokenExpiresAt * 1000 - 60000 < Date.now()) {
+    if (
+      (session.refreshToken && session.accessTokenExpiresAt * 1000 - 60000 < Date.now()) ||
+      (session.refreshToken && accessTokenRequest && accessTokenRequest.refresh)
+    ) {
       const client = await this.clientProvider();
       const tokenSet = await client.refresh(session.refreshToken);
 

--- a/src/tokens/token-cache.ts
+++ b/src/tokens/token-cache.ts
@@ -1,5 +1,6 @@
 export interface AccessTokenRequest {
   scopes?: Array<string>;
+  refresh?: boolean;
 }
 
 export interface AccessTokenResponse {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> The purpose of this pr is to allow the access token to be refreshed manually
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
Changes are to AccessTokenRequest interface to allow the option refresh which is not required.
and inside of getAccessToken() where it would check if the token was expired and there is a refresh token it now also checks 
`(session.refreshToken && accessTokenRequest && accessTokenRequest.refresh`

How it can be used is `getAccessToken({refresh:true})`

### References

> Include any links supporting this change such as a:
>
> - https://github.com/auth0/nextjs-auth0/issues/136


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
> Added a new test for this outcome next with the same code with a change to the time that is used to test the expired access token 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
