### PR TITLE
Allow setting insecure cookie 

### DIFF
--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -67,6 +67,10 @@ function isSecureEnvironment(req: IncomingMessage): boolean {
     return false;
   }
 
+  if (process.env.AUTH0_ALLOW_INSECURE_COOKIE === 'true') {
+    return false;
+  }
+
   const host = (req.headers.host.indexOf(':') > -1 && req.headers.host.split(':')[0]) || req.headers.host;
   if (['localhost', '127.0.0.1'].indexOf(host) > -1) {
     return false;

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -67,7 +67,7 @@ function isSecureEnvironment(req: IncomingMessage): boolean {
     return false;
   }
 
-  if (/^true$/i.test(process.env.AUTH0_ALLOW_INSECURE_COOKIE)) {
+  if (/^true$/i.test(process.env.AUTH0_ALLOW_INSECURE_COOKIE as string)) {
     return false;
   }
 

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -67,7 +67,7 @@ function isSecureEnvironment(req: IncomingMessage): boolean {
     return false;
   }
 
-  if (process.env.AUTH0_ALLOW_INSECURE_COOKIE === 'true') {
+  if (/^true$/i.test(process.env.AUTH0_ALLOW_INSECURE_COOKIE)) {
     return false;
   }
 

--- a/tests/utils/cookies.test.ts
+++ b/tests/utils/cookies.test.ts
@@ -138,6 +138,47 @@ describe('cookies', () => {
           ]);
         });
       });
+
+      describe('when NODE_ENV is not production', () => {
+        test('should not set a secure cookie on the response', async () => {
+          const { req, res } = getRequestResponse();
+          req.headers.host = 'www.acme.com';
+
+          process.env.NODE_ENV = 'development';
+          
+          setCookie(req, res, {
+            name: 'foo',
+            value: 'bar',
+            maxAge: 1000,
+            path: '/'
+          });
+
+          expect(res.setHeader.mock.calls).toEqual([
+            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
+          ]);
+        });
+      });
+
+      describe('when AUTH0_ALLOW_INSECURE_COOKIE is \'true\'', () => {
+        test('should not set a secure cookie on the response', async () => {
+          const { req, res } = getRequestResponse();
+          req.headers.host = 'www.acme.com';
+
+          process.env.NODE_ENV = 'production';
+          process.env.AUTH0_ALLOW_INSECURE_COOKIE = 'true';
+          
+          setCookie(req, res, {
+            name: 'foo',
+            value: 'bar',
+            maxAge: 1000,
+            path: '/'
+          });
+
+          expect(res.setHeader.mock.calls).toEqual([
+            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
+          ]);
+        });
+      });
     });
   });
 });

--- a/tests/utils/cookies.test.ts
+++ b/tests/utils/cookies.test.ts
@@ -120,65 +120,72 @@ describe('cookies', () => {
           ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
         ]);
       });
+    });
 
-      describe('when not running on localhost', () => {
-        test('should set a secure cookie on the response', async () => {
-          const { req, res } = getRequestResponse();
-          req.headers.host = 'www.acme.com';
+    describe('when not running on localhost', () => {
+      test('should set a secure cookie on the response', async () => {
+        const { req, res } = getRequestResponse();
+        req.headers.host = 'www.acme.com';
 
-          setCookie(req, res, {
-            name: 'foo',
-            value: 'bar',
-            maxAge: 1000,
-            path: '/'
-          });
-
-          expect(res.setHeader.mock.calls).toEqual([
-            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly; Secure`]]
-          ]);
+        setCookie(req, res, {
+          name: 'foo',
+          value: 'bar',
+          maxAge: 1000,
+          path: '/'
         });
+
+        expect(res.setHeader.mock.calls).toEqual([
+          ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly; Secure`]]
+        ]);
+      });
+    });
+
+    describe("when AUTH0_ALLOW_INSECURE_COOKIE is 'true'", () => {
+      const initialEnvVar = process.env.AUTH0_ALLOW_INSECURE_COOKIE;
+      beforeEach(() => {
+        process.env.AUTH0_ALLOW_INSECURE_COOKIE = 'true';
       });
 
-      describe('when NODE_ENV is not production', () => {
-        test('should not set a secure cookie on the response', async () => {
-          const { req, res } = getRequestResponse();
-          req.headers.host = 'www.acme.com';
-
-          process.env.NODE_ENV = 'development';
-          
-          setCookie(req, res, {
-            name: 'foo',
-            value: 'bar',
-            maxAge: 1000,
-            path: '/'
-          });
-
-          expect(res.setHeader.mock.calls).toEqual([
-            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
-          ]);
-        });
+      afterEach(() => {
+        process.env.AUTH0_ALLOW_INSECURE_COOKIE = initialEnvVar;
       });
 
-      describe('when AUTH0_ALLOW_INSECURE_COOKIE is \'true\'', () => {
-        test('should not set a secure cookie on the response', async () => {
-          const { req, res } = getRequestResponse();
-          req.headers.host = 'www.acme.com';
+      test('should not set a secure cookie on the response', async () => {
+        const { req, res } = getRequestResponse();
+        req.headers.host = 'www.acme.com';
 
-          process.env.NODE_ENV = 'production';
-          process.env.AUTH0_ALLOW_INSECURE_COOKIE = 'true';
-          
-          setCookie(req, res, {
-            name: 'foo',
-            value: 'bar',
-            maxAge: 1000,
-            path: '/'
-          });
-
-          expect(res.setHeader.mock.calls).toEqual([
-            ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
-          ]);
+        setCookie(req, res, {
+          name: 'foo',
+          value: 'bar',
+          maxAge: 1000,
+          path: '/'
         });
+
+        expect(res.setHeader.mock.calls).toEqual([
+          ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
+        ]);
       });
+    });
+  });
+
+  describe('when not running in production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
+    test('should not set a secure cookie on the response', async () => {
+      const { req, res } = getRequestResponse();
+      req.headers.host = 'www.acme.com';
+
+      setCookie(req, res, {
+        name: 'foo',
+        value: 'bar',
+        maxAge: 1000,
+        path: '/'
+      });
+
+      expect(res.setHeader.mock.calls).toEqual([
+        ['Set-Cookie', [`foo=bar; Max-Age=1000; Path=/; Expires=${timeString}; HttpOnly`]]
+      ]);
     });
   });
 });


### PR DESCRIPTION
### Description

Currently, the cookie set is always Secure unless running on localhost or when `NODE_ENV` is not `production`.
When deploying code to a non-https site that has `NODE_ENV=production`, setting the cookie will fail.
Our use-case is deploying PRs to a dynamically created environment, where we test that everything is working as in production (thus, we have `NODE_ENV=production`), but the environment is a random url, and so cannot have https (at least easily).

The proposed solution is to allow setting an environment variable that turns off setting the cookie as secure, `AUTH0_ALLOW_INSECURE_COOKIE=true`

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
