### PR TITLE
Fix #161 getAccessToken clears custom session.user attributes set via…

### DIFF
--- a/src/tokens/session-token-cache.ts
+++ b/src/tokens/session-token-cache.ts
@@ -84,6 +84,10 @@ export default class SessionTokenCache implements ITokenCache {
       const newSession = getSessionFromTokenSet(tokenSet);
       await this.store.save(this.req, this.res, {
         ...newSession,
+        user: {
+          ...session.user,
+          ...newSession.user
+        },
         refreshToken: newSession.refreshToken || session.refreshToken
       });
 

--- a/tests/tokens/session-token-cache.test.ts
+++ b/tests/tokens/session-token-cache.test.ts
@@ -234,7 +234,7 @@ describe('SessionTokenCache', () => {
 
         const initialSession = await getSession();
 
-        store.save((undefined as unknown) as IncomingMessage, (undefined as unknown) as ServerResponse, {
+        await store.save((undefined as unknown) as IncomingMessage, (undefined as unknown) as ServerResponse, {
           ...initialSession,
           user: {
             ...initialSession?.user,


### PR DESCRIPTION
### Description

Fixes #161. I left this code in `profile.ts` but it might now be redundant code (unless its used by another code path?) https://github.com/auth0/nextjs-auth0/blob/411896ba5044bbeda1b362f7f85b5ab8128d12cd/src/handlers/profile.ts#L40-L48  

@sandrinodimattia Let me know if this code should be removed

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
