### PR TITLE
Less specific tokenCacheHandler return type

### DIFF
--- a/src/handlers/token-cache.ts
+++ b/src/handlers/token-cache.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from 'next';
+import { IncomingMessage, ServerResponse } from 'http';
 
 import { ISessionStore } from '../session/store';
 import { ITokenCache } from '../tokens/token-cache';
@@ -6,7 +6,7 @@ import { IOidcClientFactory } from '../utils/oidc-client';
 import SessionTokenCache from '../tokens/session-token-cache';
 
 export default function tokenCacheHandler(clientProvider: IOidcClientFactory, sessionStore: ISessionStore) {
-  return (req: NextApiRequest, res: NextApiResponse): ITokenCache => {
+  return (req: IncomingMessage, res: ServerResponse): ITokenCache => {
     if (!req) {
       throw new Error('Request is not available');
     }


### PR DESCRIPTION
### Description

**Update the return type of `tokenCacheHandler` to be less restrictive.**

The invocation of `tokenCache` from `tokenCacheHandler` is necessarily restricted to taking a `NextApiRequest` and an `NextApiResponse`.

It can be less specific and take an IncomingMessage and ServerResponse, which is all  the called `SessionTokenCache` requires/

In doing so the token cache handler can be utilized in Next.js's `getServerSideProps` without type errors by passing the [`req` and `res` from `context` of type `GetServerSidePropsContext`](https://github.com/vercel/next.js/blob/master/packages/next/types/index.d.ts#L111).

I encountered this as a type error when trying to refresh a token within `getServerSideProps` by calling:

```typescript
export const getServerSideProps = (context: GetServerSidePropsContext) => {
    const { req, res } = context;
    const tokenCache = auth0.tokenCache(req, res); // <- Type error here: Argument of type 'IncomingMessage' is not assignable to parameter of type 'NextApiRequest'.
    // ...
};
```

### References

None.

### Testing

None.

### Checklist

- [ ] ~I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
