### PR TITLE
Split session cookie into multiple cookies when content is too long

### DIFF
--- a/src/session/cookie-store/index.ts
+++ b/src/session/cookie-store/index.ts
@@ -28,7 +28,14 @@ export default class CookieSessionStore implements ISessionStore {
     const cookieCount = cookies[`${cookieName}.c`] || 1;
     let cookie = '';
     for (let i = 0; i < cookieCount; i += 1) {
-      const cookiePart = cookies[`${cookieName}.${i}`];
+      let cookiePart = cookies[`${cookieName}.${i}`];
+
+      // derecated: this could be removed later, once compatibility with legacy store is not needed
+      if (i == 0 && !cookiePart) {
+        cookiePart = cookies[`${cookieName}`];
+      }
+      // end of deprecated code
+
       if (!cookiePart || cookiePart.length === 0) {
         return null; // missing or broken cookie part
       }

--- a/tests/handlers/callback.test.ts
+++ b/tests/handlers/callback.test.ts
@@ -211,7 +211,7 @@ describe('callback handler', () => {
 
         const { req } = getRequestResponse();
         req.headers = {
-          cookie: `a0:session=${parse(responseHeaders['set-cookie'][0])['a0:session']}`
+          cookie: responseHeaders['set-cookie'].join('; ')
         };
 
         const session = await store.read(req);
@@ -303,7 +303,7 @@ describe('callback handler', () => {
 
         const { req } = getRequestResponse();
         req.headers = {
-          cookie: `a0:session=${parse(responseHeaders['set-cookie'][0])['a0:session']}`
+          cookie: responseHeaders['set-cookie'].join('; ')
         };
 
         const session = await store.read(req);
@@ -388,7 +388,7 @@ describe('callback handler', () => {
 
         const { req } = getRequestResponse();
         req.headers = {
-          cookie: `a0:session=${parse(responseHeaders['set-cookie'][0])['a0:session']}`
+          cookie: responseHeaders['set-cookie'].join('; ')
         };
 
         const session = await store.read(req);
@@ -401,7 +401,7 @@ describe('callback handler', () => {
 
         const { req } = getRequestResponse();
         req.headers = {
-          cookie: `a0:session=${parse(responseHeaders['set-cookie'][0])['a0:session']}`
+          cookie: responseHeaders['set-cookie'].join('; ')
         };
 
         const session = await store.read(req);

--- a/tests/session/cookie-store.test.ts
+++ b/tests/session/cookie-store.test.ts
@@ -218,6 +218,33 @@ describe('CookieStore', () => {
     });
   });
 
+  describe('with legacy cookies', () => {
+    test('should be able to read them', async() => {
+      const store = getStore({});
+      const { req, res, setHeaderFn } = getRequestResponse();
+      
+      const now = Date.now();
+      await store.save(req, res, {
+        user: { sub: '123' },
+        createdAt: now,
+        accessToken: 'my-access-token',
+        accessTokenScope: 'read:foo',
+        accessTokenExpiresAt: 500
+      });
+
+      const [, cookies] = setHeaderFn.mock.calls[0];
+      
+      req.headers = {
+        cookie: `a0:session=${cookies[0].substr(13)}` // legacy cookie store used a single cookie to store data
+      }
+      const session = await store.read(req);
+      expect(session).toEqual({
+        user: { sub: '123' },
+        createdAt: now
+      });
+    });
+  });
+
   describe('with storeAccessToken', () => {
     describe('not configured', () => {
       const store = getStore({});


### PR DESCRIPTION
Content of the session can easily outgrow 4090 bytes which is the limit for the size of a single cookie. This happens more easily when idToken and refreshToken are stored as well.


### Description

To overcome this issue this patch will split the session cookie into multiple cookies, and will reintegrate them upon session read.

This is done by adding a postfix to the chosen cookie name:
[cookiename].c will contain the number of cookies to look for. If missing it's assumed to be 1
[cookiename].[number] will contain part of the encrypted session.

This is proposal to fix the issue, please feel free to add any thoughts or changes.

### References

This PR fixed issue #128 

### Testing

This issue can easily be reproduced by turning on all all of `storeAccessToken`, `storeIdToken`, `storeRefreshToken`, and adding a few hundred bytes of claims to these tokens.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
