### PR TITLE
Fix trailing slash bug.

### DIFF
--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -90,7 +90,7 @@ function serializeCookie(cookie: ICookie, secure: boolean): string {
     expires: new Date(Date.now() + cookie.maxAge * 1000),
     httpOnly: true,
     secure,
-    path: cookie.path,
+    path: cookie.path ? cookie.path : '/',
     domain: cookie.domain,
     sameSite: cookie.sameSite
   });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Seems like the trailing slash setting in next.js is messing with the cookie path setting. I've made a change that seems to fix this issue for me at least by setting the path to / when cookies.path is undefined. I have no idea if this is the best solution but i thought i might try to contribute and not just sit and wait for someone else to fix it.


### References

https://github.com/vercel/next.js/issues/19313
https://github.com/auth0/nextjs-auth0/issues/60

### Testing

All tests are passing. I didn't add any new tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [?] The correct base branch is being used, if not `master`
