### PR TITLE
Allow function in redirectTo in callback handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,6 @@ await auth0.handleCallback(req, res, {
     // "new_user" is a theoretical field here, you should replace it
     // with something else in your implementation
     return session.new_user ? '/onboarding': '/dashboard'
-  },
-  onUserLoaded: async (req, res, session, state) => {
-    throw new Error('You are not allowed to sign in');
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -399,6 +399,21 @@ await auth0.handleCallback(req, res, {
 });
 ```
 
+If you need to choose a redirect path based on certain parameters of the loaded user, you can feed a function to `redirectTo`
+
+```js
+await auth0.handleCallback(req, res, {
+  redirectTo: async (session) => {
+    // "new_user" is a theoretical field here, you should replace it
+    // with something else in your implementation
+    return session.new_user ? '/onboarding': '/dashboard'
+  },
+  onUserLoaded: async (req, res, session, state) => {
+    throw new Error('You are not allowed to sign in');
+  }
+});
+```
+
 ### Requiring Authentication
 
 If you have API routes for which you want to require the user to be authenticated you can use the `requireAuthentication` handler:

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -9,7 +9,7 @@ import { IOidcClientFactory } from '../utils/oidc-client';
 import getSessionFromTokenSet from '../utils/session';
 
 export type CallbackOptions = {
-  redirectTo?: string | (() => string | null | Promise<string | null>);
+  redirectTo?: string | ((session: ISession) => string | null | Promise<string | null>);
   onUserLoaded?: (
     req: NextApiRequest,
     res: NextApiResponse,
@@ -66,7 +66,7 @@ export default function callbackHandler(
       if (typeof options.redirectTo === 'string') {
         redirectTo = options.redirectTo;
       } else if (typeof options.redirectTo === 'function') {
-        redirectTo = await options.redirectTo();
+        redirectTo = await options.redirectTo(session);
       }
     }
     res.writeHead(302, {

--- a/tests/handlers/callback.test.ts
+++ b/tests/handlers/callback.test.ts
@@ -370,7 +370,7 @@ describe('callback handler', () => {
         responseHeaders = headers;
       });
 
-      test('callback should fail', async () => {
+      test('should redirect to custom uri', async () => {
         expect(responseStatus).toBe(302);
         expect(responseHeaders.location).toBe('/custom-redirect-uri');
       });
@@ -402,7 +402,7 @@ describe('callback handler', () => {
         responseHeaders = headers;
       });
 
-      test('callback should fail', async () => {
+      test('should redirect to root', async () => {
         expect(responseStatus).toBe(302);
         expect(responseHeaders.location).toBe('/');
       });


### PR DESCRIPTION
Right now the API accepts a string `redirectTo` in callback. This doesn't work when you want to do conditional callbacks. Current workaround is to add another "hop" url in the mix. That hop url houses the logic for where to send the user based on their session data. Think homepage vs onboarding.

With this PR change applied, we can remove that extra redirect hop and make the redirection decision in the callback API request.
