### PR TITLE
Fix defaultValue fallback in typescript example

### DIFF
--- a/examples/typescript-example/lib/auth0.ts
+++ b/examples/typescript-example/lib/auth0.ts
@@ -2,7 +2,7 @@ import { initAuth0 } from '@auth0/nextjs-auth0';
 
 function getServerSetting(environmentVariable: string, defaultValue?: string) {
   if (typeof window === 'undefined') {
-    return process.env[environmentVariable] ?? defaultValue;
+    return process.env[environmentVariable] ?? defaultValue ?? null;
   }
 
   return defaultValue ?? null;

--- a/examples/typescript-example/lib/auth0.ts
+++ b/examples/typescript-example/lib/auth0.ts
@@ -2,10 +2,10 @@ import { initAuth0 } from '@auth0/nextjs-auth0';
 
 function getServerSetting(environmentVariable: string, defaultValue?: string) {
   if (typeof window === 'undefined') {
-    return process.env[environmentVariable];
+    return process.env[environmentVariable] ?? defaultValue;
   }
 
-  return defaultValue || null;
+  return defaultValue ?? null;
 }
 
 export default initAuth0({


### PR DESCRIPTION
### Description

- Fix fallback on defaultValue

### Testing

Try running the example with a missing `REDIRECT_URI` - will give a weird error from Auth0 that is hard to understand as it didn't fallback on the default.
