### PR TITLE
Prepare application to be deployable with Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint --fix --ext .ts ./src",
     "build": "tsc -p tsconfig.build.json",
     "build:test": "next build tests/fixtures/test-app",
+    "build:kitchen-sync": "npm run build --prefix=examples/kitchen-sync-example",
+    "build:examples": "npm run build:kitchen-sync",
     "test": "jest tests --coverage --maxWorkers=10",
     "test:watch": "jest --coverage --watch",
     "prepublishOnly": "npm test && npm run lint",
@@ -33,7 +35,8 @@
     "test:kitchen-sink:watch": "start-server-and-test start:kitchen-sink 3000 cypress:open",
     "test:integration": "npm run test:kitchen-sink",
     "cypress:run": "cypress run",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "build:vercel": "npm run install:examples && npm run build && npm run build:examples"
   },
   "repository": {
     "type": "git",

--- a/src/config.ts
+++ b/src/config.ts
@@ -398,7 +398,7 @@ export const getParams = (params?: ConfigParameters): ConfigParameters => {
     AUTH0_COOKIE_SAME_SITE
   } = process.env;
 
-  const baseURL = AUTH0_BASE_URL?.indexOf('http') === 0 ? AUTH0_BASE_URL : `https://${AUTH0_BASE_URL}`;
+  const baseURL = AUTH0_BASE_URL && !AUTH0_BASE_URL.startsWith('http') ? `https://${AUTH0_BASE_URL}` : AUTH0_BASE_URL;
 
   return {
     secret: AUTH0_SECRET,

--- a/src/config.ts
+++ b/src/config.ts
@@ -398,10 +398,12 @@ export const getParams = (params?: ConfigParameters): ConfigParameters => {
     AUTH0_COOKIE_SAME_SITE
   } = process.env;
 
+  const baseURL = AUTH0_BASE_URL?.indexOf('http') === 0 ? AUTH0_BASE_URL : `https://${AUTH0_BASE_URL}`;
+
   return {
     secret: AUTH0_SECRET,
     issuerBaseURL: AUTH0_ISSUER_BASE_URL,
-    baseURL: AUTH0_BASE_URL,
+    baseURL: baseURL,
     clientID: AUTH0_CLIENT_ID,
     clientSecret: AUTH0_CLIENT_SECRET,
     clockTolerance: num(AUTH0_CLOCK_TOLERANCE),


### PR DESCRIPTION
As vercel wants a single npm script to build everything, this PR introduces `build:vercel` that builds both the SDK and the example.

This PR also ensures the BASE_URL is prefixed with http(s), if not it defaults to `https`.