### PR TITLE
Disable x-powered-by by header

### DIFF
--- a/examples/basic-example/next.config.js
+++ b/examples/basic-example/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  poweredByHeader: false
+};

--- a/examples/kitchen-sink-example/next.config.js
+++ b/examples/kitchen-sink-example/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  poweredByHeader: false
+};


### PR DESCRIPTION
### Description

This PR disables the [x-powered-by header](https://nextjs.org/docs/api-reference/next.config.js/disabling-x-powered-by) in both example apps.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
