### PR TITLE
Prevent caching the `/me` request

### DIFF
--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -70,6 +70,7 @@ export default function profileHandler(
       return;
     }
 
+    res.setHeader('Cache-Control', 'no-store');
     res.json(session.user);
   };
 }

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -23,6 +23,14 @@ describe('profile handler', () => {
     expect(profile).toStrictEqual({ nickname: '__test_nickname__', sub: '__test_sub__' });
   });
 
+  test('should not allow caching the profile response', async () => {
+    const baseUrl = await setup(withoutApi);
+    const cookieJar = await login(baseUrl);
+
+    const { res } = await get(baseUrl, '/api/auth/me', { cookieJar, fullResponse: true });
+    expect(res.headers['cache-control']).toEqual('no-store');
+  });
+
   test('should throw if re-fetching with no Access Token', async () => {
     const afterCallback: AfterCallback = (_req, _res, session: Session): Session => {
       delete session.accessToken;


### PR DESCRIPTION
Use the `no-store` `Cache-Control` directive to prevent any caching of the `/api/auth/me` url

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_caching