### PR TITLE
Make smoke tests more resilient

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,9 +5,11 @@
   "viewportHeight": 1000,
   "fixturesFolder": false,
   "pluginsFile": false,
-  "supportFile": false,
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "test-results/cypress/junit-[hash].xml"
+  },
+  "retries": {
+    "runMode": 3
   }
 }

--- a/cypress/integration/smoke.test.ts
+++ b/cypress/integration/smoke.test.ts
@@ -9,7 +9,7 @@ describe('smoke tests', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.get('[data-testid=login]').click();
-    cy.get('input[name=username]').focus().clear().type(EMAIL);
+    cy.get('input[name=email], input[name=username]').focus().clear().type(EMAIL);
     cy.get('input[name=password]').focus().clear().type(PASSWORD);
     cy.get('button[name=submit], button[name=action]').click();
   });

--- a/cypress/integration/smoke.test.ts
+++ b/cypress/integration/smoke.test.ts
@@ -14,10 +14,6 @@ describe('smoke tests', () => {
     cy.get('button[name=submit], button[name=action]').click();
   });
 
-  after(() => {
-    cy.get('[data-testid=logout]').click();
-  });
-
   it('should do basic login and show user', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/`);
     cy.get('[data-testid=profile]').contains(EMAIL);
@@ -34,5 +30,10 @@ describe('smoke tests', () => {
     cy.visit('/profile-ssr');
     cy.url().should('eq', `${Cypress.config().baseUrl}/profile-ssr`);
     cy.get('[data-testid=profile]').contains(EMAIL);
+  });
+
+  it('should logout and return to the index page', () => {
+    cy.get('[data-testid=logout]').click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`);
   });
 });

--- a/cypress/integration/smoke.test.ts
+++ b/cypress/integration/smoke.test.ts
@@ -35,5 +35,6 @@ describe('smoke tests', () => {
   it('should logout and return to the index page', () => {
     cy.get('[data-testid=logout]').click();
     cy.url().should('eq', `${Cypress.config().baseUrl}/`);
+    cy.get('[data-testid=login]').should('exist');
   });
 });

--- a/cypress/integration/smoke.test.ts
+++ b/cypress/integration/smoke.test.ts
@@ -5,41 +5,36 @@ if (!EMAIL || !PASSWORD) {
   throw new Error('You must provide CYPRESS_USER_EMAIL and CYPRESS_USER_PASSWORD environment variables');
 }
 
-const loginToAuth0 = (): void => {
-  cy.visit('/');
-  cy.get('#login').click();
-  cy.get('.auth0-lock-input-email input').focus().clear().type(EMAIL);
-  cy.get('.auth0-lock-input-password input').focus().clear().type(PASSWORD);
-  cy.get('.auth0-lock-submit').click();
-};
+describe('smoke tests', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.get('[data-testid=login]').click();
+    cy.get('input[name=username]').focus().clear().type(EMAIL);
+    cy.get('input[name=password]').focus().clear().type(PASSWORD);
+    cy.get('button[name=submit], button[name=action]').click();
+  });
 
-describe('Smoke tests', () => {
+  afterEach(() => {
+    cy.get('[data-testid=logout]').click();
+  });
+
   it('should do basic login and show user', () => {
-    loginToAuth0();
-
     cy.url().should('eq', `${Cypress.config().baseUrl}/`);
-    cy.get('#profile').contains(EMAIL);
-    cy.get('#logout').click();
-    cy.get('#login').should('exist');
+    cy.get('[data-testid=profile]').contains(EMAIL);
+    cy.get('[data-testid=logout]').should('exist');
   });
 
   it('should protect a client-side rendered page', () => {
-    loginToAuth0();
-
     cy.url().should('eq', `${Cypress.config().baseUrl}/`);
     cy.visit('/profile');
     cy.url().should('eq', `${Cypress.config().baseUrl}/profile`);
-    cy.get('#profile').contains(EMAIL);
-    cy.get('#logout').click();
+    cy.get('[data-testid=profile]').contains(EMAIL);
   });
 
   it('should protect a server-side-rendered page', () => {
-    loginToAuth0();
-
     cy.url().should('eq', `${Cypress.config().baseUrl}/`);
     cy.visit('/profile-ssr');
     cy.url().should('eq', `${Cypress.config().baseUrl}/profile-ssr`);
-    cy.get('#profile').contains(EMAIL);
-    cy.get('#logout').click();
+    cy.get('[data-testid=profile]').contains(EMAIL);
   });
 });

--- a/cypress/integration/smoke.test.ts
+++ b/cypress/integration/smoke.test.ts
@@ -6,7 +6,7 @@ if (!EMAIL || !PASSWORD) {
 }
 
 describe('smoke tests', () => {
-  beforeEach(() => {
+  before(() => {
     cy.visit('/');
     cy.get('[data-testid=login]').click();
     cy.get('input[name=email], input[name=username]').focus().clear().type(EMAIL);
@@ -14,7 +14,7 @@ describe('smoke tests', () => {
     cy.get('button[name=submit], button[name=action]').click();
   });
 
-  afterEach(() => {
+  after(() => {
     cy.get('[data-testid=logout]').click();
   });
 
@@ -25,14 +25,12 @@ describe('smoke tests', () => {
   });
 
   it('should protect a client-side rendered page', () => {
-    cy.url().should('eq', `${Cypress.config().baseUrl}/`);
     cy.visit('/profile');
     cy.url().should('eq', `${Cypress.config().baseUrl}/profile`);
     cy.get('[data-testid=profile]').contains(EMAIL);
   });
 
   it('should protect a server-side-rendered page', () => {
-    cy.url().should('eq', `${Cypress.config().baseUrl}/`);
     cy.visit('/profile-ssr');
     cy.url().should('eq', `${Cypress.config().baseUrl}/profile-ssr`);
     cy.get('[data-testid=profile]').contains(EMAIL);

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,3 @@
+Cypress.Cookies.defaults({
+  preserve: () => true
+});

--- a/examples/basic-example/components/header.jsx
+++ b/examples/basic-example/components/header.jsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useUser } from '@auth0/nextjs-auth0';
 
 const Header = () => {
-  const { user, isLoading } = useUser();
+  const { user } = useUser();
 
   return (
     <header>
@@ -19,24 +19,23 @@ const Header = () => {
               <a>Protected Page</a>
             </Link>
           </li>
-          {!isLoading &&
-            (user ? (
-              <>
-                <li>
-                  <a href="/api/auth/logout" id="logout">
-                    Logout
-                  </a>
-                </li>
-              </>
-            ) : (
-              <>
-                <li>
-                  <a href="/api/auth/login" id="login">
-                    Login
-                  </a>
-                </li>
-              </>
-            ))}
+          {user ? (
+            <>
+              <li>
+                <a href="/api/auth/logout" data-testid="logout">
+                  Logout
+                </a>
+              </li>
+            </>
+          ) : (
+            <>
+              <li>
+                <a href="/api/auth/login" data-testid="login">
+                  Login
+                </a>
+              </li>
+            </>
+          )}
         </ul>
       </nav>
 

--- a/examples/basic-example/pages/index.jsx
+++ b/examples/basic-example/pages/index.jsx
@@ -22,7 +22,7 @@ export default function Home() {
       {user && (
         <>
           <h4>Rendered user info on the client</h4>
-          <pre id="profile">{JSON.stringify(user, null, 2)}</pre>
+          <pre data-testid="profile">{JSON.stringify(user, null, 2)}</pre>
         </>
       )}
 

--- a/examples/kitchen-sink-example/components/header.tsx
+++ b/examples/kitchen-sink-example/components/header.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Link from 'next/link';
 import { useUser } from '@auth0/nextjs-auth0';
 
-const Header: React.FunctionComponent = () => {
-  const { user, isLoading } = useUser();
+const Header = (): React.ReactElement => {
+  const { user } = useUser();
 
   return (
     <header>
@@ -24,32 +24,31 @@ const Header: React.FunctionComponent = () => {
               <a>TV Shows</a>
             </Link>
           </li>
-          {!isLoading &&
-            (user ? (
-              <>
-                <li>
-                  <Link href="/profile">
-                    <a>Profile</a>
-                  </Link>
-                </li>{' '}
-                <li>
-                  <a href="/profile-ssr">Profile (SSR)</a>
-                </li>{' '}
-                <li>
-                  <a href="/api/auth/logout" id="logout">
-                    Logout
-                  </a>
-                </li>
-              </>
-            ) : (
-              <>
-                <li>
-                  <a href="/api/auth/login" id="login">
-                    Login
-                  </a>
-                </li>
-              </>
-            ))}
+          {user ? (
+            <>
+              <li>
+                <Link href="/profile">
+                  <a>Profile</a>
+                </Link>
+              </li>{' '}
+              <li>
+                <a href="/profile-ssr">Profile (SSR)</a>
+              </li>{' '}
+              <li>
+                <a href="/api/auth/logout" data-testid="logout">
+                  Logout
+                </a>
+              </li>
+            </>
+          ) : (
+            <>
+              <li>
+                <a href="/api/auth/login" data-testid="login">
+                  Login
+                </a>
+              </li>
+            </>
+          )}
         </ul>
       </nav>
 

--- a/examples/kitchen-sink-example/components/layout.tsx
+++ b/examples/kitchen-sink-example/components/layout.tsx
@@ -3,9 +3,7 @@ import Head from 'next/head';
 
 import Header from './header';
 
-type LayoutProps = React.PropsWithChildren<{}>;
-
-const Layout: React.FunctionComponent<LayoutProps> = ({ children }: LayoutProps) => (
+const Layout = ({ children }: React.PropsWithChildren<unknown>): React.ReactElement => (
   <>
     <Head>
       <title>Next.js with Auth0</title>

--- a/examples/kitchen-sink-example/pages/index.tsx
+++ b/examples/kitchen-sink-example/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home(): React.ReactElement {
       {user && (
         <>
           <h4>Rendered user info on the client</h4>
-          <pre id="profile">{JSON.stringify(user, null, 2)}</pre>
+          <pre data-testid="profile">{JSON.stringify(user, null, 2)}</pre>
         </>
       )}
 

--- a/examples/kitchen-sink-example/pages/profile-ssr.tsx
+++ b/examples/kitchen-sink-example/pages/profile-ssr.tsx
@@ -12,7 +12,7 @@ export default function Profile({ user }: ProfileProps): React.ReactElement {
 
       <div>
         <h3>Profile (server rendered)</h3>
-        <pre id="profile">{JSON.stringify(user, null, 2)}</pre>
+        <pre data-testid="profile">{JSON.stringify(user, null, 2)}</pre>
       </div>
     </Layout>
   );

--- a/examples/kitchen-sink-example/pages/profile.tsx
+++ b/examples/kitchen-sink-example/pages/profile.tsx
@@ -22,7 +22,7 @@ export default withPageAuthRequired(function Profile(): React.ReactElement {
       {user && (
         <>
           <h4>Profile</h4>
-          <pre id="profile">{JSON.stringify(user, null, 2)}</pre>
+          <pre data-testid="profile">{JSON.stringify(user, null, 2)}</pre>
         </>
       )}
     </Layout>

--- a/examples/kitchen-sink-example/pages/shows.tsx
+++ b/examples/kitchen-sink-example/pages/shows.tsx
@@ -4,6 +4,8 @@ import useApi from '../lib/use-api';
 import Layout from '../components/layout';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 
+type TVShow = { show: { name: string } };
+
 export default withPageAuthRequired(function TvShows(): React.ReactElement {
   const { response, error, isLoading } = useApi('/api/shows');
 
@@ -13,12 +15,12 @@ export default withPageAuthRequired(function TvShows(): React.ReactElement {
 
       {isLoading && <p>Loading TV shows...</p>}
 
-      {!isLoading && response && (
+      {response && (
         <>
           <p>My favourite TV shows:</p>
           <pre>
             {JSON.stringify(
-              response.shows.map((s) => s.show.name),
+              response.shows.map((s: TVShow) => s.show.name),
               null,
               2
             )}
@@ -26,7 +28,7 @@ export default withPageAuthRequired(function TvShows(): React.ReactElement {
         </>
       )}
 
-      {!isLoading && error && (
+      {error && (
         <>
           <p>Error loading TV shows</p>
           <pre style={{ color: 'red' }}>{JSON.stringify(error, null, 2)}</pre>


### PR DESCRIPTION
### Description

- The failing smoke tests are now retried 3 times. This helps deal with flaky tests without outright failing the CI job.
- The smoke tests no longer require a login before each test, as Cypress provides a way to [keep the cookies](https://docs.cypress.io/api/cypress-api/cookies.html). So it's now down to one login (at the beginning) plus one logout (at the end) vs 3 pairs. This reduces the chances of flaky tests, and makes the smoke tests run faster.
- The ids were replaced with `data-testid` attributes.

Also:
- Removed usage of `React.FunctionComponent` in the Kitchen Sink example, as [it's now discouraged](https://github.com/facebook/create-react-app/pull/8177) (mainly due to the implicit children).
- Removed unnecessary usage of `isLoading` in the **header** component and **shows** page of the example apps. The **profile** page [was already OK](https://github.com/auth0/nextjs-auth0/blob/beta/examples/kitchen-sink-example/pages/profile.tsx).

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
