### PR TITLE
Added checkSession method to useUser hook [SDK-2256]

### DIFF
--- a/examples/kitchen-sink-example/pages/profile-ssr.tsx
+++ b/examples/kitchen-sink-example/pages/profile-ssr.tsx
@@ -11,7 +11,7 @@ export default function Profile({ user }: ProfileProps): React.ReactElement {
       <h1>Profile</h1>
 
       <div>
-        <h3>Profile (server rendered)</h3>
+        <h4>Profile (server rendered)</h4>
         <pre data-testid="profile">{JSON.stringify(user, null, 2)}</pre>
       </div>
     </Layout>

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -12,33 +12,35 @@ export {
   WithPageAuthRequired
 } from './frontend';
 
+const serverSideOnly = (method: string): string => `The ${method} method can only be used from the server side`;
+
 const instance: SignInWithAuth0 = {
   getSession() {
-    throw new Error('The getSession method can only be used from the server side');
+    throw new Error(serverSideOnly('getSession'));
   },
   getAccessToken() {
-    throw new Error('The getAccessToken method can only be used from the server side');
+    throw new Error(serverSideOnly('getAccessToken'));
   },
   withApiAuthRequired() {
-    throw new Error('The withApiAuthRequired method can only be used from the server side');
+    throw new Error(serverSideOnly('withApiAuthRequired'));
   },
   handleLogin() {
-    throw new Error('The handleLogin method can only be used from the server side');
+    throw new Error(serverSideOnly('handleLogin'));
   },
   handleLogout() {
-    throw new Error('The handleLogout method can only be used from the server side');
+    throw new Error(serverSideOnly('handleLogout'));
   },
   handleCallback() {
-    throw new Error('The handleCallback method can only be used from the server side');
+    throw new Error(serverSideOnly('handleCallback'));
   },
   handleProfile() {
-    throw new Error('The handleProfile method can only be used from the server side');
+    throw new Error(serverSideOnly('handleProfile'));
   },
   handleAuth() {
-    throw new Error('The handleAuth method can only be used from the server side');
+    throw new Error(serverSideOnly('handleAuth'));
   },
   withPageAuthRequired() {
-    throw new Error('The withPageAuthRequired method can only be used from the server side');
+    throw new Error(serverSideOnly('withPageAuthRequired'));
   }
 };
 

--- a/tests/frontend/use-user.test.tsx
+++ b/tests/frontend/use-user.test.tsx
@@ -16,14 +16,14 @@ describe('context wrapper', () => {
     (global as any).fetch = fetchUserMock;
     const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
 
-    expect(result.current.user).toEqual(undefined);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(true);
 
     await waitForValueToChange(() => result.current.isLoading);
 
     expect(result.current.user).toEqual(user);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(false);
   });
 
@@ -31,14 +31,14 @@ describe('context wrapper', () => {
     (global as any).fetch = fetchUserUnsuccessfulMock;
     const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
 
-    expect(result.current.user).toEqual(undefined);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(true);
 
     await waitForValueToChange(() => result.current.isLoading);
 
-    expect(result.current.user).toEqual(undefined);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(false);
   });
 
@@ -46,13 +46,13 @@ describe('context wrapper', () => {
     (global as any).fetch = fetchUserErrorMock;
     const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
 
-    expect(result.current.user).toEqual(undefined);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(true);
 
     await waitForValueToChange(() => result.current.isLoading);
 
-    expect(result.current.user).toEqual(undefined);
+    expect(result.current.user).toBeUndefined();
     expect(result.current.error).toEqual(new Error('The request to /api/auth/me failed'));
     expect(result.current.isLoading).toEqual(false);
   });
@@ -61,12 +61,12 @@ describe('context wrapper', () => {
     const { result } = renderHook(() => useUser(), { wrapper: withUserProvider({ user }) });
 
     expect(result.current.user).toEqual(user);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(false);
   });
 
   test('should use a custom profileUrl', async () => {
-    const fetchSpy = jest.fn().mockReturnValue({ then: () => Promise.resolve() });
+    const fetchSpy = jest.fn().mockReturnValue(Promise.resolve());
     (global as any).fetch = fetchSpy;
     const { result, waitForValueToChange } = renderHook(() => useUser(), {
       wrapper: withUserProvider({ profileUrl: '/api/custom-url' })
@@ -87,7 +87,7 @@ describe('context wrapper', () => {
 
     await act(async () => await result.current.checkSession());
     expect(result.current.user).toEqual(user);
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(false);
   });
 
@@ -102,7 +102,16 @@ describe('context wrapper', () => {
 
     await act(async () => await result.current.checkSession());
     expect(result.current.user).toBeUndefined();
-    expect(result.current.error).toEqual(undefined);
+    expect(result.current.error).toBeUndefined();
     expect(result.current.isLoading).toEqual(false);
+  });
+
+  test('should throw an error when not wrapped in UserProvider', async () => {
+    const { result } = renderHook(() => useUser());
+
+    expect(() => result.current.user).toThrowError('You forgot to wrap your app in <UserProvider>');
+    expect(() => result.current.error).toThrowError('You forgot to wrap your app in <UserProvider>');
+    expect(() => result.current.isLoading).toThrowError('You forgot to wrap your app in <UserProvider>');
+    expect(result.current.checkSession).toThrowError('You forgot to wrap your app in <UserProvider>');
   });
 });

--- a/tests/frontend/use-user.test.tsx
+++ b/tests/frontend/use-user.test.tsx
@@ -107,11 +107,12 @@ describe('context wrapper', () => {
   });
 
   test('should throw an error when not wrapped in UserProvider', async () => {
+    const expectedError = 'You forgot to wrap your app in <UserProvider>';
     const { result } = renderHook(() => useUser());
 
-    expect(() => result.current.user).toThrowError('You forgot to wrap your app in <UserProvider>');
-    expect(() => result.current.error).toThrowError('You forgot to wrap your app in <UserProvider>');
-    expect(() => result.current.isLoading).toThrowError('You forgot to wrap your app in <UserProvider>');
-    expect(result.current.checkSession).toThrowError('You forgot to wrap your app in <UserProvider>');
+    expect(() => result.current.user).toThrowError(expectedError);
+    expect(() => result.current.error).toThrowError(expectedError);
+    expect(() => result.current.isLoading).toThrowError(expectedError);
+    expect(result.current.checkSession).toThrowError(expectedError);
   });
 });

--- a/tests/frontend/use-user.test.tsx
+++ b/tests/frontend/use-user.test.tsx
@@ -1,6 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
-import { useUser } from '../../src';
 import {
   fetchUserMock,
   fetchUserUnsuccessfulMock,
@@ -8,8 +7,11 @@ import {
   withUserProvider,
   user
 } from '../fixtures/frontend';
+import { useUser } from '../../src';
 
 describe('context wrapper', () => {
+  afterEach(() => delete (global as any).fetch);
+
   test('should fetch the user', async () => {
     (global as any).fetch = fetchUserMock;
     const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
@@ -64,7 +66,7 @@ describe('context wrapper', () => {
   });
 
   test('should use a custom profileUrl', async () => {
-    const fetchSpy = jest.fn();
+    const fetchSpy = jest.fn().mockReturnValue({ then: () => Promise.resolve() });
     (global as any).fetch = fetchSpy;
     const { result, waitForValueToChange } = renderHook(() => useUser(), {
       wrapper: withUserProvider({ profileUrl: '/api/custom-url' })
@@ -74,7 +76,33 @@ describe('context wrapper', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/custom-url');
   });
 
-  afterAll(() => {
-    delete (global as any).fetch;
+  test('should check the session when logged in', async () => {
+    (global as any).fetch = fetchUserUnsuccessfulMock;
+    const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
+
+    await waitForValueToChange(() => result.current.isLoading);
+    expect(result.current.user).toBeUndefined;
+
+    (global as any).fetch = fetchUserMock;
+
+    await act(async () => await result.current.checkSession());
+    expect(result.current.user).toEqual(user);
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.isLoading).toEqual(false);
+  });
+
+  test('should check the session when logged out', async () => {
+    (global as any).fetch = fetchUserMock;
+    const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
+
+    await waitForValueToChange(() => result.current.isLoading);
+    expect(result.current.user).toEqual(user);
+
+    (global as any).fetch = fetchUserUnsuccessfulMock;
+
+    await act(async () => await result.current.checkSession());
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.error).toEqual(undefined);
+    expect(result.current.isLoading).toEqual(false);
   });
 });


### PR DESCRIPTION
### Description

This PR adds a method `checkSession` to the `useUser` hook that allows checking the session status from the frontend.

https://user-images.githubusercontent.com/5055789/105118105-8bb98c80-5aac-11eb-8bfd-03341a7b7cab.mov

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
