### PR TITLE
propose change to nextjs ^10.0.5 on peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "openid-client": "^3.15.0"
   },
   "peerDependencies": {
-    "next": "^9.0.0"
+    "next": "^10.0.5"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
Hey all,
I was testing the nextjs-auth0 package on nextjs ^10.0.5 and could verify it's implementation.
I also saw, that somebody is working already in a branch (beta) that has a >=10 range. 

Depending on the release of the beta, this could be moved in already based on the tests I did as there were no breaking changes between nextjs9 and nextjs10.