### PR TITLE
Simplified configuration of custom URLs [SDK-2264]

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -132,7 +132,8 @@ export default async function login(req, res) {
 export default () => <a href="/api/custom-login">Login</a>;
 ```
 
-> Note: you will need to specify this custom login URL when calling `withPageAuthRequired` both the [front end version](https://auth0.github.io/nextjs-auth0/interfaces/frontend_with_page_auth_required.withpageauthrequiredoptions.html#loginurl) and [server side version](https://auth0.github.io/nextjs-auth0/modules/helpers_with_page_auth_required.html#withpageauthrequiredoptions)
+> Note: If you customise the login URL you will need to set the environment variable `NEXT_PUBLIC_AUTH0_LOGIN` to this custom value for `withPageAuthRequired` to work correctly. 
+And if you customize the profile URL, you will need to set the `NEXT_PUBLIC_AUTH0_PROFILE` environment variable to this custom value for the `useUser` hook to work properly.
 
 ## Protecting a Server Side Rendered (SSR) Page
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -132,8 +132,7 @@ export default async function login(req, res) {
 export default () => <a href="/api/custom-login">Login</a>;
 ```
 
-> Note: If you customize the login URL you will need to set the environment variable `NEXT_PUBLIC_AUTH0_LOGIN` to this custom value for `withPageAuthRequired` to work correctly. 
-And if you customize the profile URL, you will need to set the `NEXT_PUBLIC_AUTH0_PROFILE` environment variable to this custom value for the `useUser` hook to work properly.
+> Note: If you customize the login URL you will need to set the environment variable `NEXT_PUBLIC_AUTH0_LOGIN` to this custom value for `withPageAuthRequired` to work correctly. And if you customize the profile URL, you will need to set the `NEXT_PUBLIC_AUTH0_PROFILE` environment variable to this custom value for the `useUser` hook to work properly.
 
 ## Protecting a Server Side Rendered (SSR) Page
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,7 +1,7 @@
 # Examples
 
 - [Basic Setup](#basic-setup)
-- [Customise handlers behaviour](#customise-handlers-behaviour)
+- [Customize handlers behaviour](#customize-handlers-behaviour)
 - [Use custom auth urls](#use-custom-auth-urls)
 - [Protecting a Server Side Rendered (SSR) Page](#protecting-a-server-side-rendered-ssr-page)
 - [Protecting a Client Side Rendered (CSR) Page](#protecting-a-client-side-rendered-csr-page)
@@ -78,7 +78,7 @@ export default () => {
 
 Have a look at the `basic-example` app [./examples/basic-example](./examples/basic-example).
 
-## Customise handlers behaviour
+## Customize handlers behaviour
 
 Pass custom parameters to the auth handlers or add your own logging and error handling.
 
@@ -132,7 +132,7 @@ export default async function login(req, res) {
 export default () => <a href="/api/custom-login">Login</a>;
 ```
 
-> Note: If you customise the login URL you will need to set the environment variable `NEXT_PUBLIC_AUTH0_LOGIN` to this custom value for `withPageAuthRequired` to work correctly. 
+> Note: If you customize the login URL you will need to set the environment variable `NEXT_PUBLIC_AUTH0_LOGIN` to this custom value for `withPageAuthRequired` to work correctly. 
 And if you customize the profile URL, you will need to set the `NEXT_PUBLIC_AUTH0_PROFILE` environment variable to this custom value for the `useUser` hook to work properly.
 
 ## Protecting a Server Side Rendered (SSR) Page

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -164,7 +164,7 @@ export const get = (params: ConfigParameters = {}): Config => {
     ...params
   };
 
-  const { value, error, warning } = paramsSchema.validate(config);
+  const { value, error, warning } = paramsSchema.validate(config, { allowUnknown: true });
   if (error) {
     throw new TypeError(error.details[0].message);
   }

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,2 +1,3 @@
+export { default as ConfigProvider, ConfigProviderProps, useConfig } from './use-config';
 export { default as UserProvider, UserProviderProps, UserProfile, UserContext, useUser } from './use-user';
 export { default as withPageAuthRequired, WithPageAuthRequired } from './with-page-auth-required';

--- a/src/frontend/use-config.tsx
+++ b/src/frontend/use-config.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement, useContext, createContext } from 'react';
+import { useRouter } from 'next/router';
+
+export type ConfigContext = {
+  loginUrl?: string;
+  returnTo?: string;
+};
+
+const Config = createContext<ConfigContext>({});
+
+export type ConfigProviderProps = React.PropsWithChildren<ConfigContext>;
+export type UseConfig = () => ConfigContext;
+export const useConfig: UseConfig = () => useContext<ConfigContext>(Config);
+
+export default ({
+  children,
+  loginUrl = process.env.NEXT_PUBLIC_AUTH0_LOGIN || '/api/auth/login',
+  returnTo = process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT
+}: ConfigProviderProps): ReactElement<ConfigContext> => {
+  const router = useRouter();
+  return <Config.Provider value={{ loginUrl, returnTo: returnTo || router.asPath }}>{children}</Config.Provider>;
+};

--- a/src/frontend/use-user.tsx
+++ b/src/frontend/use-user.tsx
@@ -121,6 +121,15 @@ export const useUser: UseUser = () => useContext<UserContext>(User);
  */
 export type UserProvider = (props: UserProviderProps) => ReactElement<UserContext>;
 
+/**
+ * @ignore
+ */
+type UserProviderState = {
+  user?: UserProfile;
+  error?: Error;
+  isLoading: boolean;
+};
+
 export default ({
   children,
   user: initialUser,
@@ -128,28 +137,28 @@ export default ({
   loginUrl,
   returnTo
 }: UserProviderProps): ReactElement<UserContext> => {
-  const [user, setUser] = useState<UserProfile | undefined>(initialUser);
-  const [error, setError] = useState<Error | undefined>();
-  const [isLoading, setIsLoading] = useState<boolean>(!initialUser);
+  const [state, setState] = useState<UserProviderState>({ user: initialUser, isLoading: !initialUser });
 
   const checkSession = useCallback(async (): Promise<void> => {
     try {
       const response = await fetch(profileUrl);
-      setUser(response.ok ? await response.json() : undefined);
-      setError(undefined);
+      const user = response.ok ? await response.json() : undefined;
+      setState((previous) => ({ ...previous, user, error: undefined }));
     } catch (_e) {
-      setUser(undefined);
-      setError(new Error(`The request to ${profileUrl} failed`));
+      const error = new Error(`The request to ${profileUrl} failed`);
+      setState((previous) => ({ ...previous, user: undefined, error }));
     }
   }, [profileUrl]);
 
   useEffect((): void => {
-    if (user) return;
+    if (state.user) return;
     (async (): Promise<void> => {
       await checkSession();
-      setIsLoading(false);
+      setState((previous) => ({ ...previous, isLoading: false }));
     })();
-  }, [user]);
+  }, [state.user]);
+
+  const { user, error, isLoading } = state;
 
   return (
     <ConfigProvider loginUrl={loginUrl} returnTo={returnTo}>

--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType, useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import { useConfig } from './use-config';
 import { useUser } from './use-user';
 
 /**
@@ -19,25 +20,6 @@ const defaultOnError = (): JSX.Element => <></>;
  * @category Client
  */
 export interface WithPageAuthRequiredOptions {
-  /**
-   * ```js
-   * withPageAuthRequired(Profile, {
-   *   returnTo: '/profile'
-   * });
-   * ```
-   *
-   * Add a path to return the user to after login.
-   */
-  returnTo?: string;
-  /**
-   * ```js
-   * withPageAuthRequired(Profile, {
-   *   loginUrl: '/api/login'
-   * });
-   * ```
-   * The path of your custom login API route.
-   */
-  loginUrl?: string;
   /**
    * ```js
    * withPageAuthRequired(Profile, {
@@ -81,12 +63,8 @@ export type WithPageAuthRequired = <P extends object>(
 const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => {
   return function withPageAuthRequired(props): JSX.Element {
     const router = useRouter();
-    const {
-      returnTo = router.asPath,
-      onRedirecting = defaultOnRedirecting,
-      onError = defaultOnError,
-      loginUrl = '/api/auth/login'
-    } = options;
+    const { onRedirecting = defaultOnRedirecting, onError = defaultOnError } = options;
+    const { loginUrl, returnTo } = useConfig();
     const { user, error, isLoading } = useUser();
 
     useEffect(() => {

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -66,7 +66,7 @@ export type AfterCallback = (
 ) => Promise<Session> | Session;
 
 /**
- * Options to customise the callback handler.
+ * Options to customize the callback handler.
  *
  * @category Server
  */

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -1,5 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next';
-import { ClientFactory, Config, callbackHandler, TransientStore } from '../auth0-session';
+
+import { ClientFactory, callbackHandler, TransientStore } from '../auth0-session';
+import { Config } from '../config';
 import { Session, SessionCache } from '../session';
 import { assertReqRes } from '../utils/assert';
 

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -1,5 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next';
-import { AuthorizationParameters, ClientFactory, Config, loginHandler, TransientStore } from '../auth0-session';
+
+import { AuthorizationParameters, ClientFactory, loginHandler, TransientStore } from '../auth0-session';
+import { Config } from '../config';
 import isSafeRedirect from '../utils/url-helpers';
 import { assertReqRes } from '../utils/assert';
 

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -1,5 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next';
-import { ClientFactory, Config, logoutHandler } from '../auth0-session';
+
+import { ClientFactory, logoutHandler } from '../auth0-session';
+import { Config } from '../config';
 import { SessionCache } from '../session';
 import { assertReqRes } from '../utils/assert';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ function getInstance(): SignInWithAuth0 {
 }
 
 export const initAuth0: InitAuth0 = (params) => {
-  const config = getConfig(getParams(params));
+  const config = getConfig(getParams(params)) as Config;
   const getClient = clientFactory(config, { name: 'nextjs-auth0', version });
   const transientStore = new TransientStore(config);
   const cookieStore = new CookieStore(config);
@@ -61,7 +61,7 @@ export const initAuth0: InitAuth0 = (params) => {
   const getSession = sessionFactory(sessionCache);
   const getAccessToken = accessTokenFactory(getClient, config, sessionCache);
   const withApiAuthRequired = withApiAuthRequiredFactory(sessionCache);
-  const withPageAuthRequired = withPageAuthRequiredFactory(sessionCache);
+  const withPageAuthRequired = withPageAuthRequiredFactory(config, sessionCache);
   const handleLogin = loginHandler(config, getClient, transientStore);
   const handleLogout = logoutHandler(config, getClient, sessionCache);
   const handleCallback = callbackHandler(config, getClient, sessionCache, transientStore);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,7 +1,7 @@
 import { GetSession, GetAccessToken } from './session';
 import { WithApiAuthRequired, WithPageAuthRequired } from './helpers';
 import { HandleAuth, HandleCallback, HandleLogin, HandleLogout, HandleProfile } from './handlers';
-import { ConfigParameters } from './auth0-session';
+import { ConfigParameters } from './config';
 
 /**
  * The SDK server instance.

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -1,5 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import { ClientFactory, Config } from '../auth0-session';
+
+import { ClientFactory } from '../auth0-session';
+import { Config } from '../config';
 import { AccessTokenError } from '../utils/errors';
 import { intersect, match } from '../utils/array';
 import { SessionCache, fromTokenSet } from '../session';

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -43,8 +43,10 @@ describe('config params', () => {
       issuerBaseURL: undefined,
       legacySameSiteCookie: undefined,
       routes: {
-        callback: '/api/auth/callback',
-        postLogoutRedirect: undefined
+        login: '/api/auth/login',
+        postLoginRedirect: undefined,
+        postLogoutRedirect: undefined,
+        callback: '/api/auth/callback'
       },
       secret: undefined,
       session: {

--- a/tests/fixtures/frontend.tsx
+++ b/tests/fixtures/frontend.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { UserProvider, UserProviderProps, UserProfile } from '../../src';
+import { ConfigProvider, ConfigProviderProps } from '../../src/frontend';
 
 type FetchUserMock = {
   ok: boolean;
@@ -16,8 +18,15 @@ export const user: UserProfile = {
   updated_at: null
 };
 
-export const withUserProvider = ({ user, profileUrl }: UserProviderProps = {}): React.ComponentType => {
-  return (props: any): React.ReactElement => <UserProvider {...props} user={user} profileUrl={profileUrl} />;
+export const withUserProvider = ({
+  user,
+  profileUrl,
+  loginUrl,
+  returnTo
+}: UserProviderProps = {}): React.ComponentType => {
+  return (props: any): React.ReactElement => (
+    <UserProvider {...props} user={user} profileUrl={profileUrl} loginUrl={loginUrl} returnTo={returnTo} />
+  );
 };
 
 export const fetchUserMock = (): Promise<FetchUserMock> => {
@@ -34,3 +43,7 @@ export const fetchUserUnsuccessfulMock = (): Promise<FetchUserMock> => {
 };
 
 export const fetchUserErrorMock = (): Promise<FetchUserMock> => Promise.reject(new Error('Error'));
+
+export const withConfigProvider = ({ loginUrl, returnTo }: ConfigProviderProps = {}): React.ComponentType => {
+  return (props: any): React.ReactElement => <ConfigProvider {...props} loginUrl={loginUrl} returnTo={returnTo} />;
+};

--- a/tests/frontend/use-config.test.ts
+++ b/tests/frontend/use-config.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { withConfigProvider } from '../fixtures/frontend';
+import { useConfig } from '../../src/frontend/use-config';
+
+jest.mock('next/router', () => ({
+  useRouter: (): any => ({ asPath: '/' })
+}));
+
+describe('context wrapper', () => {
+  test('should provide the default login url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider({ loginUrl: '/api/auth/login' })
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/auth/login');
+  });
+
+  test('should provide a custom login url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider({ loginUrl: '/api/custom-url' })
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/custom-url');
+  });
+
+  test('should provide a custom returnTo url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider({ returnTo: '/foo' })
+    });
+
+    expect(result.current.returnTo).toEqual('/foo');
+  });
+
+  test('should provide a custom login url from an environment variable', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_LOGIN = '/api/custom-url';
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider()
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/custom-url');
+    delete process.env.NEXT_PUBLIC_AUTH0_LOGIN;
+  });
+
+  test('should provide a custom returnTo url from an environment variable', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT = '/foo';
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider()
+    });
+
+    expect(result.current.returnTo).toEqual('/foo');
+    delete process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT;
+  });
+});

--- a/tests/frontend/use-user.test.ts
+++ b/tests/frontend/use-user.test.ts
@@ -104,6 +104,7 @@ describe('context wrapper', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/custom-url');
     delete process.env.NEXT_PUBLIC_AUTH0_PROFILE;
   });
+
   test('should accept a custom login url', async () => {
     const { result } = renderHook(() => useConfig(), {
       wrapper: withUserProvider({ user, loginUrl: '/api/custom-url' })

--- a/tests/frontend/use-user.test.ts
+++ b/tests/frontend/use-user.test.ts
@@ -7,7 +7,12 @@ import {
   withUserProvider,
   user
 } from '../fixtures/frontend';
+import { useConfig } from '../../src/frontend';
 import { useUser } from '../../src';
+
+jest.mock('next/router', () => ({
+  useRouter: (): any => ({ asPath: '/' })
+}));
 
 describe('context wrapper', () => {
   afterEach(() => delete (global as any).fetch);
@@ -57,7 +62,7 @@ describe('context wrapper', () => {
     expect(result.current.isLoading).toEqual(false);
   });
 
-  test('should use the existing user', async () => {
+  test('should provide the existing user', async () => {
     const { result } = renderHook(() => useUser(), { wrapper: withUserProvider({ user }) });
 
     expect(result.current.user).toEqual(user);
@@ -65,7 +70,18 @@ describe('context wrapper', () => {
     expect(result.current.isLoading).toEqual(false);
   });
 
-  test('should use a custom profileUrl', async () => {
+  test('should use the default profile url', async () => {
+    const fetchSpy = jest.fn().mockReturnValue(Promise.resolve());
+    (global as any).fetch = fetchSpy;
+    const { result, waitForValueToChange } = renderHook(() => useUser(), {
+      wrapper: withUserProvider()
+    });
+
+    await waitForValueToChange(() => result.current.isLoading);
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/me');
+  });
+
+  test('should use a custom profile url', async () => {
     const fetchSpy = jest.fn().mockReturnValue(Promise.resolve());
     (global as any).fetch = fetchSpy;
     const { result, waitForValueToChange } = renderHook(() => useUser(), {
@@ -76,12 +92,40 @@ describe('context wrapper', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/custom-url');
   });
 
+  test('should use a custom profile url from an environment variable', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_PROFILE = '/api/custom-url';
+    const fetchSpy = jest.fn().mockReturnValue(Promise.resolve());
+    (global as any).fetch = fetchSpy;
+    const { result, waitForValueToChange } = renderHook(() => useUser(), {
+      wrapper: withUserProvider()
+    });
+
+    await waitForValueToChange(() => result.current.isLoading);
+    expect(fetchSpy).toHaveBeenCalledWith('/api/custom-url');
+    delete process.env.NEXT_PUBLIC_AUTH0_PROFILE;
+  });
+  test('should accept a custom login url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withUserProvider({ user, loginUrl: '/api/custom-url' })
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/custom-url');
+  });
+
+  test('should accept a custom returnTo url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withUserProvider({ user, returnTo: '/foo' })
+    });
+
+    expect(result.current.returnTo).toEqual('/foo');
+  });
+
   test('should check the session when logged in', async () => {
     (global as any).fetch = fetchUserUnsuccessfulMock;
     const { result, waitForValueToChange } = renderHook(() => useUser(), { wrapper: withUserProvider() });
 
     await waitForValueToChange(() => result.current.isLoading);
-    expect(result.current.user).toBeUndefined;
+    expect(result.current.user).toBeUndefined();
 
     (global as any).fetch = fetchUserMock;
 

--- a/tests/frontend/with-page-auth-required.test.tsx
+++ b/tests/frontend/with-page-auth-required.test.tsx
@@ -75,12 +75,25 @@ describe('with-page-auth-required csr', () => {
     await waitFor(() => expect(screen.getByText('Error')).toBeInTheDocument());
   });
 
-  it('should accept a returnTo url', async () => {
+  it('should use a custom login url', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_LOGIN = '/api/foo';
     (global as any).fetch = fetchUserUnsuccessfulMock;
     const MyPage = (): JSX.Element => <>Private</>;
-    const ProtectedPage = withPageAuthRequired(MyPage, { returnTo: '/foo' });
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withUserProvider() });
+    await waitFor(() => expect(routerMock.push).toHaveBeenCalledWith(expect.stringContaining('/api/foo')));
+    delete process.env.NEXT_PUBLIC_AUTH0_LOGIN;
+  });
+
+  it('should use a custom returnTo url', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT = '/foo';
+    (global as any).fetch = fetchUserUnsuccessfulMock;
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
 
     render(<ProtectedPage />, { wrapper: withUserProvider() });
     await waitFor(() => expect(routerMock.push).toHaveBeenCalledWith(expect.stringContaining('?returnTo=/foo')));
+    delete process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT;
   });
 });

--- a/tests/helpers/with-page-auth-required.test.ts
+++ b/tests/helpers/with-page-auth-required.test.ts
@@ -26,12 +26,25 @@ describe('with-page-auth-required ssr', () => {
   });
 
   test('use a custom login url', async () => {
-    const baseUrl = await setup(withoutApi, { withPageAuthRequiredOptions: { loginUrl: '/api/foo' } });
+    process.env.NEXT_PUBLIC_AUTH0_LOGIN = '/api/foo';
+    const baseUrl = await setup(withoutApi);
     const {
       res: { statusCode, headers }
     } = await get(baseUrl, '/protected', { fullResponse: true });
     expect(statusCode).toBe(307);
     expect(headers.location).toBe('/api/foo?returnTo=/protected');
+    delete process.env.NEXT_PUBLIC_AUTH0_LOGIN;
+  });
+
+  test('use a custom returnTo url', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT = '/foo';
+    const baseUrl = await setup(withoutApi);
+    const {
+      res: { statusCode, headers }
+    } = await get(baseUrl, '/protected', { fullResponse: true });
+    expect(statusCode).toBe(307);
+    expect(headers.location).toBe('/api/auth/login?returnTo=/foo');
+    delete process.env.NEXT_PUBLIC_AUTH0_POST_LOGIN_REDIRECT;
   });
 
   test('use custom server side props', async () => {


### PR DESCRIPTION
### Description

If the developer set up their login handler URL to be something other than the default `/api/auth/login`, then they would have to pass the custom value on every call to `withPageAuthRequired`. Same if they wanted to customize the URL the user would be redirected to after login (the `returnTo` URL).

This PR moves the configuration of custom URLs out of `withPageAuthRequired` to the `UserProvider` on the client-side and the config object on the server-side. Plus it's now also possible to set them via environment variables that are accessible both on the server and the client, enabling the developer to just set them once in a single place. This results in an improved developer experience.

Also, it's possible to customize the profile handler URL via environment variable as well, saving the developer from having to pass it to the `UserProvider`.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
