### PR TITLE
[SDK-2258] Prevent custom session props being removed when refreshing AT

### DIFF
--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { ClientFactory, Config } from '../auth0-session';
 import { AccessTokenError } from '../utils/errors';
 import { intersect, match } from '../utils/array';
-import { SessionCache, fromTokenSet } from '../session';
+import { SessionCache, fromTokenSet, fromJson } from '../session';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -113,8 +113,16 @@ export default function accessTokenFactory(
 
       // Update the session.
       const newSession = fromTokenSet(tokenSet, config);
-      newSession.refreshToken = newSession.refreshToken || session.refreshToken;
-      sessionCache.set(req, res, newSession);
+      sessionCache.set(
+        req,
+        res,
+        fromJson({
+          ...session,
+          ...newSession,
+          refreshToken: newSession.refreshToken || session.refreshToken,
+          user: { ...session.user, ...newSession.user }
+        })
+      );
 
       // Return the new access token.
       return {


### PR DESCRIPTION
### Description

When a new AT is fetched, the session is also updated with a new ID Token and corresponding claims. Custom claims (usually added in the `afterCallback` hook) should not be removed when these new claims are applied.

### References

fix #161 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
