### PR TITLE
Added internal useConfig hook [SDK-2264]

### DIFF
--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,2 +1,3 @@
+export { default as ConfigProvider, ConfigProviderProps, useConfig } from './use-config';
 export { default as UserProvider, UserProviderProps, UserProfile, UserContext, useUser } from './use-user';
 export { default as withPageAuthRequired, WithPageAuthRequired } from './with-page-auth-required';

--- a/src/frontend/use-config.tsx
+++ b/src/frontend/use-config.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement, useContext, createContext } from 'react';
+
+export type ConfigContext = {
+  loginUrl?: string;
+};
+
+const Config = createContext<ConfigContext>({});
+
+export type ConfigProviderProps = React.PropsWithChildren<ConfigContext>;
+export type UseConfig = () => ConfigContext;
+export const useConfig: UseConfig = () => useContext<ConfigContext>(Config);
+
+export default ({
+  children,
+  loginUrl = process.env.NEXT_PUBLIC_AUTH0_LOGIN || '/api/auth/login'
+}: ConfigProviderProps): ReactElement<ConfigContext> => {
+  return <Config.Provider value={{ loginUrl }}>{children}</Config.Provider>;
+};

--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType, useEffect } from 'react';
 import { useRouter } from 'next/router';
 
+import { useConfig } from './use-config';
 import { useUser } from './use-user';
 
 /**
@@ -29,15 +30,6 @@ export interface WithPageAuthRequiredOptions {
    * Add a path to return the user to after login.
    */
   returnTo?: string;
-  /**
-   * ```js
-   * withPageAuthRequired(Profile, {
-   *   loginUrl: '/api/login'
-   * });
-   * ```
-   * The path of your custom login API route.
-   */
-  loginUrl?: string;
   /**
    * ```js
    * withPageAuthRequired(Profile, {
@@ -81,12 +73,8 @@ export type WithPageAuthRequired = <P extends object>(
 const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => {
   return function withPageAuthRequired(props): JSX.Element {
     const router = useRouter();
-    const {
-      returnTo = router.asPath,
-      onRedirecting = defaultOnRedirecting,
-      onError = defaultOnError,
-      loginUrl = '/api/auth/login'
-    } = options;
+    const { returnTo = router.asPath, onRedirecting = defaultOnRedirecting, onError = defaultOnError } = options;
+    const { loginUrl } = useConfig();
     const { user, error, isLoading } = useUser();
 
     useEffect(() => {

--- a/tests/fixtures/frontend.tsx
+++ b/tests/fixtures/frontend.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { UserProvider, UserProviderProps, UserProfile } from '../../src';
+import { ConfigProvider, ConfigProviderProps } from '../../src/frontend';
 
 type FetchUserMock = {
   ok: boolean;
@@ -16,8 +18,10 @@ export const user: UserProfile = {
   updated_at: null
 };
 
-export const withUserProvider = ({ user, profileUrl }: UserProviderProps = {}): React.ComponentType => {
-  return (props: any): React.ReactElement => <UserProvider {...props} user={user} profileUrl={profileUrl} />;
+export const withUserProvider = ({ user, profileUrl, loginUrl }: UserProviderProps = {}): React.ComponentType => {
+  return (props: any): React.ReactElement => (
+    <UserProvider {...props} user={user} profileUrl={profileUrl} loginUrl={loginUrl} />
+  );
 };
 
 export const fetchUserMock = (): Promise<FetchUserMock> => {
@@ -34,3 +38,7 @@ export const fetchUserUnsuccessfulMock = (): Promise<FetchUserMock> => {
 };
 
 export const fetchUserErrorMock = (): Promise<FetchUserMock> => Promise.reject(new Error('Error'));
+
+export const withConfigProvider = ({ loginUrl }: ConfigProviderProps = {}): React.ComponentType => {
+  return (props: any): React.ReactElement => <ConfigProvider {...props} loginUrl={loginUrl} />;
+};

--- a/tests/frontend/use-config.test.ts
+++ b/tests/frontend/use-config.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { withConfigProvider } from '../fixtures/frontend';
+import { useConfig } from '../../src/frontend/use-config';
+
+jest.mock('next/router', () => ({
+  useRouter: (): any => ({ asPath: '/' })
+}));
+
+describe('context wrapper', () => {
+  test('should provide the default login url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider({ loginUrl: '/api/auth/login' })
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/auth/login');
+  });
+
+  test('should provide a custom login url', async () => {
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider({ loginUrl: '/api/custom-url' })
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/custom-url');
+  });
+
+  test('should provide a custom login url from an environment variable', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_LOGIN = '/api/custom-url';
+    const { result } = renderHook(() => useConfig(), {
+      wrapper: withConfigProvider()
+    });
+
+    expect(result.current.loginUrl).toEqual('/api/custom-url');
+    delete process.env.NEXT_PUBLIC_AUTH0_LOGIN;
+  });
+});

--- a/tests/frontend/with-page-auth-required.test.tsx
+++ b/tests/frontend/with-page-auth-required.test.tsx
@@ -18,7 +18,7 @@ jest.mock('next/router', () => ({ useRouter: (): any => routerMock }));
 describe('with-page-auth-required csr', () => {
   afterEach(() => delete (global as any).fetch);
 
-  it('should block access to a CSR page when not authenticated', async () => {
+  it('should deny access to a CSR page when not authenticated', async () => {
     (global as any).fetch = fetchUserUnsuccessfulMock;
     const MyPage = (): JSX.Element => <>Private</>;
     const ProtectedPage = withPageAuthRequired(MyPage);
@@ -82,5 +82,16 @@ describe('with-page-auth-required csr', () => {
 
     render(<ProtectedPage />, { wrapper: withUserProvider() });
     await waitFor(() => expect(routerMock.push).toHaveBeenCalledWith(expect.stringContaining('?returnTo=/foo')));
+  });
+
+  it('should use a custom login url', async () => {
+    process.env.NEXT_PUBLIC_AUTH0_LOGIN = '/api/foo';
+    (global as any).fetch = fetchUserUnsuccessfulMock;
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withUserProvider() });
+    await waitFor(() => expect(routerMock.push).toHaveBeenCalledWith(expect.stringContaining('/api/foo')));
+    delete process.env.NEXT_PUBLIC_AUTH0_LOGIN;
   });
 });

--- a/typedoc.js
+++ b/typedoc.js
@@ -4,6 +4,7 @@ module.exports = {
   exclude: [
     './src/auth0-session/**',
     './src/session/cache.ts',
+    './src/frontend/use-config.tsx',
     './src/utils/!(errors.ts)',
     './src/index.ts',
     './src/index.browser.ts'


### PR DESCRIPTION
### Description

If the developer set up their login handler URL to be something other than the default `/api/auth/login`, then they would have to pass the custom value on every call to `withPageAuthRequired`. 

This PR moves the configuration of custom URLs out of `withPageAuthRequired` to the `UserProvider`. Plus it's now also possible to set it with an environment variable that is accessible from the client-side, enabling the developer to just set it once in a single place. This results in an improved developer experience.

Also, it's possible to customize the profile handler URL via an environment variable as well, saving the developer from having to pass it to the `UserProvider`.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
