### PR TITLE
Get the ID Token before deleting the session

### DIFF
--- a/src/auth0-session/handlers/logout.ts
+++ b/src/auth0-session/handlers/logout.ts
@@ -32,6 +32,7 @@ export default function logoutHandlerFactory(
       return;
     }
 
+    const idToken = sessionCache.getIdToken(req, res);
     sessionCache.delete(req, res);
 
     if (!config.idpLogout) {
@@ -46,7 +47,7 @@ export default function logoutHandlerFactory(
     const client = await getClient();
     returnURL = client.endSessionUrl({
       post_logout_redirect_uri: returnURL,
-      id_token_hint: sessionCache.getIdToken(req, res)
+      id_token_hint: idToken
     });
 
     debug('logging out of identity provider, redirecting to %s', returnURL);

--- a/tests/auth0-session/handlers/logout.test.ts
+++ b/tests/auth0-session/handlers/logout.test.ts
@@ -55,7 +55,7 @@ describe('logout route', () => {
   });
 
   it('should perform a distributed logout', async () => {
-    const baseURL = await setup({ ...defaultConfig, idpLogout: true });
+    const baseURL = await setup({ ...defaultConfig, auth0Logout: false, idpLogout: true });
     const cookieJar = await login(baseURL);
 
     const session: SessionResponse = await get(baseURL, '/session', { cookieJar });
@@ -71,7 +71,10 @@ describe('logout route', () => {
       hostname: 'op.example.com',
       pathname: '/session/end',
       protocol: 'https:',
-      query: expect.objectContaining({ post_logout_redirect_uri: baseURL })
+      query: {
+        post_logout_redirect_uri: baseURL,
+        id_token_hint: session.id_token
+      }
     });
   });
 


### PR DESCRIPTION
### Description

Auth0 logout doesn't use `id_token_hint`, but we should still make sure it's passed to `openid-client#endSessionUrl` as the underlying library is idp agnostic.

### References

fix #265

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
