### PR TITLE
Adding `afterRefetch` hook

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -4,7 +4,7 @@ import { Session } from '../session';
 import { assertReqRes } from '../utils/assert';
 
 /**
- * Use this function for validating additional claims on the user's access token or adding removing items from
+ * Use this function for validating additional claims on the user's ID Token or adding removing items from
  * the session after login, eg
  *
  * ### Validate additional claims

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,5 +1,5 @@
 export { default as callbackHandler, HandleCallback, CallbackOptions, AfterCallback } from './callback';
 export { default as loginHandler, HandleLogin, LoginOptions, GetLoginState } from './login';
 export { default as logoutHandler, HandleLogout, LogoutOptions } from './logout';
-export { default as profileHandler, HandleProfile, ProfileOptions } from './profile';
+export { default as profileHandler, HandleProfile, ProfileOptions, AfterRefetch } from './profile';
 export { default as handlerFactory, Handlers, HandleAuth } from './auth';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ import {
   GetLoginState,
   ProfileOptions,
   CallbackOptions,
-  AfterCallback
+  AfterCallback,
+  AfterRefetch
 } from './handlers';
 import {
   sessionFactory,
@@ -131,6 +132,7 @@ export {
   GetAccessTokenResult,
   CallbackOptions,
   AfterCallback,
+  AfterRefetch,
   LoginOptions,
   LogoutOptions,
   GetLoginState


### PR DESCRIPTION
### Description

Like the `AfterCallback` hook gives you the opportunity to validate/add/remove claims when the session is created, the `AfterRefetch` hook allows you to validate/add/remove claims when the session is updated.

### References

fixes #273 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
