### PR TITLE
Update external API example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -217,9 +217,11 @@ export default handleAuth({
   async login(req, res) {
     try {
       await handleLogin(req, res, {
-        audience: 'https://api.example.com/products', // or AUTH0_AUDIENCE
-        // Add the `offline_access` scope to also get a Refresh Token
-        scope: 'openid profile email read:products' // or AUTH0_SCOPE
+        authorizationParams: {
+          audience: 'https://api.example.com/products', // or AUTH0_AUDIENCE
+          // Add the `offline_access` scope to also get a Refresh Token
+          scope: 'openid profile email read:products' // or AUTH0_SCOPE
+        }
       });
     } catch (error) {
       res.status(error.status || 400).end(error.message);


### PR DESCRIPTION
### Description

The **Access an External API from an API Route** [example](https://github.com/auth0/nextjs-auth0/blob/beta/EXAMPLES.md#access-an-external-api-from-an-api-route) features a snippet that is outdated. It instructs to pass the audience and scope like:

```js
await handleLogin(req, res, {
  audience: 'https://api.example.com/products', // or AUTH0_AUDIENCE
  // Add the `offline_access` scope to also get a Refresh Token
  scope: 'openid profile email read:products' // or AUTH0_SCOPE
});
```

But they should go inside the `authorizationParams` object, like so:

```js
await handleLogin(req, res, {
  authorizationParams: {
    audience: 'https://api.example.com/products', // or AUTH0_AUDIENCE
    // Add the `offline_access` scope to also get a Refresh Token
    scope: 'openid profile email read:products' // or AUTH0_SCOPE
  }
});
```

<img width="681" alt="Screen Shot 2021-02-13 at 15 28 54" src="https://user-images.githubusercontent.com/5055789/107858182-a4019a80-6e11-11eb-8f8d-715817212a16.png">
<img width="640" alt="Screen Shot 2021-02-13 at 15 29 55" src="https://user-images.githubusercontent.com/5055789/107858185-a8c64e80-6e11-11eb-99c9-2425d85c6bba.png">
<img width="384" alt="Screen Shot 2021-02-13 at 15 30 23" src="https://user-images.githubusercontent.com/5055789/107858188-ac59d580-6e11-11eb-8f12-fb4dc8d36776.png">

### References

Fixes #291

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
