### PR TITLE
Added clarifying help to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ npm install @auth0/nextjs-auth0
 
 ### Auth0 Configuration
 
-Create a **Regular Web Application** in the [Auth0 Dashboard](https://manage.auth0.com/). If you're using an existing application you'll want to verify that the following settings are configured as follows:
+Create a **Regular Web Application** in the [Auth0 Dashboard](https://manage.auth0.com/). If you're using an existing application you'll want to verify that the following settings are configured as follows.
 
+_In your application's Advanced Settings (click "Show Advanced Settings"):_
 - **Json Web Token Signature Algorithm**: `RS256`
 - **OIDC Conformant**: `True`
 
-Go ahead and configure the URLs for your application:
+_Go ahead and configure the following URLs for your application under Application URIs:_
 
 - **Allowed Callback URLs**: http://localhost:3000/api/auth/callback
 - **Allowed Logout URLs**: http://localhost:3000/


### PR DESCRIPTION
### Description

This is a simple change, but it wasn't obvious that the JSON Token Signing settings were under a tab, in a hidden section of the settings - I had to search the Auth0 docs just to track this down.


### References

[https://auth0.com/docs/applications/change-application-signing-algorithms](https://auth0.com/docs/applications/change-application-signing-algorithms)

### Testing

Review the README

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
