### PR TITLE
Allow setting redirect_uri at runtime on the callback handler just like it's allowed on the login handler

### DIFF
--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -15,6 +15,8 @@ export type AfterCallback = (req: any, res: any, session: any, state: Record<str
 
 export type CallbackOptions = {
   afterCallback?: AfterCallback;
+
+  redirectUri?: string;
 };
 
 export type HandleCallback = (req: IncomingMessage, res: ServerResponse, options?: CallbackOptions) => Promise<void>;
@@ -27,8 +29,7 @@ export default function callbackHandlerFactory(
 ): HandleCallback {
   return async (req, res, options) => {
     const client = await getClient();
-
-    const redirectUri = getRedirectUri(config);
+    const redirectUri = options?.redirectUri || getRedirectUri(config);
 
     let expectedState;
     let tokenSet;

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -70,6 +70,8 @@ export type AfterCallback = (
  */
 export type CallbackOptions = {
   afterCallback?: AfterCallback;
+
+  redirectUri?: string;
 };
 
 /**

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -372,4 +372,22 @@ describe('callback', () => {
     expect(res.statusCode).toEqual(302);
     expect(res.headers.location).toEqual(baseURL);
   });
+
+  it('should accept custom runtime redirect over base url', async () => {
+    const redirectUri = 'http://messi:3000/api/auth/callback/runtime';
+    const baseURL = await setup(defaultConfig, { callbackOptions: { redirectUri } });
+    const state = encodeState({ foo: 'bar' });
+    const cookieJar = toSignedCookieJar( { state, nonce: '__test_nonce__' }, baseURL);
+    const { res } = await post(baseURL, '/callback', {
+      body: {
+        state: state,
+        id_token: makeIdToken()
+      },
+      cookieJar,
+      fullResponse: true
+    });
+
+    expect(res.statusCode).toEqual(302);
+    expect(res.headers.location).toEqual(baseURL);
+  });
 });


### PR DESCRIPTION
### Description

While there is currently a way to specify at runtime the `redirect_uri` used within the login handler (thus overriding  `process.env.AUTH0_BASE_URL`), the same cannot be done from within the callback handler, resulting in an `unauthorized_client` bad request error indicating the mismatch between both URLs.

This lack of consistency is evident in [login.ts](https://github.com/auth0/nextjs-auth0/blob/beta/src/auth0-session/handlers/login.ts#L26) where `LoginOptions.authorizationParams.redirect_uri` takes precedence over building the redirect URL with `urlJoin(config.baseURL, config.routes.callback)`, while on [callback.ts](https://github.com/auth0/nextjs-auth0/blob/beta/src/auth0-session/handlers/callback.ts#L31) there is no possibility of modification: the redirect url will always be `urlJoin(config.baseURL, config.routes.callback)`.

This PR introduces a new option on `CallbackOptions`: the optional `redirectUri`. With it, one can specify a different URL at runtime in `[...auth0].tsx` by overriding the `login` and `callback` handlers. In the following example, assume that the redirect URI is different from `AUTH0_BASE_URL`, and that its definition might depend on custom headers or other data coming from `NextApiRequest`, thus rendering the alternative of customizing `initAuth0` not viable.

```typescript
import { handleAuth, handleCallback, handleLogin } from '@auth0/nextjs-auth0';
import { NextApiRequest } from 'next';

export default handleAuth({
  async login(req, res) {
    const baseUrl = "http://messi:3000";
    const options = {
      authorizationParams: {
        redirect_uri: `${baseUrl}/api/auth/callback`
      }
    };

    try {
      await handleLogin(req, res, options);
    } catch (error) {
      res.status(error.status || 400).end(error.message);
    }
  },

  async callback(req, res) {
    const baseUrl = "http://messi:3000";
    const options = {
      redirectUri: `${baseUrl}/api/auth/callback`
    };

    try {
      await handleCallback(req, res, options);
    } catch (error) {
      res.status(error.status || 400).end(error.message);
    }
  }
});
```

### References

Other issues (#108, #154, #295) either directly or indirectly reference this limitation, mostly within the context of a Vercel deployment. We have experienced this ourselves while developing a multi-tenant nextjs auth0 app.

### Testing

I've introduced a test case to ensure `CallbackOptions.redirect_uri` can be specified at runtime.

To replicate this in a real application just set your `AUTH0_BASE_URL` environment variable to a specific host (for example `http://localhost:3000`), and then define a different URL in `authorizationParams.redirect_uri` on the login handler (such as `http://messi:3000`), which should resolve to the same nextjs app. After logging in on auth0 and being sent back to the nextjs app to handle the oauth callback, it'll consistently fail with a bad request `unauthorized_client (The redirect URI is wrong. You sent http://localhost:3000, and we expected http://messi:3000)`. Applying this PR and utilizing `CallbackOptions.redirectUri` as shown before solves the problem.