### PR TITLE
[SDK-2330] New tokens should be applied to existing session

### DIFF
--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { ClientFactory } from '../auth0-session';
 import { AccessTokenError } from '../utils/errors';
 import { intersect, match } from '../utils/array';
-import { SessionCache, fromTokenSet, fromJson } from '../session';
+import { SessionCache, fromTokenSet } from '../session';
 import { NextConfig } from '../config';
 
 /**
@@ -114,16 +114,11 @@ export default function accessTokenFactory(
 
       // Update the session.
       const newSession = fromTokenSet(tokenSet, config);
-      sessionCache.set(
-        req,
-        res,
-        fromJson({
-          ...session,
-          ...newSession,
-          refreshToken: newSession.refreshToken || session.refreshToken,
-          user: { ...session.user, ...newSession.user }
-        })
-      );
+      Object.assign(session, {
+        ...newSession,
+        refreshToken: newSession.refreshToken || session.refreshToken,
+        user: { ...session.user, ...newSession.user }
+      });
 
       // Return the new access token.
       return {

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -29,6 +29,7 @@ export type SetupOptions = {
   getAccessTokenOptions?: AccessTokenRequest;
   discoveryOptions?: object;
   userInfoPayload?: object;
+  userInfoToken?: string;
 };
 
 export const setup = async (
@@ -42,13 +43,14 @@ export const setup = async (
     withPageAuthRequiredOptions,
     getAccessTokenOptions,
     discoveryOptions,
-    userInfoPayload = {}
+    userInfoPayload = {},
+    userInfoToken = 'eyJz93a...k4laUWw'
   }: SetupOptions = {}
 ): Promise<string> => {
   discovery(config, discoveryOptions);
   jwksEndpoint(config, jwks);
   codeExchange(config, makeIdToken({ iss: 'https://acme.auth0.local/', ...idTokenClaims }));
-  userInfo(config, 'eyJz93a...k4laUWw', userInfoPayload);
+  userInfo(config, userInfoToken, userInfoPayload);
   const {
     handleAuth,
     handleCallback,

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
-import { withoutApi } from '../fixtures/default-settings';
-import { userInfo } from '../fixtures/oidc-nocks';
+import { withApi, withoutApi } from '../fixtures/default-settings';
+import { refreshTokenRotationExchange, userInfo } from '../fixtures/oidc-nocks';
 import { get } from '../auth0-session/fixtures/helpers';
 import { setup, teardown, login } from '../fixtures/setup';
 import { Session, AfterCallback } from '../../src';
@@ -89,6 +89,28 @@ describe('profile handler', () => {
     await expect(get(baseUrl, '/api/auth/me', { cookieJar })).rejects.toThrow(
       'No access token available to refetch the profile'
     );
+  });
+
+  test('should refetch the user and preserve new tokens', async () => {
+    const afterCallback: AfterCallback = (_req, _res, session: Session): Session => {
+      session.accessTokenExpiresAt = -60;
+      return session;
+    };
+    const baseUrl = await setup(withApi, {
+      profileOptions: { refetch: true },
+      userInfoPayload: { foo: 'bar' },
+      callbackOptions: {
+        afterCallback
+      },
+      userInfoToken: 'new-access-token'
+    });
+    refreshTokenRotationExchange(withApi, 'GEbRxBN...edjnXbL', {}, 'new-access-token', 'new-refresh-token');
+    const cookieJar = await login(baseUrl);
+    const profile = await get(baseUrl, '/api/auth/me', { cookieJar });
+    expect(profile).toMatchObject({ foo: 'bar' });
+    const session = await get(baseUrl, `/api/session`, { cookieJar });
+    expect(session.accessToken).toEqual('new-access-token');
+    expect(session.refreshToken).toEqual('new-refresh-token');
   });
 
   test('should update the session in the afterRefetch hook', async () => {

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -108,7 +108,7 @@ describe('profile handler', () => {
     const cookieJar = await login(baseUrl);
     const profile = await get(baseUrl, '/api/auth/me', { cookieJar });
     expect(profile).toMatchObject({ foo: 'bar' });
-    const session = await get(baseUrl, `/api/session`, { cookieJar });
+    const session = await get(baseUrl, '/api/session', { cookieJar });
     expect(session.accessToken).toEqual('new-access-token');
     expect(session.refreshToken).toEqual('new-refresh-token');
   });


### PR DESCRIPTION
### Description

`handleProfile` will use the a stale session if `getAccessToken` updates the session.

On the whole a user should be able to continue to use a refrence to the session after `getAccessToken` is called, without having to call `getSession` again.

```js
const session = getSession(req, res);
const { accessToken } = await getAccessToken(req, res);

// If AT was updated, session.accessToken should be updated too
session.accessToken === accessToken;
```

### References

See https://github.com/auth0/nextjs-auth0/issues/294#issuecomment-781376276

### Testing

Given I have Refresh Token Rotation enabled
And I have an expired Access Token
When I visit `handleProfile` with refetch `true`
Then I should get an updated profile
And I should get an updated Access Token and Refresh Token

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
