### PR TITLE
Missing 'getSession' in 'Protect an API Route'

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -174,7 +174,7 @@ Requests to `/pages/api/protected` without a valid session cookie will fail with
 
 ```js
 // pages/api/protected.js
-import { withApiAuthRequired } from '@auth0/nextjs-auth0';
+import { withApiAuthRequired, getSession } from '@auth0/nextjs-auth0';
 
 export default withApiAuthRequired(async function myApiRoute(req, res) {
   const { user } = getSession(req, res);


### PR DESCRIPTION

### Description

Missing method declaration in [https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#protect-an-api-route](docs).

PR adds the missing method declaration.

On Line 177, I added 'getSession' to the destructured import of the auth0 library.  Otherwise 'getSession()' being called on Line 180 results in an "Internal Service Error".

### References

The page in question being edited is https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#protect-an-api-route 

### Testing

Docs change.

- [no] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
