### PR TITLE
Fix missing basePath [SDK-2373]

### DIFF
--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -62,6 +62,7 @@ export interface WithPageAuthRequiredOptions {
  *
  * @category Client
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type WithPageAuthRequired = <P extends object>(
   Component: ComponentType<P>,
   options?: WithPageAuthRequiredOptions
@@ -73,16 +74,17 @@ export type WithPageAuthRequired = <P extends object>(
 const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => {
   return function withPageAuthRequired(props): JSX.Element {
     const router = useRouter();
-    const { returnTo = router.asPath, onRedirecting = defaultOnRedirecting, onError = defaultOnError } = options;
+    const {
+      returnTo = `${router.basePath ?? ''}${router.asPath}`,
+      onRedirecting = defaultOnRedirecting,
+      onError = defaultOnError
+    } = options;
     const { loginUrl } = useConfig();
     const { user, error, isLoading } = useUser();
 
     useEffect(() => {
       if ((user && !error) || isLoading) return;
-
-      (async (): Promise<void> => {
-        await router.push(`${loginUrl}?returnTo=${returnTo}`);
-      })();
+      window.location.assign(`${loginUrl}?returnTo=${returnTo}`);
     }, [user, error, isLoading]);
 
     if (error) return onError(error);

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -84,7 +84,7 @@ export type HandleCallback = (req: NextApiRequest, res: NextApiResponse, options
 /**
  * @ignore
  */
-export default function handleLoginFactory(handler: BaseHandleCallback): HandleCallback {
+export default function handleCallbackFactory(handler: BaseHandleCallback): HandleCallback {
   return async (req, res, options): Promise<void> => {
     assertReqRes(req, res);
     return handler(req, res, options);


### PR DESCRIPTION
### Description

This PR prepends the `returnTo` URL in the client-side `withPageAuthRequired` with the `basePath`, if there's one configured. Also the `router.push` call was replaced with `window.location.assign`.

### References

Fixes #312

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
