### PR TITLE
Export context for stubbing default Provider behaviour

### DIFF
--- a/src/frontend/use-user.tsx
+++ b/src/frontend/use-user.tsx
@@ -71,7 +71,7 @@ const missingUserProvider = 'You forgot to wrap your app in <UserProvider>';
 /**
  * @ignore
  */
-const User = createContext<UserContext>({
+export const UserContext = createContext<UserContext>({
   get user(): never {
     throw new Error(missingUserProvider);
   },
@@ -112,7 +112,7 @@ export type UseUser = () => UserContext;
 /**
  * @ignore
  */
-export const useUser: UseUser = () => useContext<UserContext>(User);
+export const useUser: UseUser = () => useContext<UserContext>(UserContext);
 
 /**
  * To use the {@link useUser} hook. You must wrap your application in a `<UserProvider>` component.
@@ -161,7 +161,7 @@ export default ({
 
   return (
     <ConfigProvider loginUrl={loginUrl}>
-      <User.Provider value={{ user, error, isLoading, checkSession }}>{children}</User.Provider>
+      <UserContext.Provider value={{ user, error, isLoading, checkSession }}>{children}</UserContext.Provider>
     </ConfigProvider>
   );
 };

--- a/tests/frontend/use-user.test.tsx
+++ b/tests/frontend/use-user.test.tsx
@@ -8,7 +8,8 @@ import {
   user
 } from '../fixtures/frontend';
 import { useConfig } from '../../src/frontend';
-import { useUser } from '../../src';
+import { useUser, UserContext } from '../../src';
+import React from 'react';
 
 jest.mock('next/router', () => ({
   useRouter: (): any => ({ asPath: '/' })
@@ -151,5 +152,13 @@ describe('context wrapper', () => {
     expect(() => result.current.error).toThrowError(expectedError);
     expect(() => result.current.isLoading).toThrowError(expectedError);
     expect(result.current.checkSession).toThrowError(expectedError);
+  });
+
+  test('should be able to stub UserProvider with UserContext.Provider', async () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper: (props: any): React.ReactElement => <UserContext.Provider {...props} value={{ user: { foo: 'bar' } }} />
+    });
+
+    expect(result.current.user).toEqual({ foo: 'bar' });
   });
 });


### PR DESCRIPTION
### Description

Export `UserContext` so that you can create your own `UserContext.Provider` - this is useful if you want to override the default `Auth0Provider` behaviour, in testing particularly.

Eg to disable the profile request on page load and only derive the user from any server side code, you can do:

```tsx
import React from 'react';
import type { AppProps } from 'next/app';
import { UserProvider } from '@auth0/nextjs-auth0';
import { UserContext } from '@auth0/nextjs-auth0';

export default function App({ Component, pageProps }: AppProps): React.ReactElement<AppProps> {
  const { user } = pageProps;

  return (
    <UserContext.Provider value={{ user, isLoading: false, checkSession: () => Promise.resolve() }}>
      <Component {...pageProps} />
    </UserContext.Provider>
  );
}
```

(you'd only need to stub `checkSession` to keep TS happy)

### References

fixes #313 
