### PR TITLE
chore(deps): move from @hapi/joi to joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,15 +6,15 @@
   "packages": {
     "": {
       "name": "@auth0/nextjs-auth0",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@hapi/joi": "^17.1.1",
         "base64url": "^3.0.1",
         "cookie": "^0.4.1",
         "debug": "^4.3.1",
         "futoin-hkdf": "^1.3.2",
         "http-errors": "^1.8.0",
+        "joi": "^17.4.0",
         "jose": "^2.0.4",
         "on-headers": "^1.0.2",
         "openid-client": "^4.2.3",
@@ -29,7 +29,6 @@
         "@types/clone": "^2.1.0",
         "@types/cookie": "^0.4.0",
         "@types/debug": "^4.1.5",
-        "@types/hapi__joi": "^17.1.6",
         "@types/http-errors": "^1.8.0",
         "@types/jest": "^26.0.20",
         "@types/jsonwebtoken": "^8.5.0",
@@ -753,19 +752,6 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@hapi/address/node_modules/@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
-    },
     "node_modules/@hapi/boom": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
@@ -775,38 +761,10 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-      "dev": true
-    },
-    "node_modules/@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "dependencies": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
-      }
-    },
-    "node_modules/@hapi/joi/node_modules/@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
       "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
-    },
-    "node_modules/@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
     },
     "node_modules/@hapi/topo": {
       "version": "5.0.0",
@@ -1384,7 +1342,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
       "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
-      "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1392,14 +1349,12 @@
     "node_modules/@sideway/formula": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
-      "dev": true
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.0.0",
@@ -1667,12 +1622,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/hapi__joi": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.6.tgz",
-      "integrity": "sha512-y3A1MzNC0FmzD5+ys59RziE1WqKrL13nxtJgrSzjoO7boue5B7zZD2nZLPwrSuUviFjpKFQtgHYSvhDGfIE4jA==",
-      "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.0",
@@ -8017,10 +7966,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
-      "dev": true,
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -14320,21 +14268,6 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
-        }
-      }
-    },
     "@hapi/boom": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
@@ -14344,40 +14277,10 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-    },
     "@hapi/hoek": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-      "dev": true
-    },
-    "@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "requires": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
-        }
-      }
-    },
-    "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
     },
     "@hapi/topo": {
       "version": "5.0.0",
@@ -14849,7 +14752,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
       "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
-      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -14857,14 +14759,12 @@
     "@sideway/formula": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
-      "dev": true
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sindresorhus/is": {
       "version": "4.0.0",
@@ -15103,12 +15003,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/hapi__joi": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.6.tgz",
-      "integrity": "sha512-y3A1MzNC0FmzD5+ys59RziE1WqKrL13nxtJgrSzjoO7boue5B7zZD2nZLPwrSuUviFjpKFQtgHYSvhDGfIE4jA==",
-      "dev": true
     },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
@@ -20303,10 +20197,9 @@
       }
     },
     "joi": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
-      "dev": true,
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/clone": "^2.1.0",
     "@types/cookie": "^0.4.0",
     "@types/debug": "^4.1.5",
-    "@types/hapi__joi": "^17.1.6",
     "@types/http-errors": "^1.8.0",
     "@types/jest": "^26.0.20",
     "@types/jsonwebtoken": "^8.5.0",
@@ -105,12 +104,12 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
     "base64url": "^3.0.1",
     "cookie": "^0.4.1",
     "debug": "^4.3.1",
     "futoin-hkdf": "^1.3.2",
     "http-errors": "^1.8.0",
+    "joi": "^17.4.0",
     "jose": "^2.0.4",
     "on-headers": "^1.0.2",
     "openid-client": "^4.2.3",

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { getLoginState } from './hooks/get-login-state';
 import { Config } from './config';
 


### PR DESCRIPTION
### Description

The `@hapi/joi` package has moved to `joi`, and the TS definitions are now included with the package.

### Testing

N/A, but I ran the test suite locally.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

Note: I got a warning from using package-lock v1, while the project uses v2. This would explain the huge change of `package-lock.json`. Not sure how to change that, I'm using Node 14 locally.

(by the way, the https://github.com/auth0/open-source-template/blob/main/CONTRIBUTING.md link is a 404)
