### PR TITLE
docs: fix contribution links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.Md
+++ b/.github/PULL_REQUEST_TEMPLATE.Md
@@ -1,4 +1,4 @@
-By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/main/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/main/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.
+By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.
 
 ### Description
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribution
+
+Please read [Auth0's contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
+
+## Environment setup
+
+- Make sure you have node and npm installed
+- Run `npm install` to install dependencies
+- Follow the local development steps below to get started
+
+## Local development
+
+- `npm install`: install dependencies
+- `npm run build`: Build the binary
+- `npm run build:test`: Do this once to build the test harness for the tests
+- `npm test`: Run the unit tests
+- `npm run test:watch`: Run the unit tests and watch for changes
+- `npm run install:examples`: Install the examples
+- Setup the examples https://github.com/auth0/nextjs-auth0/tree/main/examples
+- `npm run start:basic`: Run the basic example
+- `npm run start:kitchen-sink`: Run the kitchen sink example
+- `npm run test:kitchen-sink`: Run the E2E tests (you will need to populate the `CYPRESS_USER_EMAIL` and `CYPRESS_USER_PASSWORD` env vars)
+- `npm run test:kitchen-sink:watch`: Run the E2E tests and watch for changes


### PR DESCRIPTION
### Description

This fixes the 404 on the code of conduct and contribution to Auth0's OSS template, and adds a copy of the `CONTRIBUTION.md` to the project, which was a 404 from the project's `README.md`.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
