### PR TITLE
Only run integration tests if not on a forked PR [SDK-2406]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,12 @@ jobs:
       - restore_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/kitchen-sink-example/package.json" }}
       - run: npm ci
-      - run: |
-          if [ -z "$CIRCLE_PR_NUMBER" ]; then
-            npm run install:kitchen-sink
-          fi
+      - run:
+          name: npm run install:kitchen-sink
+          command: |
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              npm run install:kitchen-sink
+            fi
       - save_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/kitchen-sink-example/package.json" }}
           paths:
@@ -20,10 +22,12 @@ jobs:
             - ~/.cache
       - run: npm run build
       - run: npm test
-      - run:  |
-          if [ -z "$CIRCLE_PR_NUMBER" ]; then
-            npm run test:kitchen-sink
-          fi
+      - run:
+          name: npm run test:kitchen-sink
+          command: |
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              npm run test:kitchen-sink
+            fi
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,10 @@ jobs:
       - restore_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/kitchen-sink-example/package.json" }}
       - run: npm ci
-      - run: npm run install:kitchen-sink
+      - run: |
+          if [ -z "$CIRCLE_PR_NUMBER" ]; then
+            npm run install:kitchen-sink
+          fi
       - save_cache:
           key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "examples/kitchen-sink-example/package.json" }}
           paths:
@@ -17,7 +20,10 @@ jobs:
             - ~/.cache
       - run: npm run build
       - run: npm test
-      - run: npm run test:kitchen-sink
+      - run:  |
+          if [ -z "$CIRCLE_PR_NUMBER" ]; then
+            npm run test:kitchen-sink
+          fi
       - store_test_results:
           path: test-results
       - store_artifacts:


### PR DESCRIPTION
### Description

This PR updates the CI config to only run integration tests when not building a forked PR.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
