### PR TITLE
[SDK-2405] Organisations support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -280,7 +280,12 @@ export interface AuthorizationParameters extends OidcAuthorizationParameters {
  */
 export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
   /**
-   * Log users in to a specific organization.
+   * Log users in to a specific organization (Organizations is currently a Closed Beta).
+   *
+   * This will specify an `organization` parameter in your user's login request and will add a step to validate
+   * the `org_id` claim in your user's ID Token.
+   *
+   * If your app supports multiple organizations, you should take a look at {@Link AuthorizationParams.organization}
    */
   organization?: string;
   routes: {

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -2,6 +2,7 @@ import { NextApiResponse, NextApiRequest } from 'next';
 import { AuthorizationParameters, HandleLogin as BaseHandleLogin } from '../auth0-session';
 import isSafeRedirect from '../utils/url-helpers';
 import { assertReqRes } from '../utils/assert';
+import { NextConfig } from '../config';
 
 /**
  * Use this to store additional state for the user before they visit the Identity Provider to login.
@@ -30,6 +31,23 @@ import { assertReqRes } from '../utils/assert';
 export type GetLoginState = (req: NextApiRequest, options: LoginOptions) => { [key: string]: any };
 
 /**
+ * Authorization params to pass to the login handler.
+ *
+ * @category Server
+ */
+export interface AuthorizationParams extends Partial<AuthorizationParameters> {
+  /**
+   * The invitation id to join an organization.
+   */
+  invitation?: string;
+  /**
+   * This is useful to specify instead of {@Link NextConfig.organization} when your app has multiple
+   * organizations, it should match {@Link CallbackOptions.organization}.
+   */
+  organization?: string;
+}
+
+/**
  * Custom options to pass to login.
  *
  * @category Server
@@ -38,7 +56,7 @@ export interface LoginOptions {
   /**
    * Override the default {@link BaseConfig.authorizationParams authorizationParams}
    */
-  authorizationParams?: Partial<AuthorizationParameters>;
+  authorizationParams?: AuthorizationParams;
 
   /**
    *  URL to return to after login, overrides the Default is {@link BaseConfig.baseURL}
@@ -61,8 +79,8 @@ export type HandleLogin = (req: NextApiRequest, res: NextApiResponse, options?: 
 /**
  * @ignore
  */
-export default function handleLoginFactory(handler: BaseHandleLogin): HandleLogin {
-  return async (req, res, options): Promise<void> => {
+export default function handleLoginFactory(handler: BaseHandleLogin, nextConfig: NextConfig): HandleLogin {
+  return async (req, res, options = {}): Promise<void> => {
     assertReqRes(req, res);
     if (req.query.returnTo) {
       const returnTo = Array.isArray(req.query.returnTo) ? req.query.returnTo[0] : req.query.returnTo;
@@ -72,6 +90,12 @@ export default function handleLoginFactory(handler: BaseHandleLogin): HandleLogi
       }
 
       options = { ...options, returnTo };
+    }
+    if (nextConfig.organization) {
+      options = {
+        ...options,
+        authorizationParams: { organization: nextConfig.organization, ...options.authorizationParams }
+      };
     }
 
     return handler(req, res, options);

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -50,7 +50,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    *   try {
    *     const { invitation, organization } = req.query;
    *     if (!invitation) {
-   *       res.status(400).end('Missing 'invitation' parameter');
+   *       res.status(400).end('Missing "invitation" parameter');
    *     }
    *     await handleLogin(req, res, {
    *       authorizationParams: {
@@ -65,7 +65,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    * ```
    *
    * Your invite url can then take the format:
-   * `https://example.com/api/invite?invitation=invitation_id&prganization=org_id`
+   * `https://example.com/api/invite?invitation=invitation_id&organization=org_id`
    */
   invitation?: string;
   /**

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -15,7 +15,7 @@ import { NextConfig } from '../config';
  *   return { basket_id: getBasketId(req) };
  * };
  *
- * export handleAuth({
+ * export default handleAuth({
  *   async login(req, res) {
  *     try {
  *       await handleLogin(req, res, { getLoginState });
@@ -37,7 +37,35 @@ export type GetLoginState = (req: NextApiRequest, options: LoginOptions) => { [k
  */
 export interface AuthorizationParams extends Partial<AuthorizationParameters> {
   /**
-   * The invitation id to join an organization.
+   * The invitation id to join an organization (Organizations is currently a Closed Beta).
+   *
+   * To create a link for your user's to accept an organization invite, accept invitation and organization
+   * query params and pass them to the authorization server to log the user in:
+   *
+   * ```js
+   * // pages/api/invite.js
+   * import { handleLogin } from '@auth0/nextjs-auth0';
+   *
+   * export default async function invite(req, res) {
+   *   try {
+   *     const { invitation, organization } = req.query;
+   *     if (!invitation) {
+   *       res.status(400).end('Missing 'invitation' parameter');
+   *     }
+   *     await handleLogin(req, res, {
+   *       authorizationParams: {
+   *         invitation,
+   *         organization
+   *       }
+   *     });
+   *   } catch (error) {
+   *     res.status(error.status || 500).end(error.message);
+   *   }
+   * } ;
+   * ```
+   *
+   * Your invite url can then take the format:
+   * `https://example.com/api/invite?invitation=invitation_id&prganization=org_id`
    */
   invitation?: string;
   /**

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -39,7 +39,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
   /**
    * The invitation id to join an organization (Organizations is currently a Closed Beta).
    *
-   * To create a link for your user's to accept an organization invite, accept invitation and organization
+   * To create a link for your user's to accept an organization invite, read the `invitation` and `organization`
    * query params and pass them to the authorization server to log the user in:
    *
    * ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,9 @@ export const initAuth0: InitAuth0 = (params) => {
   const getAccessToken = accessTokenFactory(nextConfig, getClient, sessionCache);
   const withApiAuthRequired = withApiAuthRequiredFactory(sessionCache);
   const withPageAuthRequired = withPageAuthRequiredFactory(nextConfig.routes.login, getSession);
-  const handleLogin = loginHandler(baseHandleLogin);
+  const handleLogin = loginHandler(baseHandleLogin, nextConfig);
   const handleLogout = logoutHandler(baseHandleLogout);
-  const handleCallback = callbackHandler(baseHandleCallback);
+  const handleCallback = callbackHandler(baseHandleCallback, nextConfig);
   const handleProfile = profileHandler(getClient, getAccessToken, sessionCache);
   const handleAuth = handlerFactory({ handleLogin, handleLogout, handleCallback, handleProfile });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -92,7 +92,8 @@ describe('config params', () => {
         login: '/api/auth/login',
         callback: '/api/auth/callback',
         postLogoutRedirect: ''
-      }
+      },
+      organization: undefined
     });
   });
 
@@ -145,28 +146,30 @@ describe('config params', () => {
   });
 
   test('passed in arguments should take precedence', () => {
-    expect(
-      getConfigWithEnv(
-        {},
-        {
-          authorizationParams: {
-            audience: 'foo',
-            scope: 'openid bar'
+    const { baseConfig, nextConfig } = getConfigWithEnv(
+      {
+        AUTH0_ORGANIZATION: 'foo'
+      },
+      {
+        authorizationParams: {
+          audience: 'foo',
+          scope: 'openid bar'
+        },
+        baseURL: 'https://baz.com',
+        routes: {
+          callback: 'qux'
+        },
+        session: {
+          absoluteDuration: 100,
+          cookie: {
+            transient: false
           },
-          baseURL: 'https://baz.com',
-          routes: {
-            callback: 'qux'
-          },
-          session: {
-            absoluteDuration: 100,
-            cookie: {
-              transient: false
-            },
-            name: 'quuuux'
-          }
-        }
-      ).baseConfig
-    ).toMatchObject({
+          name: 'quuuux'
+        },
+        organization: 'bar'
+      }
+    );
+    expect(baseConfig).toMatchObject({
       authorizationParams: {
         audience: 'foo',
         scope: 'openid bar'
@@ -182,6 +185,9 @@ describe('config params', () => {
         },
         name: 'quuuux'
       }
+    });
+    expect(nextConfig).toMatchObject({
+      organization: 'bar'
     });
   });
 

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -38,7 +38,7 @@ export const setup = async (
     idTokenClaims,
     callbackOptions,
     logoutOptions,
-    loginOptions = { returnTo: '/custom-url' },
+    loginOptions,
     profileOptions,
     withPageAuthRequiredOptions,
     getAccessTokenOptions,


### PR DESCRIPTION
### Description

Add support for Organisations (currently a Closed Beta)

- supports an `organization` config or `AUTH0_ORGANIZATION` environment variable which, when specified, passes the `organization` query param to the `/authorize` endpoint and validates it against the user's `org_id` ID Token claim.
- Allows the `organization` query param to be specified in the `loginHandler` and `callbackHandler` so that app's can support multiple Organzations.
- Document the `invitation` query parameter for the `/authorize` endpoint and add an example of creating a route that accepts Organization invites.