### PR TITLE
Use `window.location.toString()` as the default `returnTo` value [SDK-2453]

### DIFF
--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -1,5 +1,4 @@
 import React, { ComponentType, useEffect } from 'react';
-import { useRouter } from 'next/router';
 
 import { useConfig } from './use-config';
 import { useUser } from './use-user';
@@ -73,18 +72,22 @@ export type WithPageAuthRequired = <P extends object>(
  */
 const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => {
   return function withPageAuthRequired(props): JSX.Element {
-    const router = useRouter();
-    const {
-      returnTo = `${router.basePath ?? ''}${router.asPath}`,
-      onRedirecting = defaultOnRedirecting,
-      onError = defaultOnError
-    } = options;
+    const { returnTo, onRedirecting = defaultOnRedirecting, onError = defaultOnError } = options;
     const { loginUrl } = useConfig();
     const { user, error, isLoading } = useUser();
 
     useEffect(() => {
       if ((user && !error) || isLoading) return;
-      window.location.assign(`${loginUrl}?returnTo=${encodeURIComponent(returnTo)}`);
+      let returnToPath: string;
+
+      if (!returnTo) {
+        const currentLocation = window.location.toString();
+        returnToPath = currentLocation.replace(new URL(currentLocation).origin, '') || '/';
+      } else {
+        returnToPath = returnTo;
+      }
+
+      window.location.assign(`${loginUrl}?returnTo=${encodeURIComponent(returnToPath)}`);
     }, [user, error, isLoading]);
 
     if (error) return onError(error);

--- a/tests/frontend/use-config.test.ts
+++ b/tests/frontend/use-config.test.ts
@@ -3,10 +3,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { withConfigProvider } from '../fixtures/frontend';
 import { useConfig } from '../../src/frontend/use-config';
 
-jest.mock('next/router', () => ({
-  useRouter: (): any => ({ asPath: '/' })
-}));
-
 describe('context wrapper', () => {
   test('should provide the default login url', async () => {
     const { result } = renderHook(() => useConfig(), {

--- a/tests/frontend/use-user.test.tsx
+++ b/tests/frontend/use-user.test.tsx
@@ -11,10 +11,6 @@ import { useConfig } from '../../src/frontend';
 import { useUser, UserContext } from '../../src';
 import React from 'react';
 
-jest.mock('next/router', () => ({
-  useRouter: (): any => ({ asPath: '/' })
-}));
-
 describe('context wrapper', () => {
   afterEach(() => delete (global as any).fetch);
 


### PR DESCRIPTION
### Description

This PR uses `window.location.toString()` as the default `returnTo` value, removing all remaining usages of the Next.js router.

### References

Fixes the client-side part of https://github.com/auth0/nextjs-auth0/issues/353.

### Testing

Unit tests have been added and also the change has been tested manually using a `basePath` value.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
