### PR TITLE
withPageAuthRequired adds user to ctx

### DIFF
--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -115,7 +115,7 @@ export default function withPageAuthRequiredFactory(loginUrl: string, getSession
       }
       let ret: any = { props: {} };
       if (getServerSideProps) {
-        ret = await getServerSideProps(ctx);
+        ret = await getServerSideProps({ ...ctx, user: session.user });
       }
       return { ...ret, props: { ...ret.props, user: session.user } };
     };


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

I think it would be very convenient to make the user available to the getServerSideProps wrapped on withPageAuthRequired.

In terms of verbosity it's not a big deal, though it helps, but it's not just about typing less, it's about making sense: withPageAuthRequires adds user to the page props, and thus it makes a los of sense to add user to ctx too.


### Testing

I would be very happy to add tests for this, if the maintainers agrees on the proposed change.

I did it not yet, just to save the effort if the change is not welcome.
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

Same here. I'll be glad to add the documentation if this goes forward.

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
