### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.1](https://github.com/auth0/nextjs-auth0/tree/v1.3.1) (2021-05-05)
+
+**Fixed**
+
+- Use `window.location.toString()` as the default `returnTo` value [#370](https://github.com/auth0/nextjs-auth0/pull/370) ([Widcket](https://github.com/Widcket))
+- `returnTo` should be encoded as it contains url unsafe chars [#365](https://github.com/auth0/nextjs-auth0/pull/365) ([adamjmcgrath](https://github.com/adamjmcgrath))
+
 ## [1.3.0](https://github.com/auth0/nextjs-auth0/tree/v1.3.0) (2021-03-26)
 
 **Added**

--- a/docs/classes/session.sessioncache.html
+++ b/docs/classes/session.sessioncache.html
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L12">src/session/cache.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L12">src/session/cache.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L26">src/session/cache.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L26">src/session/cache.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L31">src/session/cache.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L31">src/session/cache.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L58">src/session/cache.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L58">src/session/cache.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L53">src/session/cache.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L53">src/session/cache.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L42">src/session/cache.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L42">src/session/cache.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L18">src/session/cache.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L18">src/session/cache.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -303,7 +303,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L36">src/session/cache.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L36">src/session/cache.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/cache.ts#L48">src/session/cache.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/cache.ts#L48">src/session/cache.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/session_session.default.html
+++ b/docs/classes/session_session.default.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L50">src/session/session.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L50">src/session/session.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">access<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L33">src/session/session.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L33">src/session/session.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">access<wbr>Token<wbr>Expires<wbr>At<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L43">src/session/session.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L43">src/session/session.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">access<wbr>Token<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L38">src/session/session.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L38">src/session/session.ts:38</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L28">src/session/session.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L28">src/session/session.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">refresh<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L48">src/session/session.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L48">src/session/session.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <a href="../interfaces/session_session.claims.html" class="tsd-signature-type" data-tsd-kind="Interface">Claims</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/session.ts#L23">src/session/session.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/session.ts#L23">src/session/session.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/utils_errors.accesstokenerror.html
+++ b/docs/classes/utils_errors.accesstokenerror.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/utils/errors.ts#L7">src/utils/errors.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/utils/errors.ts#L7">src/utils/errors.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/utils/errors.ts#L7">src/utils/errors.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/utils/errors.ts#L7">src/utils/errors.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/config.authorizationparameters.html
+++ b/docs/interfaces/config.authorizationparameters.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">response_<wbr>mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;query&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;form_post&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L274">src/config.ts:274</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L274">src/config.ts:274</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">response_<wbr>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;id_token&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;code id_token&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;code&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L275">src/config.ts:275</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L275">src/config.ts:275</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L273">src/config.ts:273</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L273">src/config.ts:273</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/config.baseconfig.html
+++ b/docs/interfaces/config.baseconfig.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">auth0<wbr>Logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L26">src/config.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L26">src/config.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">authorization<wbr>Params<span class="tsd-signature-symbol">:</span> <a href="config.authorizationparameters.html" class="tsd-signature-type" data-tsd-kind="Interface">AuthorizationParameters</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L56">src/config.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L56">src/config.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">baseURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L64">src/config.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L64">src/config.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">clientID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L70">src/config.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L70">src/config.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<wbr>Secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L77">src/config.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L77">src/config.ts:77</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">clock<wbr>Tolerance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L84">src/config.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L84">src/config.ts:84</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Telemetry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L98">src/config.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L98">src/config.ts:98</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Login<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">IncomingMessage</span>, options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">LoginOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L117">src/config.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L117">src/config.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">http<wbr>Timeout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L91">src/config.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L91">src/config.ts:91</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -314,7 +314,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<wbr>Token<wbr>Signing<wbr>Alg<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L135">src/config.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L135">src/config.ts:135</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -330,7 +330,7 @@
 					<div class="tsd-signature tsd-kind-icon">identity<wbr>Claim<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L123">src/config.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L123">src/config.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">idp<wbr>Logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L129">src/config.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L129">src/config.ts:129</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -362,7 +362,7 @@
 					<div class="tsd-signature tsd-kind-icon">issuer<wbr>BaseURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L142">src/config.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L142">src/config.ts:142</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -379,7 +379,7 @@
 					<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L149">src/config.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L149">src/config.ts:149</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -396,7 +396,7 @@
 					<div class="tsd-signature tsd-kind-icon">routes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>postLogoutRedirect<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L154">src/config.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L154">src/config.ts:154</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 					<div class="tsd-signature tsd-kind-icon">secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L15">src/config.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L15">src/config.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -455,7 +455,7 @@
 					<div class="tsd-signature tsd-kind-icon">session<span class="tsd-signature-symbol">:</span> <a href="config.sessionconfig.html" class="tsd-signature-type" data-tsd-kind="Interface">SessionConfig</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L20">src/config.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L20">src/config.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/config.cookieconfig.html
+++ b/docs/interfaces/config.cookieconfig.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L226">src/config.ts:226</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L226">src/config.ts:226</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">http<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L248">src/config.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L248">src/config.ts:248</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L234">src/config.ts:234</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L234">src/config.ts:234</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">same<wbr>Site<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;lax&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;strict&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;none&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L262">src/config.ts:262</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L262">src/config.ts:262</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L255">src/config.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L255">src/config.ts:255</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">transient<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L241">src/config.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L241">src/config.ts:241</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/config.nextconfig.html
+++ b/docs/interfaces/config.nextconfig.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">identity<wbr>Claim<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L123">src/config.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L123">src/config.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">organization<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L290">src/config.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L290">src/config.ts:290</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">routes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>login<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L291">src/config.ts:291</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L291">src/config.ts:291</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/config.sessionconfig.html
+++ b/docs/interfaces/config.sessionconfig.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">absolute<wbr>Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L211">src/config.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L211">src/config.ts:211</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">cookie<span class="tsd-signature-symbol">:</span> <a href="config.cookieconfig.html" class="tsd-signature-type" data-tsd-kind="Interface">CookieConfig</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L213">src/config.ts:213</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L213">src/config.ts:213</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L184">src/config.ts:184</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L184">src/config.ts:184</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">rolling<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L194">src/config.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L194">src/config.ts:194</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">rolling<wbr>Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L202">src/config.ts:202</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L202">src/config.ts:202</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/frontend_use_user.userprofile.html
+++ b/docs/interfaces/frontend_use_user.userprofile.html
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L11">src/frontend/use-user.tsx:11</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L11">src/frontend/use-user.tsx:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">email_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L12">src/frontend/use-user.tsx:12</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L12">src/frontend/use-user.tsx:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L13">src/frontend/use-user.tsx:13</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L13">src/frontend/use-user.tsx:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">nickname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L14">src/frontend/use-user.tsx:14</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L14">src/frontend/use-user.tsx:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L15">src/frontend/use-user.tsx:15</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L15">src/frontend/use-user.tsx:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">sub<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L16">src/frontend/use-user.tsx:16</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L16">src/frontend/use-user.tsx:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">updated_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L17">src/frontend/use-user.tsx:17</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L17">src/frontend/use-user.tsx:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/frontend_with_page_auth_required.withpageauthrequiredoptions.html
+++ b/docs/interfaces/frontend_with_page_auth_required.withpageauthrequiredoptions.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol">)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/with-page-auth-required.tsx#L52">src/frontend/with-page-auth-required.tsx:52</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/with-page-auth-required.tsx#L51">src/frontend/with-page-auth-required.tsx:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">on<wbr>Redirecting<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol">)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/with-page-auth-required.tsx#L42">src/frontend/with-page-auth-required.tsx:42</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/with-page-auth-required.tsx#L41">src/frontend/with-page-auth-required.tsx:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/with-page-auth-required.tsx#L32">src/frontend/with-page-auth-required.tsx:32</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/with-page-auth-required.tsx#L31">src/frontend/with-page-auth-required.tsx:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/handlers_auth.handlers.html
+++ b/docs/interfaces/handlers_auth.handlers.html
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">callback<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_callback.html#handlecallback" class="tsd-signature-type" data-tsd-kind="Type alias">HandleCallback</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/auth.ts#L37">src/handlers/auth.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/auth.ts#L37">src/handlers/auth.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">login<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_login.html#handlelogin" class="tsd-signature-type" data-tsd-kind="Type alias">HandleLogin</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/auth.ts#L35">src/handlers/auth.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/auth.ts#L35">src/handlers/auth.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">logout<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_logout.html#handlelogout" class="tsd-signature-type" data-tsd-kind="Type alias">HandleLogout</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/auth.ts#L36">src/handlers/auth.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/auth.ts#L36">src/handlers/auth.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">profile<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_profile.html#handleprofile" class="tsd-signature-type" data-tsd-kind="Type alias">HandleProfile</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/auth.ts#L38">src/handlers/auth.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/auth.ts#L38">src/handlers/auth.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/handlers_callback.callbackoptions.html
+++ b/docs/interfaces/handlers_callback.callbackoptions.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">after<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../modules/handlers_callback.html#aftercallback" class="tsd-signature-type" data-tsd-kind="Type alias">AfterCallback</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/callback.ts#L74">src/handlers/callback.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/callback.ts#L74">src/handlers/callback.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">organization<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/callback.ts#L86">src/handlers/callback.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/callback.ts#L86">src/handlers/callback.ts:86</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">redirect<wbr>Uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/callback.ts#L80">src/handlers/callback.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/callback.ts#L80">src/handlers/callback.ts:80</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/handlers_login.authorizationparams.html
+++ b/docs/interfaces/handlers_login.authorizationparams.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">invitation<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L70">src/handlers/login.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L70">src/handlers/login.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">organization<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L75">src/handlers/login.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L75">src/handlers/login.ts:75</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">response_<wbr>mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;query&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;form_post&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/auth0-session/config.ts#L247">src/auth0-session/config.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/auth0-session/config.ts#L247">src/auth0-session/config.ts:247</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">response_<wbr>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;id_token&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;code id_token&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;code&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/auth0-session/config.ts#L248">src/auth0-session/config.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/auth0-session/config.ts#L248">src/auth0-session/config.ts:248</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/auth0-session/config.ts#L246">src/auth0-session/config.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/auth0-session/config.ts#L246">src/auth0-session/config.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/handlers_login.loginoptions.html
+++ b/docs/interfaces/handlers_login.loginoptions.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">authorization<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="handlers_login.authorizationparams.html" class="tsd-signature-type" data-tsd-kind="Interface">AuthorizationParams</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L87">src/handlers/login.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L87">src/handlers/login.ts:87</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Login<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../modules/handlers_login.html#getloginstate" class="tsd-signature-type" data-tsd-kind="Type alias">GetLoginState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L97">src/handlers/login.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L97">src/handlers/login.ts:97</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L92">src/handlers/login.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L92">src/handlers/login.ts:92</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/handlers_logout.logoutoptions.html
+++ b/docs/interfaces/handlers_logout.logoutoptions.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/logout.ts#L15">src/handlers/logout.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/logout.ts#L15">src/handlers/logout.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/instance.signinwithauth0.html
+++ b/docs/interfaces/instance.signinwithauth0.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Access<wbr>Token<span class="tsd-signature-symbol">:</span> <a href="../modules/session_get_access_token.html#getaccesstoken" class="tsd-signature-type" data-tsd-kind="Type alias">GetAccessToken</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L24">src/instance.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L24">src/instance.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="../modules/session_get_session.html#getsession" class="tsd-signature-type" data-tsd-kind="Type alias">GetSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L19">src/instance.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L19">src/instance.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>Auth<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_auth.html#handleauth" class="tsd-signature-type" data-tsd-kind="Type alias">HandleAuth</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L59">src/instance.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L59">src/instance.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>Callback<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_callback.html#handlecallback" class="tsd-signature-type" data-tsd-kind="Type alias">HandleCallback</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L34">src/instance.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L34">src/instance.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>Login<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_login.html#handlelogin" class="tsd-signature-type" data-tsd-kind="Type alias">HandleLogin</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L29">src/instance.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L29">src/instance.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>Logout<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_logout.html#handlelogout" class="tsd-signature-type" data-tsd-kind="Type alias">HandleLogout</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L39">src/instance.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L39">src/instance.ts:39</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>Profile<span class="tsd-signature-symbol">:</span> <a href="../modules/handlers_profile.html#handleprofile" class="tsd-signature-type" data-tsd-kind="Type alias">HandleProfile</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L44">src/instance.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L44">src/instance.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">with<wbr>Api<wbr>Auth<wbr>Required<span class="tsd-signature-symbol">:</span> <a href="../modules/helpers_with_api_auth_required.html#withapiauthrequired" class="tsd-signature-type" data-tsd-kind="Type alias">WithApiAuthRequired</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L49">src/instance.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L49">src/instance.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">with<wbr>Page<wbr>Auth<wbr>Required<span class="tsd-signature-symbol">:</span> <a href="../modules/helpers_with_page_auth_required.html#withpageauthrequired" class="tsd-signature-type" data-tsd-kind="Type alias">WithPageAuthRequired</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L54">src/instance.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L54">src/instance.ts:54</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/session_get_access_token.accesstokenrequest.html
+++ b/docs/interfaces/session_get_access_token.accesstokenrequest.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">refresh<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/get-access-token.ts#L24">src/session/get-access-token.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/get-access-token.ts#L24">src/session/get-access-token.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">scopes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/get-access-token.ts#L18">src/session/get-access-token.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/get-access-token.ts#L18">src/session/get-access-token.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/session_get_access_token.getaccesstokenresult.html
+++ b/docs/interfaces/session_get_access_token.getaccesstokenresult.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">access<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/get-access-token.ts#L36">src/session/get-access-token.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/get-access-token.ts#L36">src/session/get-access-token.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/config.html
+++ b/docs/modules/config.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Config<wbr>Parameters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">DeepPartial</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/config.baseconfig.html" class="tsd-signature-type" data-tsd-kind="Interface">BaseConfig</a><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/config.nextconfig.html" class="tsd-signature-type" data-tsd-kind="Interface">NextConfig</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/config.ts#L378">src/config.ts:378</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/config.ts#L378">src/config.ts:378</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/frontend.html
+++ b/docs/modules/frontend.html
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">Config<wbr>Provider<wbr>Props<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">React.PropsWithChildren</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ConfigContext</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-config.tsx#L9">src/frontend/use-config.tsx:9</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-config.tsx#L9">src/frontend/use-config.tsx:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-config.tsx#L11">src/frontend/use-config.tsx:11</a></li>
+									<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-config.tsx#L11">src/frontend/use-config.tsx:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ConfigContext</span></h4>

--- a/docs/modules/frontend_use_user.html
+++ b/docs/modules/frontend_use_user.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Use<wbr>User<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">UserContext</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L110">src/frontend/use-user.tsx:110</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L110">src/frontend/use-user.tsx:110</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">User<wbr>Context<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>checkSession<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>error<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">; </span>isLoading<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>user<span class="tsd-signature-symbol">?: </span><a href="../interfaces/frontend_use_user.userprofile.html" class="tsd-signature-type" data-tsd-kind="Interface">UserProfile</a><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L26">src/frontend/use-user.tsx:26</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L26">src/frontend/use-user.tsx:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">User<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>props<span class="tsd-signature-symbol">: </span><a href="frontend_use_user.html#userproviderprops" class="tsd-signature-type" data-tsd-kind="Type alias">UserProviderProps</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">ReactElement</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserContext</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L122">src/frontend/use-user.tsx:122</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L122">src/frontend/use-user.tsx:122</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">User<wbr>Provider<wbr>Props<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">React.PropsWithChildren</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>profileUrl<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>user<span class="tsd-signature-symbol">?: </span><a href="../interfaces/frontend_use_user.userprofile.html" class="tsd-signature-type" data-tsd-kind="Interface">UserProfile</a><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">ConfigContext</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/use-user.tsx#L64">src/frontend/use-user.tsx:64</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/use-user.tsx#L64">src/frontend/use-user.tsx:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/frontend_with_page_auth_required.html
+++ b/docs/modules/frontend_with_page_auth_required.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">With<wbr>Page<wbr>Auth<wbr>Required<span class="tsd-signature-symbol">:</span> &lt;P&gt;<span class="tsd-signature-symbol">(</span>Component<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ComponentType</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span>, options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/frontend_with_page_auth_required.withpageauthrequiredoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">WithPageAuthRequiredOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">React.FC</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/frontend/with-page-auth-required.tsx#L66">src/frontend/with-page-auth-required.tsx:66</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/frontend/with-page-auth-required.tsx#L65">src/frontend/with-page-auth-required.tsx:65</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/handlers_auth.html
+++ b/docs/modules/handlers_auth.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Handle<wbr>Auth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>userHandlers<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/handlers_auth.handlers.html" class="tsd-signature-type" data-tsd-kind="Interface">Handlers</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">NextApiHandler</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/auth.ts#L62">src/handlers/auth.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/auth.ts#L62">src/handlers/auth.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/handlers_callback.html
+++ b/docs/modules/handlers_callback.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">After<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, session<span class="tsd-signature-symbol">: </span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a>, state<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/callback.ts#L61">src/handlers/callback.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/callback.ts#L61">src/handlers/callback.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">Handle<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/handlers_callback.callbackoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">CallbackOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/callback.ts#L94">src/handlers/callback.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/callback.ts#L94">src/handlers/callback.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/handlers_login.html
+++ b/docs/modules/handlers_login.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">Get<wbr>Login<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, options<span class="tsd-signature-symbol">: </span><a href="../interfaces/handlers_login.loginoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LoginOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L31">src/handlers/login.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L31">src/handlers/login.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">Handle<wbr>Login<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/handlers_login.loginoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LoginOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/login.ts#L105">src/handlers/login.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/login.ts#L105">src/handlers/login.ts:105</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/handlers_logout.html
+++ b/docs/modules/handlers_logout.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Handle<wbr>Logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/handlers_logout.logoutoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LogoutOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/logout.ts#L23">src/handlers/logout.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/logout.ts#L23">src/handlers/logout.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/handlers_profile.html
+++ b/docs/modules/handlers_profile.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">After<wbr>Refetch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, session<span class="tsd-signature-symbol">: </span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/profile.ts#L6">src/handlers/profile.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/profile.ts#L6">src/handlers/profile.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Handle<wbr>Profile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiResponse</span>, options<span class="tsd-signature-symbol">?: </span><a href="handlers_profile.html#profileoptions" class="tsd-signature-type" data-tsd-kind="Type alias">ProfileOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/profile.ts#L31">src/handlers/profile.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/profile.ts#L31">src/handlers/profile.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">Profile<wbr>Options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>afterRefetch<span class="tsd-signature-symbol">?: </span><a href="handlers_profile.html#afterrefetch" class="tsd-signature-type" data-tsd-kind="Type alias">AfterRefetch</a><span class="tsd-signature-symbol">; </span>refetch<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/handlers/profile.ts#L13">src/handlers/profile.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/handlers/profile.ts#L13">src/handlers/profile.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/helpers_with_api_auth_required.html
+++ b/docs/modules/helpers_with_api_auth_required.html
@@ -84,7 +84,7 @@
 					<div class="tsd-signature tsd-kind-icon">With<wbr>Api<wbr>Auth<wbr>Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>apiRoute<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">NextApiHandler</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">NextApiHandler</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/helpers/with-api-auth-required.ts#L23">src/helpers/with-api-auth-required.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/helpers/with-api-auth-required.ts#L23">src/helpers/with-api-auth-required.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/helpers_with_page_auth_required.html
+++ b/docs/modules/helpers_with_page_auth_required.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Get<wbr>Server<wbr>Side<wbr>Props<wbr>Result<wbr>With<wbr>Session<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">GetServerSidePropsResult</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>user<span class="tsd-signature-symbol">?: </span><a href="../interfaces/session_session.claims.html" class="tsd-signature-type" data-tsd-kind="Interface">Claims</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/helpers/with-page-auth-required.ts#L25">src/helpers/with-page-auth-required.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/helpers/with-page-auth-required.ts#L25">src/helpers/with-page-auth-required.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">Page<wbr>Route<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>cts<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">GetServerSidePropsContext</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="helpers_with_page_auth_required.html#getserversidepropsresultwithsession" class="tsd-signature-type" data-tsd-kind="Type alias">GetServerSidePropsResultWithSession</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/helpers/with-page-auth-required.ts#L35">src/helpers/with-page-auth-required.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/helpers/with-page-auth-required.ts#L35">src/helpers/with-page-auth-required.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">With<wbr>Page<wbr>Auth<wbr>Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><span class="tsd-signature-symbol">(</span>opts<span class="tsd-signature-symbol">?: </span><a href="helpers_with_page_auth_required.html#withpageauthrequiredoptions" class="tsd-signature-type" data-tsd-kind="Type alias">WithPageAuthRequiredOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="helpers_with_page_auth_required.html#pageroute" class="tsd-signature-type" data-tsd-kind="Type alias">PageRoute</a><span class="tsd-signature-symbol">; </span>&lt;P&gt;<span class="tsd-signature-symbol">(</span>Component<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ComponentType</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span>, options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/frontend_with_page_auth_required.withpageauthrequiredoptions.html" class="tsd-signature-type" data-tsd-kind="Interface">WithPageAuthRequiredOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">FC</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/helpers/with-page-auth-required.ts#L82">src/helpers/with-page-auth-required.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/helpers/with-page-auth-required.ts#L82">src/helpers/with-page-auth-required.ts:82</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">With<wbr>Page<wbr>Auth<wbr>Required<wbr>Options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>getServerSideProps<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">GetServerSideProps</span><span class="tsd-signature-symbol">; </span>returnTo<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/helpers/with-page-auth-required.ts#L61">src/helpers/with-page-auth-required.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/helpers/with-page-auth-required.ts#L61">src/helpers/with-page-auth-required.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/instance.html
+++ b/docs/modules/instance.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Init<wbr>Auth0<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>params<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfigParameters</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="../interfaces/instance.signinwithauth0.html" class="tsd-signature-type" data-tsd-kind="Interface">SignInWithAuth0</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/instance.ts#L69">src/instance.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/instance.ts#L69">src/instance.ts:69</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/session_get_access_token.html
+++ b/docs/modules/session_get_access_token.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Get<wbr>Access<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">IncomingMessage</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ServerResponse</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NextApiResponse</span>, accessTokenRequest<span class="tsd-signature-symbol">?: </span><a href="../interfaces/session_get_access_token.accesstokenrequest.html" class="tsd-signature-type" data-tsd-kind="Interface">AccessTokenRequest</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/session_get_access_token.getaccesstokenresult.html" class="tsd-signature-type" data-tsd-kind="Interface">GetAccessTokenResult</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/get-access-token.ts#L44">src/session/get-access-token.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/get-access-token.ts#L44">src/session/get-access-token.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/session_get_session.html
+++ b/docs/modules/session_get_session.html
@@ -84,7 +84,7 @@
 					<div class="tsd-signature tsd-kind-icon">Get<wbr>Session<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">IncomingMessage</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NextApiRequest</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ServerResponse</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NextApiResponse</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="../classes/session_session.default.html" class="tsd-signature-type" data-tsd-kind="Class">default</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/50e27fc/src/session/get-session.ts#L10">src/session/get-session.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/auth0/nextjs-auth0/blob/b3e0e99/src/session/get-session.ts#L10">src/session/get-session.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/version.html
+++ b/docs/modules/version.html
@@ -81,7 +81,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-module">
 					<a name="default" class="tsd-anchor"></a>
 					<h3>default</h3>
-					<div class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;1.3.0&quot;</span></div>
+					<div class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;1.3.1&quot;</span></div>
 					<aside class="tsd-sources">
 					</aside>
 				</section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/nextjs-auth0",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "base64url": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Next.js SDK for signing in with Auth0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.3.0';
+export default '1.3.1';


### PR DESCRIPTION
**Fixed**

- Use `window.location.toString()` as the default `returnTo` value [#370](https://github.com/auth0/nextjs-auth0/pull/370) ([Widcket](https://github.com/Widcket))
- `returnTo` should be encoded as it contains url unsafe chars [#365](https://github.com/auth0/nextjs-auth0/pull/365) ([adamjmcgrath](https://github.com/adamjmcgrath))
