### PR TITLE
Include message body in 302 responses

### DIFF
--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -62,6 +62,6 @@ export default function callbackHandlerFactory(
     res.writeHead(302, {
       Location: openidState.returnTo || config.baseURL
     });
-    res.end();
+    res.end(openidState.returnTo || config.baseURL);
   };
 }

--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -92,6 +92,6 @@ export default function loginHandlerFactory(
     res.writeHead(302, {
       Location: authorizationUrl
     });
-    res.end();
+    res.end(authorizationUrl);
   };
 }

--- a/src/auth0-session/handlers/logout.ts
+++ b/src/auth0-session/handlers/logout.ts
@@ -54,6 +54,6 @@ export default function logoutHandlerFactory(
     res.writeHead(302, {
       Location: returnURL
     });
-    res.end();
+    res.end(returnURL);
   };
 }


### PR DESCRIPTION
### Description

The 302 responses from the auth API do not contain a message body. This is in conflict with the RFCs below and causes Traefik (a reverse proxy) to invalidate the responses. In this pull request, I add a response body to the 302 responses.

### References

- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3

> All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses must not include a message-body. All other responses do include a message-body, although the body may be of zero length.

- https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.3

> The server's response payload usually contains a short hypertext note with a hyperlink to the different URI(s).

- https://github.com/traefik/traefik/issues/4456
