### PR TITLE
Add missing `default` keyword to doc snippets

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -35,7 +35,7 @@ const afterCallback = (req, res, session, state) => {
   return session;
 };
 
-export handleAuth({
+export default handleAuth({
   async callback(req, res) {
     try {
       await handleCallback(req, res, { afterCallback });

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -22,7 +22,7 @@ import { NextConfig } from '../config';
  *   return session;
  * };
  *
- * export handleAuth({
+ * export default handleAuth({
  *   async callback(req, res) {
  *     try {
  *       await handleCallback(req, res, { afterCallback });
@@ -45,7 +45,7 @@ import { NextConfig } from '../config';
  *   return session;
  * };
  *
- * export handleAuth({
+ * export default handleAuth({
  *   async callback(req, res) {
  *     try {
  *       await handleCallback(req, res, { afterCallback });


### PR DESCRIPTION
### Description

The doc snippets that show how to add an `afterCallback` hook were missing the `default` (`export default`).
I noticed this  last week while testing #416

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
