### PR TITLE
Replace prepublish with prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pretty": "prettier --write \"src/**/*.{ts,tsx}\" \"src/*.ts\"",
     "lint": "eslint --fix --ext .ts ./src",
     "docs": "typedoc --options typedoc.js src",
-    "prepublish": "npm run build",
+    "prepack": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "install:basic": "npm i --prefix=examples/basic-example --no-package-lock",
     "install:kitchen-sink": "npm i --prefix=examples/kitchen-sink-example --no-package-lock",


### PR DESCRIPTION
### Description

This PR replaces the `prepublish` script with `prepack`, as the former is deprecated and does not run before publishing. `prepublish` has been in the `package.json` since the experimental days. See https://github.com/auth0/nextjs-auth0/commit/1f5505687c2b3e2b29c65dcd2db2c888ba10e518#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

<img width="718" alt="Screen Shot 2021-06-24 at 19 37 08" src="https://user-images.githubusercontent.com/5055789/123341058-adb7af00-d523-11eb-9e18-024e242b7d66.png">

### References

- NPM script docs: https://docs.npmjs.com/cli/v7/using-npm/scripts

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
