### PR TITLE
Update cookie size FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -31,7 +31,7 @@ For the latter, you can add an `afterCallback` hook to remove the ID Token and/o
 import { handleAuth, handleCallback } from '@auth0/nextjs-auth0';
 
 const afterCallback = (req, res, session, state) => {
-  delete session.idToken; // This gets persisted by the SDK
+  delete session.user.unusedClaim; // This gets persisted by the SDK
   return session;
 };
 


### PR DESCRIPTION
Removing `idToken` is not an ideal example as it gets restored if you refresh the Access Token

See: #416