### PR TITLE
Add maxChunkSize to cookie options

### DIFF
--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -240,6 +240,11 @@ export interface CookieConfig {
    * Defaults to "Lax" but will be adjusted based on {@link AuthorizationParameters.response_type}.
    */
   sameSite: 'lax' | 'strict' | 'none';
+
+  /**
+   * Max size of the cookie chunks, use to override the default of 4096.
+   */
+  maxChunkSize: number;
 }
 
 export interface AuthorizationParameters extends OidcAuthorizationParameters {

--- a/src/auth0-session/cookie-store.ts
+++ b/src/auth0-session/cookie-store.ts
@@ -9,7 +9,6 @@ import { CookieSerializeOptions, serialize } from 'cookie';
 
 const debug = createDebug('cookie-store');
 const epoch = (): number => (Date.now() / 1000) | 0; // eslint-disable-line no-bitwise
-const MAX_COOKIE_SIZE = 4096;
 const alg = 'dir';
 const enc = 'A256GCM';
 
@@ -46,7 +45,7 @@ export default class CookieStore {
     }
 
     const emptyCookie = serialize(`${sessionName}.0`, '', cookieOptions);
-    this.chunkSize = MAX_COOKIE_SIZE - emptyCookie.length;
+    this.chunkSize = cookieConfig.maxChunkSize - emptyCookie.length;
   }
 
   private encrypt(payload: string, headers: { [key: string]: any }): string {

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -54,7 +54,8 @@ const paramsSchema = Joi.object({
           'any.only': 'Cookies set with the `Secure` property wont be attached to http requests'
         })
       }),
-      path: Joi.string().uri({ relativeOnly: true }).optional()
+      path: Joi.string().uri({ relativeOnly: true }).optional(),
+      maxChunkSize: Joi.number().integer().optional()
     })
       .default()
       .unknown(false)

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,6 +260,11 @@ export interface CookieConfig {
    * You can also use the AUTH0_COOKIE_SAME_SITE environment variable.
    */
   sameSite: 'lax' | 'strict' | 'none';
+
+  /**
+   * max size of the cookie chunks, use to override the default of 4096.
+   */
+  maxchunksize: number;
 }
 
 /**
@@ -394,7 +399,8 @@ const bool = (param?: any, defaultValue?: boolean): boolean | undefined => {
 /**
  * @ignore
  */
-const num = (param?: string): number | undefined => (param === undefined || param === '' ? undefined : +param);
+const num = (param?: string, defaultValue?: number): number | undefined =>
+  (param === undefined || param === '' ? defaultValue : +param);
 
 /**
  * @ignore
@@ -434,6 +440,7 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   const AUTH0_COOKIE_HTTP_ONLY = process.env.AUTH0_COOKIE_HTTP_ONLY;
   const AUTH0_COOKIE_SECURE = process.env.AUTH0_COOKIE_SECURE;
   const AUTH0_COOKIE_SAME_SITE = process.env.AUTH0_COOKIE_SAME_SITE;
+  const AUTH0_COOKIE_MAX_CHUNK_SIZE = process.env.AUTH0_COOKIE_MAX_CHUNK_SIZE;
 
   const baseURL =
     AUTH0_BASE_URL && !/^https?:\/\//.test(AUTH0_BASE_URL as string) ? `https://${AUTH0_BASE_URL}` : AUTH0_BASE_URL;
@@ -476,6 +483,7 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
         httpOnly: bool(AUTH0_COOKIE_HTTP_ONLY),
         secure: bool(AUTH0_COOKIE_SECURE),
         sameSite: AUTH0_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none' | undefined,
+        maxChunkSize: num(AUTH0_COOKIE_MAX_CHUNK_SIZE, 4096),
         ...baseParams.session?.cookie
       }
     },

--- a/tests/auth0-session/fixtures/helpers.ts
+++ b/tests/auth0-session/fixtures/helpers.ts
@@ -14,6 +14,11 @@ export const defaultConfig: Omit<ConfigParameters, 'baseURL'> = {
   issuerBaseURL: 'https://op.example.com',
   routes: {
     callback: '/callback'
+  },
+  session: {
+    cookie: {
+      maxChunkSize: 4096,
+    }
   }
 };
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -54,7 +54,8 @@ describe('config params', () => {
           transient: false,
           httpOnly: true,
           secure: true,
-          sameSite: 'lax'
+          sameSite: 'lax',
+          maxChunkSize: 4096
         }
       },
       routes: { callback: '/api/auth/callback', postLogoutRedirect: '' },


### PR DESCRIPTION
### Description

Added a config option to the cookie config in order to be able to control the chunk size of cookies.

As discussed in this issue
https://github.com/auth0/nextjs-auth0/issues/487

We experienced our cookie being rejected due to it being too large. This turned out to be caused by us enabeling HSTS on our ingress. Which causes `; Secure` to be appended to all `Set-Cookie` headers.
https://voyagermesh.com/docs/7.0.0/guides/ingress/http/hsts/

Seems like the solution for us will be to disable secure in the cookie config and lowering the chunk size to 4088.

### References
https://github.com/auth0/nextjs-auth0/issues/487
https://voyagermesh.com/docs/7.0.0/guides/ingress/http/hsts/

### Testing
Added unit test that verifies that reducing maxChunkSize works.
