### PR TITLE
[SDK-2813] Add afterRefresh hook

### DIFF
--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -18,8 +18,8 @@ export type ProfileOptions = {
   refetch?: boolean;
 
   /**
-   * Like {@AfterCallback} when a session is created, you can use this function to validate or add/remove claims
-   * after the session is updated. Will only run if {@link ProfileOptions.refetch} is `true`
+   * Like {@AfterCallback} and {@AfterRefresh} when a session is created, you can use this function to validate or
+   * add/remove claims after the session is updated. Will only run if {@link ProfileOptions.refetch} is `true`
    */
   afterRefetch?: AfterRefetch;
 };


### PR DESCRIPTION
### Description

When the Access Token is refreshed, the session gets a new set of tokens (Access Token, ID Token, Refresh Token).

Our advice for dealing with large cookies is to delete optional data from the session (like ID Token in some cases).

In order to do this and have the tokens refreshed, we need to add another hook (this time to `getAccessToken`) that allows you to modify the session, so that changes like removing the ID Token in `afterCallback` aren't reverted in `getAccessToken` when the session is refreshed.

Ideally we'd have a `sessionUpdated` hook, that runs accross all scenarios where a session is updated, but we don't have a place to configure a non literal config globally (all config should be able to be defined as an environment variable and I don;t want to introduce features that require `initAuth`) so we'll have to make do with these 3 hooks:

- `afterCallback`: When the session is establised including tokens and user
- `afterRefetch`: When the user is potentially updated from `/userinfo`
- `afterRefresh`: When the tokens are potentially updated from the Refresh grant

### References

Fixes #416 
See [updated FAQ](https://github.com/auth0/nextjs-auth0/blob/c80ea310f0f44df75cc85e8272debbd0661a78b7/FAQ.md#2-how-can-i-reduce-the-cookie-size)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
