### PR TITLE
[SDK-2529] Add ability to pass custom params to refresh grant and code exchange

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { NextApiResponse, NextApiRequest } from 'next';
-import { HandleCallback as BaseHandleCallback } from '../auth0-session';
+import { AuthorizationParameters, HandleCallback as BaseHandleCallback } from '../auth0-session';
 import { Session } from '../session';
 import { assertReqRes } from '../utils/assert';
 import { NextConfig } from '../config';
@@ -85,6 +85,11 @@ export interface CallbackOptions {
    * organizations, it should match {@Link LoginOptions.authorizationParams}.
    */
   organization?: string;
+
+  /**
+   * This is useful for sending custom query parameters in the body of the code exchange request for use in rules.
+   */
+  authorizationParams?: Partial<AuthorizationParameters>;
 }
 
 /**


### PR DESCRIPTION
### Description

Sometimes it's useful to pass custom params to a rule or action from the code exchange or RT grant, eg

```js
// For code exchange
await handleCallback(req, res, { authorizationParams: { foo: 'bar' } });
// For refresh grant
await getAccessToken(req, res, { authorizationParams: { foo: 'bar' } });
```

### References

fixes #369 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
