### PR TITLE
[SDK-2818] Export error classes

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -57,6 +57,8 @@ import { HandlerError } from '../utils/errors';
  * });
  * ```
  *
+ * @throws {@Link HandlerError}
+ *
  * @category Server
  */
 export type AfterCallback = (
@@ -94,6 +96,8 @@ export interface CallbackOptions {
 
 /**
  * The handler for the `api/auth/callback` route.
+ *
+ * @throws {@Link HandlerError}
  *
  * @category Server
  */

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -108,6 +108,8 @@ export interface LoginOptions {
 /**
  * The handler for the `api/auth/login` route.
  *
+ * @throws {@Link HandlerError}
+ *
  * @category Server
  */
 export type HandleLogin = (req: NextApiRequest, res: NextApiResponse, options?: LoginOptions) => Promise<void>;

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -19,6 +19,8 @@ export interface LogoutOptions {
 /**
  * The handler for the `api/auth/logout` route.
  *
+ * @throws {@Link HandlerError}
+ *
  * @category Server
  */
 export type HandleLogout = (req: NextApiRequest, res: NextApiResponse, options?: LogoutOptions) => Promise<void>;

--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -27,6 +27,8 @@ export type ProfileOptions = {
 /**
  * The handler for the `/api/auth/me` route.
  *
+ * @throws {@Link HandlerError}
+ *
  * @category Server
  */
 export type HandleProfile = (req: NextApiRequest, res: NextApiResponse, options?: ProfileOptions) => Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,8 @@ export {
   WithPageAuthRequiredProps
 } from './frontend';
 
+export { AccessTokenError, HandlerError } from './utils/errors';
+
 export {
   ConfigParameters,
   HandleAuth,

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -74,6 +74,8 @@ export interface GetAccessTokenResult {
 /**
  * Get an Access Token to access an external API.
  *
+ * @throws {@Link AccessTokenError}
+ *
  * @category Server
  */
 export type GetAccessToken = (


### PR DESCRIPTION
### Description

It's useful to be able to import the error classes, especially for user's of the recently released TypeScript 4.4 which introduces the [`useUnknownInCatchVariables` flag](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables) which changes the default type of catch clause variables from `any` to `unknown`. 

### References

fixes #479 
