### PR TITLE
Allow logout API to accept returnTo query string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Executing `handleAuth()` creates the following route handlers under the hood tha
 
 - `/api/auth/callback`: Your Identity Provider redirects users to this route after they successfully log in.
 
-- `/api/auth/logout`: Your Next.js application logs out the user.
+- `/api/auth/logout`: Your Next.js application logs out the user (you can optionally pass a `returnTo` parameter to return to a custom relative URL after logout, eg `/api/auth/logout?returnTo=/login`).
 
 - `/api/auth/me`: You can fetch user profile information in JSON format.
 

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -2,6 +2,7 @@ import { NextApiResponse, NextApiRequest } from 'next';
 import { HandleLogout as BaseHandleLogout } from '../auth0-session';
 import { assertReqRes } from '../utils/assert';
 import { HandlerError } from '../utils/errors';
+import isSafeRedirect from '../utils/url-helpers';
 
 /**
  * Custom options to pass to logout.
@@ -32,6 +33,16 @@ export default function handleLogoutFactory(handler: BaseHandleLogout): HandleLo
   return async (req, res, options): Promise<void> => {
     try {
       assertReqRes(req, res);
+      if (req.query.returnTo) {
+        const returnTo = Array.isArray(req.query.returnTo) ? req.query.returnTo[0] : req.query.returnTo;
+
+        if (!isSafeRedirect(returnTo)) {
+          throw new Error('Invalid value provided for returnTo, must be a relative url');
+        }
+
+        options = { ...options, returnTo };
+      }
+
       return await handler(req, res, options);
     } catch (e) {
       throw new HandlerError(e);


### PR DESCRIPTION
### Description

Make it possible to receive returnTo as a query string with logout api endpoint.

### References

#532 

### Testing

I added some tests to `tests/handlers/logout.test.ts`.

`npm run test`

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
