### PR TITLE
Fix issue where error reporting wrong instanceof

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,13 +149,6 @@
       }
     },
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": {
-          "target": "es6"
-        }
-      }
-    },
     "globalSetup": "./tests/global-setup.ts",
     "setupFilesAfterEnv": [
       "./tests/setup.ts"

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -8,6 +8,7 @@ import { HttpError } from 'http-errors';
 export class AccessTokenError extends Error {
   public code: string;
 
+  /* istanbul ignore next */
   constructor(code: string, message: string) {
     super(message);
 
@@ -19,6 +20,7 @@ export class AccessTokenError extends Error {
 
     // Machine readable code.
     this.code = code;
+    Object.setPrototypeOf(this, AccessTokenError.prototype);
   }
 }
 
@@ -48,6 +50,7 @@ export class HandlerError extends Error {
   public status: number | undefined;
   public code: string | undefined;
 
+  /* istanbul ignore next */
   constructor(error: Error | AccessTokenError | HttpError) {
     super(htmlSafe(error.message));
 
@@ -60,5 +63,6 @@ export class HandlerError extends Error {
     if ('status' in error) {
       this.status = error.status;
     }
+    Object.setPrototypeOf(this, HandlerError.prototype);
   }
 }

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,0 +1,8 @@
+import { AccessTokenError, HandlerError } from '../../src/utils/errors';
+
+describe('errors', () => {
+  test('should be instance of themselves', () => {
+    expect(new AccessTokenError('code', 'message')).toBeInstanceOf(AccessTokenError);
+    expect(new HandlerError(new Error('message'))).toBeInstanceOf(HandlerError);
+  });
+});


### PR DESCRIPTION
### Description

Using the `instanceof` operator against the `AccessTokenError` constructor always returns false, even if the object that is being tested is actually an instance of `AccessTokenError`.

This is an issue introduced in nextjs-auth0 v1.5.0 by https://github.com/microsoft/TypeScript/issues/13965 when we downgraded the compilation target to `es5` to support IE11 in https://github.com/auth0/nextjs-auth0/commit/c248efe2488b9884d6ab4c88c12b00aa67fe99f7#diff-3ae20d611c1c7263a9c1bce0449291ebfea1c5d578b3fcdbb596353ad885db25R19

Using the workaround here https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

### References

fixes #535 

### Testing

Set the target for jest to be the same as the main binary, so I could add a test case for this regression.
Using target `es5` on jest meant I had to add a couple of `ignore next`'s to resolve an issue in istanbul (see https://github.com/gotwarlost/istanbul/issues/690)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
