### PR TITLE
Fix false positive when check isSafeRedirect and a absolute URL is in URL Params

### DIFF
--- a/src/utils/url-helpers.ts
+++ b/src/utils/url-helpers.ts
@@ -8,7 +8,7 @@ export default function isSafeRedirect(url: string): boolean {
   }
 
   // Prevent open redirects using the //foo.com format (double forward slash).
-  if (/\/\//.test(url)) {
+  if (/^\/\//.test(url)) {
     return false;
   }
 

--- a/src/utils/url-helpers.ts
+++ b/src/utils/url-helpers.ts
@@ -8,7 +8,7 @@ export default function isSafeRedirect(url: string): boolean {
   }
 
   // Prevent open redirects using the //foo.com format (double forward slash).
-  if (/^\/\//.test(url)) {
+  if (/^\s*\/\//.test(url)) {
     return false;
   }
 

--- a/tests/utils/url-helpers.test.ts
+++ b/tests/utils/url-helpers.test.ts
@@ -11,8 +11,8 @@ describe('url-helpers', () => {
     test('should allow relative urls', () => {
       expect(isSafeRedirect('/foo')).toEqual(true);
       expect(isSafeRedirect('/foo?some=value')).toEqual(true);
-      expect(isSafeRedirect('/foo?urlParam=https://bar'));
-      expect(isSafeRedirect('/foo?urlParam=//bar'));
+      expect(isSafeRedirect('/foo?urlParam=https://bar')).toEqual(true);
+      expect(isSafeRedirect('/foo?urlParam=//bar')).toEqual(true);
     });
 
     test('should prevent open redirects', () => {

--- a/tests/utils/url-helpers.test.ts
+++ b/tests/utils/url-helpers.test.ts
@@ -11,6 +11,8 @@ describe('url-helpers', () => {
     test('should allow relative urls', () => {
       expect(isSafeRedirect('/foo')).toEqual(true);
       expect(isSafeRedirect('/foo?some=value')).toEqual(true);
+      expect(isSafeRedirect('/foo?urlParam=https://bar'));
+      expect(isSafeRedirect('/foo?urlParam=//bar'));
     });
 
     test('should prevent open redirects', () => {

--- a/tests/utils/url-helpers.test.ts
+++ b/tests/utils/url-helpers.test.ts
@@ -18,6 +18,7 @@ describe('url-helpers', () => {
     test('should prevent open redirects', () => {
       expect(isSafeRedirect('//google.com')).toEqual(false);
       expect(isSafeRedirect(' //google.com')).toEqual(false);
+      expect(isSafeRedirect('    //google.com')).toEqual(false);
       expect(isSafeRedirect('\n//google.com')).toEqual(false);
       expect(isSafeRedirect('///google.com')).toEqual(false);
     });

--- a/tests/utils/url-helpers.test.ts
+++ b/tests/utils/url-helpers.test.ts
@@ -17,6 +17,8 @@ describe('url-helpers', () => {
 
     test('should prevent open redirects', () => {
       expect(isSafeRedirect('//google.com')).toEqual(false);
+      expect(isSafeRedirect(' //google.com')).toEqual(false);
+      expect(isSafeRedirect('\n//google.com')).toEqual(false);
       expect(isSafeRedirect('///google.com')).toEqual(false);
     });
 


### PR DESCRIPTION
### Description

As Described in #545 -> When a absolute URL is in a parameter of redirectURL then we get a false positive. Fixed by check double // only on the beginning of the URL

### References

 Fix #545 

### Testing

Added Unit Test to test the changed helper Function (isSafeRedirect)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
