### PR TITLE
Improve types in server-side withPageAuthRequired

### DIFF
--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -7,6 +7,7 @@ import {
   WithPageAuthRequiredProps
 } from '../frontend/with-page-auth-required';
 import { withPageAuthRequired as withPageAuthRequiredCSR } from '../frontend';
+import { ParsedUrlQuery } from 'querystring';
 
 /**
  * If you wrap your `getServerSideProps` with {@link WithPageAuthRequired} your props object will be augmented with
@@ -32,7 +33,9 @@ export type GetServerSidePropsResultWithSession<P = any> = GetServerSidePropsRes
  *
  * @category Server
  */
-export type PageRoute<P> = (cts: GetServerSidePropsContext) => Promise<GetServerSidePropsResultWithSession<P>>;
+export type PageRoute<P, Q extends ParsedUrlQuery> = (
+  cts: GetServerSidePropsContext<Q>
+) => Promise<GetServerSidePropsResultWithSession<P>>;
 
 /**
  * If you have a custom returnTo url you should specify it in `returnTo`.
@@ -60,8 +63,8 @@ export type PageRoute<P> = (cts: GetServerSidePropsContext) => Promise<GetServer
  *
  * @category Server
  */
-export type WithPageAuthRequiredOptions<P = any> = {
-  getServerSideProps?: GetServerSideProps<P>;
+export type WithPageAuthRequiredOptions<P = any, Q extends ParsedUrlQuery = ParsedUrlQuery> = {
+  getServerSideProps?: GetServerSideProps<P, Q>;
   returnTo?: string;
 };
 
@@ -85,7 +88,7 @@ export type WithPageAuthRequiredOptions<P = any> = {
  * @category Server
  */
 export type WithPageAuthRequired = {
-  <P>(opts?: WithPageAuthRequiredOptions<P>): PageRoute<P>;
+  <P, Q extends ParsedUrlQuery>(opts?: WithPageAuthRequiredOptions<P, Q>): PageRoute<P, Q>;
   <P extends WithPageAuthRequiredProps>(
     Component: ComponentType<P>,
     options?: WithPageAuthRequiredCSROptions


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR is about server-side withPageAuthRequired.
Because `withPageAuthRequired` does not accept Query as a type parameter, it's returned GetServerSideProps with a default Query type of ParsedUrlQuery.

```ts
withPageAuthRequired({
  getServerSideProps,
  returnTo: "/foo/bar"
});
```
The type of this will be `GetServerSideProps<P, ParsedUrlQuery>` no matter what type of getServerSideProps is passed.

In this PR, withPageAuthRequired has been changed so that Query can also be specified as a type parameter.

### Testing
Since this is a modification of the type definition, no tests have been added.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
