### PR TITLE
Fix tab character open redirect

### DIFF
--- a/src/utils/url-helpers.ts
+++ b/src/utils/url-helpers.ts
@@ -8,7 +8,7 @@ export default function isSafeRedirect(url: string): boolean {
   }
 
   // Prevent open redirects using the //foo.com format (double forward slash).
-  if (/\/\//.test(url)) {
+  if (/\/\s*\//.test(url)) {
     return false;
   }
 

--- a/tests/utils/url-helpers.test.ts
+++ b/tests/utils/url-helpers.test.ts
@@ -16,6 +16,7 @@ describe('url-helpers', () => {
     test('should prevent open redirects', () => {
       expect(isSafeRedirect('//google.com')).toEqual(false);
       expect(isSafeRedirect('///google.com')).toEqual(false);
+      expect(isSafeRedirect('/\t/google.com')).toEqual(false);
     });
 
     test('should throw when non string provided', () => {


### PR DESCRIPTION
### Description

Fixes an open redirect vulnerability via the `returnTo` parameter, via checking for whitespace characters.

Chrome based browsers (in my testing) will trim off the tab character for a redirect, as [defined in the URL parser spec](https://url.spec.whatwg.org/#concept-basic-url-parser). This leads to an open redirect through `returnTo` by setting it to something like `/%09/google.com`.

You can test this in chrome by executing the following in the console:

```javascript
window.location.href = '/\x09/google.com'
```

### Testing

Include `returnTo=/%09/google.com` in the login, it should fail with this change.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
