### PR TITLE
Include message body in 302 responses

### DIFF
--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -6,6 +6,7 @@ import { ClientFactory } from '../client';
 import TransientStore from '../transient-store';
 import { decodeState } from '../hooks/get-login-state';
 import { SessionCache } from '../session-cache';
+import { htmlSafe } from '../../utils/errors';
 
 function getRedirectUri(config: Config): string {
   return urlJoin(config.baseURL, config.routes.callback);
@@ -69,6 +70,6 @@ export default function callbackHandlerFactory(
     res.writeHead(302, {
       Location: openidState.returnTo || config.baseURL
     });
-    res.end();
+    res.end(htmlSafe(openidState.returnTo || config.baseURL));
   };
 }

--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -6,6 +6,7 @@ import TransientStore, { StoreOptions } from '../transient-store';
 import { encodeState } from '../hooks/get-login-state';
 import { ClientFactory } from '../client';
 import createDebug from '../utils/debug';
+import { htmlSafe } from '../../utils/errors';
 
 const debug = createDebug('handlers');
 
@@ -92,6 +93,6 @@ export default function loginHandlerFactory(
     res.writeHead(302, {
       Location: authorizationUrl
     });
-    res.end();
+    res.end(htmlSafe(authorizationUrl));
   };
 }

--- a/src/auth0-session/handlers/logout.ts
+++ b/src/auth0-session/handlers/logout.ts
@@ -5,6 +5,7 @@ import createDebug from '../utils/debug';
 import { Config, LogoutOptions } from '../config';
 import { ClientFactory } from '../client';
 import { SessionCache } from '../session-cache';
+import { htmlSafe } from '../../utils/errors';
 
 const debug = createDebug('logout');
 
@@ -28,7 +29,7 @@ export default function logoutHandlerFactory(
       res.writeHead(302, {
         Location: returnURL
       });
-      res.end();
+      res.end(htmlSafe(returnURL));
       return;
     }
 
@@ -40,7 +41,7 @@ export default function logoutHandlerFactory(
       res.writeHead(302, {
         Location: returnURL
       });
-      res.end();
+      res.end(htmlSafe(returnURL));
       return;
     }
 
@@ -54,6 +55,6 @@ export default function logoutHandlerFactory(
     res.writeHead(302, {
       Location: returnURL
     });
-    res.end();
+    res.end(htmlSafe(returnURL));
   };
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -26,7 +26,7 @@ export class AccessTokenError extends Error {
 
 // eslint-disable-next-line max-len
 // Basic escaping for putting untrusted data directly into the HTML body, per: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content
-function htmlSafe(input: string): string {
+export function htmlSafe(input: string): string {
   return input
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')


### PR DESCRIPTION
### Description
The 302 responses from the auth API do not contain a message body. This is in conflict with the RFCs below and causes Traefik (a reverse proxy) to invalidate the responses. In this pull request, I add a response body to the 302 responses.

### References
- My previous PR, sorry for not following up on this! https://github.com/auth0/nextjs-auth0/pull/399
- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3

> All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses must not include a message-body. All other responses do include a message-body, although the body may be of zero length.

- https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.3

> The server's response payload usually contains a short hypertext note with a hyperlink to the different URI(s).

- Similar fix in Next.js: https://github.com/vercel/next.js/pull/25257
- Similar fix in Next.js: https://github.com/vercel/next.js/pull/31886