### PR TITLE
Cookies with samesite=none must have the secure attr set

### DIFF
--- a/src/auth0-session/cookie-store.ts
+++ b/src/auth0-session/cookie-store.ts
@@ -166,10 +166,7 @@ export default class CookieStore {
       debug('clearing all matching session cookies');
       for (const cookieName of Object.keys(cookies)) {
         if (cookieName.match(`^${sessionName}(?:\\.\\d)?$`)) {
-          clearCookie(res, cookieName, {
-            domain: cookieConfig.domain,
-            path: cookieConfig.path
-          });
+          clearCookie(res, cookieName, cookieConfig);
         }
       }
       return;
@@ -198,19 +195,13 @@ export default class CookieStore {
         setCookie(res, chunkCookieName, chunkValue, cookieOptions);
       }
       if (sessionName in cookies) {
-        clearCookie(res, sessionName, {
-          domain: cookieConfig.domain,
-          path: cookieConfig.path
-        });
+        clearCookie(res, sessionName, cookieConfig);
       }
     } else {
       setCookie(res, sessionName, value, cookieOptions);
       for (const cookieName of Object.keys(cookies)) {
         if (cookieName.match(`^${sessionName}\\.\\d$`)) {
-          clearCookie(res, cookieName, {
-            domain: cookieConfig.domain,
-            path: cookieConfig.path
-          });
+          clearCookie(res, cookieName, cookieConfig);
         }
       }
     }

--- a/src/auth0-session/transient-store.ts
+++ b/src/auth0-session/transient-store.ts
@@ -133,10 +133,10 @@ export default class TransientStore {
    */
   read(key: string, req: IncomingMessage, res: ServerResponse): string | undefined {
     const cookie = getCookie(req, key);
-    const { domain, path } = this.config.session.cookie;
+    const cookieConfig = this.config.session.cookie;
 
     let value = getCookieValue(key, cookie, this.keyStore);
-    clearCookie(res, key, { domain, path });
+    clearCookie(res, key, cookieConfig);
 
     if (this.config.legacySameSiteCookie) {
       const fallbackKey = `_${key}`;
@@ -144,7 +144,7 @@ export default class TransientStore {
         const fallbackCookie = getCookie(req, fallbackKey);
         value = getCookieValue(fallbackKey, fallbackCookie, this.keyStore);
       }
-      clearCookie(res, fallbackKey, { domain, path });
+      clearCookie(res, fallbackKey, cookieConfig);
     }
 
     return value;

--- a/src/auth0-session/utils/cookies.ts
+++ b/src/auth0-session/utils/cookies.ts
@@ -22,5 +22,17 @@ export const set = (res: ServerResponse, name: string, value: string, options: C
 };
 
 export const clear = (res: ServerResponse, name: string, options: CookieSerializeOptions = {}): void => {
-  set(res, name, '', { ...options, maxAge: 0 });
+  const { domain, path, secure, sameSite } = options;
+  const clearOptions: CookieSerializeOptions = {
+    domain,
+    path,
+    maxAge: 0
+  };
+  // If SameSite=None is set, the cookie Secure attribute must also be set (or the cookie will be blocked)
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none
+  if (sameSite === 'none') {
+    clearOptions.secure = secure;
+  }
+
+  set(res, name, '', clearOptions);
 };

--- a/src/auth0-session/utils/cookies.ts
+++ b/src/auth0-session/utils/cookies.ts
@@ -32,6 +32,7 @@ export const clear = (res: ServerResponse, name: string, options: CookieSerializ
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none
   if (sameSite === 'none') {
     clearOptions.secure = secure;
+    clearOptions.sameSite = sameSite;
   }
 
   set(res, name, '', clearOptions);

--- a/tests/auth0-session/handlers/logout.test.ts
+++ b/tests/auth0-session/handlers/logout.test.ts
@@ -174,7 +174,9 @@ describe('logout route', () => {
 
     const { res } = await get(baseURL, '/logout', { cookieJar, fullResponse: true });
     const cookies = fromCookieJar(cookieJar, baseURL);
-    expect(res.headers['set-cookie'].find((setCookie: string) => /^appSession/.test(setCookie))).toMatch(/Secure/);
+    const sessionCookie = res.headers['set-cookie'].find((s: string) => /^appSession/.test(s));
+    expect(sessionCookie).toMatch(/Secure/);
+    expect(sessionCookie).toMatch(/SameSite=None/);
     expect(cookies).toHaveProperty('foo');
     expect(cookies).not.toHaveProperty('appSession');
   });


### PR DESCRIPTION
### Description

Fix issue where transient and session cookies weren't cleared when `SameSite=None`

> If `SameSite=None` is set, the cookie Secure attribute must also be set (or the cookie will be blocked)
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none

### References

fixes #569 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
