### PR TITLE
Honor configured sameSite in transient cookies so you can login to iframe using 'none'

### DIFF
--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -40,7 +40,7 @@ export default function loginHandlerFactory(
     };
 
     const transientOpts: StoreOptions = {
-      sameSite: opts.authorizationParams.response_mode === 'form_post' ? 'none' : 'lax'
+      sameSite: opts.authorizationParams.response_mode === 'form_post' ? 'none' : config.session.cookie.sameSite
     };
 
     const stateValue = await opts.getLoginState(req as any, opts);


### PR DESCRIPTION
### Description

Honor the `SameSite` configuration (which defaults to 'lax') when setting the transient nonce/state cookies.

This will allow users to login to iframes over https when using the [AUTH0_COOKIE_SAME_SITE](https://auth0.github.io/nextjs-auth0/interfaces/config.cookieconfig.html#samesite) config set to `'none'`

### References

Same as https://github.com/auth0/express-openid-connect/pull/188
fixes #541 

### Testing

Tested by logging in to auth0 from an iframe in https://codepen.io/adamjmcgrath/pen/bGoKBMW

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
