### PR TITLE
Fix types in client-side `withPageAuthRequired`

### DIFF
--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -55,8 +55,11 @@ export interface WithPageAuthRequiredOptions {
  * @ignore
  */
 export interface WithPageAuthRequiredProps {
-  user: UserProfile;
   [key: string]: any;
+}
+
+export interface UserProps {
+  user: UserProfile;
 }
 
 /**
@@ -70,9 +73,9 @@ export interface WithPageAuthRequiredProps {
  * @category Client
  */
 export type WithPageAuthRequired = <P extends WithPageAuthRequiredProps>(
-  Component: ComponentType<P>,
+  Component: ComponentType<P & UserProps>,
   options?: WithPageAuthRequiredOptions
-) => React.FC<Omit<P, 'user'>>;
+) => React.FC<P>;
 
 /**
  * @ignore

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -3,6 +3,7 @@ import { Claims, GetSession } from '../session';
 import { assertCtx } from '../utils/assert';
 import React, { ComponentType } from 'react';
 import {
+  UserProps,
   WithPageAuthRequiredOptions as WithPageAuthRequiredCSROptions,
   WithPageAuthRequiredProps
 } from '../frontend/with-page-auth-required';
@@ -90,7 +91,7 @@ export type WithPageAuthRequiredOptions<P = any, Q extends ParsedUrlQuery = Pars
 export type WithPageAuthRequired = {
   <P, Q extends ParsedUrlQuery = ParsedUrlQuery>(opts?: WithPageAuthRequiredOptions<P, Q>): PageRoute<P, Q>;
   <P extends WithPageAuthRequiredProps>(
-    Component: ComponentType<P>,
+    Component: ComponentType<P & UserProps>,
     options?: WithPageAuthRequiredCSROptions
   ): React.FC<P>;
 };
@@ -100,7 +101,9 @@ export type WithPageAuthRequired = {
  */
 export default function withPageAuthRequiredFactory(loginUrl: string, getSession: GetSession): WithPageAuthRequired {
   return (
-    optsOrComponent: WithPageAuthRequiredOptions | ComponentType<WithPageAuthRequiredProps> = {},
+    optsOrComponent:
+      | WithPageAuthRequiredOptions
+      | ComponentType<WithPageAuthRequiredProps & UserProps> = {},
     csrOpts?: WithPageAuthRequiredCSROptions
   ): any => {
     if (typeof optsOrComponent === 'function') {

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -89,11 +89,11 @@ export type WithPageAuthRequiredOptions<P = any, Q extends ParsedUrlQuery = Pars
  * @category Server
  */
 export type WithPageAuthRequired = {
-  <P, Q extends ParsedUrlQuery = ParsedUrlQuery>(opts?: WithPageAuthRequiredOptions<P, Q>): PageRoute<P, Q>;
   <P extends WithPageAuthRequiredProps>(
     Component: ComponentType<P & UserProps>,
     options?: WithPageAuthRequiredCSROptions
   ): React.FC<P>;
+  <P, Q extends ParsedUrlQuery = ParsedUrlQuery>(opts?: WithPageAuthRequiredOptions<P, Q>): PageRoute<P, Q>;
 };
 
 /**
@@ -101,9 +101,7 @@ export type WithPageAuthRequired = {
  */
 export default function withPageAuthRequiredFactory(loginUrl: string, getSession: GetSession): WithPageAuthRequired {
   return (
-    optsOrComponent:
-      | WithPageAuthRequiredOptions
-      | ComponentType<WithPageAuthRequiredProps & UserProps> = {},
+    optsOrComponent: WithPageAuthRequiredOptions | ComponentType<WithPageAuthRequiredProps & UserProps> = {},
     csrOpts?: WithPageAuthRequiredCSROptions
   ): any => {
     if (typeof optsOrComponent === 'function') {


### PR DESCRIPTION
### Description

This PR modifies types related to client-side `withPageAuthRequired` to fix several issues.

- Return type of `withPageAuthRequired` has `user` in props incorrectly
- Passing `{ user: UserProfile }` as a part of generic parameter of `withPageAuthRequired` seems redundant
- Props of component passed to `withPageAuthRequired` does not infer types properly

These issues are commented in a sample code below:

```ts
export async function getStaticProps() {
  return {
    props: {
      locale: "en"
    }
  };
}

// passing `{ user: UserProfile }` as a part of generic parameter for `withPageAuthRequired` is necessary, that seems redundant.
const Page = withPageAuthRequired<InferGetStaticPropsType<typeof getStaticProps> & { user: UserProfile }>(
  ({ locale, user }) => {    
    // `locale` and `user` are inferred `any` here. they should be `string` and `UserProfile`.
    return <></>;
  }
);
// type of `Page` is `FC<{ locale: string; } & { user: UserProfile; }>`, where `{ user: UserProfile }` is improper.
export default Page

```

#### Solutions

- Take `{ user: UserProfile }` apart from `WithPageAuthRequiredProps`
- Swap call signatures in `WithPageAuthRequired` for the last issue
  - Although I am not sure the cause of the improper type inference

### Testing

If this PR solves those issues can be checked by following code:

```ts
export async function getStaticProps() {
  return {
    props: {
      locale: "en"
    }
  };
}

// `{ user: UserProfile }` can be omitted from generic parameter
const Page = withPageAuthRequired<InferGetStaticPropsType<typeof getStaticProps>>(
  // type of `locale` is `string` and `user` is `UserProfile`
  ({ locale, user }) => {    
    return <></>;
  }
);
// type of `Page` is `FC<{ locale: string; }>`
export default Page

```

TypeScript 4.5.4 is used for my check

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
