### PR TITLE
Should be able to set rollingDuration as false (when rolling is false)

### DIFF
--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -186,9 +186,10 @@ export interface SessionConfig {
   /**
    * Integer value, in seconds, for application session rolling duration.
    * The amount of time for which the user must be idle for then to be logged out.
+   * Should be false when rolling is false.
    * Default is 86400 seconds (1 day).
    */
-  rollingDuration: number;
+  rollingDuration: number | false;
 
   /**
    * Integer value, in seconds, for application absolute rolling duration.

--- a/src/auth0-session/cookie-store.ts
+++ b/src/auth0-session/cookie-store.ts
@@ -70,12 +70,12 @@ export default class CookieStore {
     const { rolling, rollingDuration } = this.config.session;
 
     if (typeof absoluteDuration !== 'number') {
-      return uat + rollingDuration;
+      return uat + (rollingDuration as number);
     }
     if (!rolling) {
       return iat + absoluteDuration;
     }
-    return Math.min(uat + rollingDuration, iat + absoluteDuration);
+    return Math.min(uat + (rollingDuration as number), iat + absoluteDuration);
   }
 
   public read(req: IncomingMessage): [{ [key: string]: any }?, number?] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -196,10 +196,11 @@ export interface SessionConfig {
   /**
    * Integer value, in seconds, for application session rolling duration.
    * The amount of time for which the user must be idle for then to be logged out.
+   * Should be false when rolling is false.
    * Default is 86400 seconds (1 day).
    * You can also use the AUTH0_SESSION_ROLLING_DURATION environment variable.
    */
-  rollingDuration: number;
+  rollingDuration: number | false;
 
   /**
    * Integer value, in seconds, for application absolute rolling duration.
@@ -463,7 +464,10 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
     session: {
       name: AUTH0_SESSION_NAME,
       rolling: bool(AUTH0_SESSION_ROLLING),
-      rollingDuration: num(AUTH0_SESSION_ROLLING_DURATION),
+      rollingDuration:
+        AUTH0_SESSION_ROLLING_DURATION && isNaN(Number(AUTH0_SESSION_ROLLING_DURATION))
+          ? (bool(AUTH0_SESSION_ROLLING_DURATION) as false)
+          : num(AUTH0_SESSION_ROLLING_DURATION),
       absoluteDuration:
         AUTH0_SESSION_ABSOLUTE_DURATION && isNaN(Number(AUTH0_SESSION_ABSOLUTE_DURATION))
           ? bool(AUTH0_SESSION_ABSOLUTE_DURATION)

--- a/tests/auth0-session/config.test.ts
+++ b/tests/auth0-session/config.test.ts
@@ -210,6 +210,19 @@ describe('Config', () => {
     ).toThrow('"session.rollingDuration" must be false when "session.rolling" is disabled');
   });
 
+  it('should succeed when rollingDuration is defined as false and rolling is false', function () {
+    expect(() =>
+      getConfig({
+        ...defaultConfig,
+        session: {
+          rolling: false,
+          rollingDuration: false,
+          absoluteDuration: 10
+        }
+      })
+    ).not.toThrow();
+  });
+
   it('should fail when rollingDuration is not defined and rolling is true', function () {
     expect(() =>
       getConfig({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -124,6 +124,17 @@ describe('config params', () => {
         }
       }
     });
+    expect(
+      getConfigWithEnv({
+        AUTH0_SESSION_ROLLING_DURATION: 'no',
+        AUTH0_SESSION_ROLLING: 'no'
+      }).baseConfig
+    ).toMatchObject({
+      session: {
+        rolling: false,
+        rollingDuration: false
+      }
+    });
   });
 
   test('should populate numbers', () => {


### PR DESCRIPTION
### Description

The types for `rollingDuration` don't match the run time checks that Joi does.

You should be able to set `rollingDuration` as `false` (when `rolling` is `false`)

### References

fixes #591 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
