### PR TITLE
Add default to PageRoute type parameter

### DIFF
--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -34,7 +34,7 @@ export type GetServerSidePropsResultWithSession<P = any> = GetServerSidePropsRes
  *
  * @category Server
  */
-export type PageRoute<P, Q extends ParsedUrlQuery> = (
+export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
   cts: GetServerSidePropsContext<Q>
 ) => Promise<GetServerSidePropsResultWithSession<P>>;
 


### PR DESCRIPTION
### Description

Add default to PageRoute type parameter to match the default for the WithPageAuthRequiredOptions type and make it easier for the generic type to be used.

The generic type arguments for URL queries were added here: https://github.com/auth0/nextjs-auth0/pull/554 and these changes were released in v1.7.0.

For codebases that were already importing the PageRoute type, the introduction of the new required type argument failed type-checking with this error:
> Generic type 'PageRoute' requires 2 type argument(s). ts(2314)

It is easily fixed by providing a value for the new type argument, but by adding the default into this package it makes it easier for users of the package since they do not have to update their codebases.

### Testing

Since this is a modification of the type definition, no tests have been added.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
