### PR TITLE
Fix broken link to Vercel documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -45,7 +45,7 @@ This can be done manually, by going to the Application Settings on your [Auth0 d
 
 ##### Wildcards
 
-By default, Vercel uses the `vercel.app` domain for all of your environments. Using wildcards for a shared domain opens the possibility to redirect back to a malicious website, as long as the Callback URLs matches the wildcard configuration. Because of that, you should only consider using wildcards for the preview deployments when using a [Custom Deployment Suffix](https://vercel.com/docs/platform/frequently-asked-questions#preview-deployment-suffix), which is available as part of Vercel's Pro or Enterprise plan.
+By default, Vercel uses the `vercel.app` domain for all of your environments. Using wildcards for a shared domain opens the possibility to redirect back to a malicious website, as long as the Callback URLs matches the wildcard configuration. Because of that, you should only consider using wildcards for the preview deployments when using a [Preview Deployment Suffix](https://vercel.com/docs/concepts/deployments/automatic-urls#preview-deployment-suffix), which is available as part of Vercel's Pro or Enterprise plan.
 
 | Setting               | Description                                                                                                                  |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### Description

This PR fixes a broken link to the Vercel documentation on [Preview Deployment Suffix](https://vercel.com/docs/concepts/deployments/automatic-urls#preview-deployment-suffix).

### References

Found while investigating https://github.com/auth0/nextjs-auth0/issues/640

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
