### PR TITLE
Fix Fast Refresh for WithPageAuthRequired

### DIFF
--- a/src/frontend/with-page-auth-required.tsx
+++ b/src/frontend/with-page-auth-required.tsx
@@ -81,7 +81,7 @@ export type WithPageAuthRequired = <P extends WithPageAuthRequiredProps>(
  * @ignore
  */
 const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => {
-  return function withPageAuthRequired(props): JSX.Element {
+  return function WithPageAuthRequired(props): JSX.Element {
     const { returnTo, onRedirecting = defaultOnRedirecting, onError = defaultOnError } = options;
     const { loginUrl } = useConfig();
     const { user, error, isLoading } = useUser();


### PR DESCRIPTION
### Description

After a bit of trial and error, I discovered that this function needs to be named as Title Case in order to work with Fast Refresh.

### References

fixes #652 
