### PR TITLE
[SDK-3332] Constrain session lifecycle to `withPageAuthrequired` to avoid Next warning

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,6 +2,7 @@
 
 1. [Why do I get a `checks.state argument is missing` error when logging in from different tabs?](#1-why-do-i-get-a-checks.state-argument-is-missing-error-if-i-try-to-log-in-from-different-tabs)
 2. [How can I reduce the cookie size?](#2-how-can-i-reduce-the-cookie-size)
+3. [I'm getting the warning/error `You should not access 'res' after getServerSideProps resolves.`](#3-i-m-getting-the-warning-error--you-should-not-access--res--after-getserversideprops-resolves.)
 
 ## 1. Why do I get a `checks.state argument is missing` error if I try to log in from different tabs?
 
@@ -63,3 +64,11 @@ export default async function MyHandler(req, res) {
 ```
 
 > Note: support for custom session stores [is in our roadmap](https://github.com/auth0/nextjs-auth0/issues/279).
+
+## 3. I'm getting the warning/error `You should not access 'res' after getServerSideProps resolves.`
+
+Because this SDK provides a rolling session by default, it writes to the header at the end of every request. This can cause the above warning when you use `getSession` or `getAccessToken` in >=Next.js 12, and an error if your `props` are defined as a `Promise`.
+
+Wrapping your `getServerSideProps` in `withAuthenticationRequired` will fix this because it will constrain the lifecycle of the session to the life of `getServerSideProps`.
+
+If you don't want to require authentication for your route, you can use `withAuthenticationRequired` with the `authRequired: false` option.

--- a/FAQ.md
+++ b/FAQ.md
@@ -69,6 +69,6 @@ export default async function MyHandler(req, res) {
 
 Because this SDK provides a rolling session by default, it writes to the header at the end of every request. This can cause the above warning when you use `getSession` or `getAccessToken` in >=Next.js 12, and an error if your `props` are defined as a `Promise`.
 
-Wrapping your `getServerSideProps` in `withAuthenticationRequired` will fix this because it will constrain the lifecycle of the session to the life of `getServerSideProps`.
+Wrapping your `getServerSideProps` in `getServerSidePropsWrapper` will fix this because it will constrain the lifecycle of the session to the life of `getServerSideProps`.
 
-If you don't want to require authentication for your route, you can use `withAuthenticationRequired` with the `authRequired: false` option.
+> Note: you should not use this if you are already using `withPageAuthenticationRequired` since this should already constrain the lifecycle of the session.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ For other comprehensive examples, see the [EXAMPLES.md](./EXAMPLES.md) document.
 - [handleProfile](https://auth0.github.io/nextjs-auth0/modules/handlers_profile.html)
 - [withApiAuthRequired](https://auth0.github.io/nextjs-auth0/modules/helpers_with_api_auth_required.html)
 - [withPageAuthRequired](https://auth0.github.io/nextjs-auth0/modules/helpers_with_page_auth_required.html#withpageauthrequired)
+- [getServerSidePropsWrapper](https://auth0.github.io/nextjs-auth0/modules/helpers_get_server_side_props_wrapper.html)
 - [getSession](https://auth0.github.io/nextjs-auth0/modules/session_get_session.html)
 - [getAccessToken](https://auth0.github.io/nextjs-auth0/modules/session_get_access_token.html)
 - [initAuth0](https://auth0.github.io/nextjs-auth0/modules/instance.html)

--- a/src/helpers/get-server-side-props-wrapper.ts
+++ b/src/helpers/get-server-side-props-wrapper.ts
@@ -1,0 +1,49 @@
+import { GetServerSideProps } from 'next';
+import SessionCache from '../session/cache';
+
+/**
+ * If you're using >=Next 12 and {@link getSession} or {@link getAccessToken} without `withPageAuthRequired`, because
+ * you don't want to require authentication on your route, you might get a warning/error: "You should not access 'res'
+ * after getServerSideProps resolves". You can work around this by wrapping your `getServerSideProps` in
+ * `getServerSidePropsWrapper`, this ensures that the code that accesses `res` will run within
+ * the lifecycle of `getServerSideProps`, avoiding the warning/error eg:
+ *
+ * **NOTE: you do not need to do this if you're already using {@link WithPageAuthRequired}**
+ *
+ * ```js
+ * // pages/protected-page.js
+ * import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+ *
+ * export default function ProtectedPage() {
+ *   return <div>Protected content</div>;
+ * }
+ *
+ * export const getServerSideProps = getServerSidePropsWrapper(async (ctx) => {
+ *   const session = getSession(ctx.req, ctx.res);
+ *   if (session) {
+ *     // Use is authenticated
+ *   } else {
+ *     // User is not authenticated
+ *   }
+ * });
+ * ```
+ *
+ * @category Server
+ */
+export type GetServerSidePropsWrapper = (getServerSideProps: GetServerSideProps) => GetServerSideProps;
+
+/**
+ * @ignore
+ */
+export default function getServerSidePropsWrapperFactory(getSessionCache: () => SessionCache) {
+  return function getServerSidePropsWrapper(getServerSideProps: GetServerSideProps): GetServerSideProps {
+    return function wrappedGetServerSideProps(...args) {
+      const sessionCache = getSessionCache();
+      const [ctx] = args;
+      sessionCache.init(ctx.req, ctx.res, false);
+      const ret = getServerSideProps(...args);
+      sessionCache.save(ctx.req, ctx.res);
+      return ret;
+    };
+  };
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,3 +6,7 @@ export {
   WithPageAuthRequiredOptions,
   PageRoute
 } from './with-page-auth-required';
+export {
+  default as getServerSidePropsWrapperFactory,
+  GetServerSidePropsWrapper
+} from './get-server-side-props-wrapper';

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -62,10 +62,11 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  * });
  * ```
  *
- * If you're using >=Next 12 and {@link getSession} or {@link getAccessToken} without `getServerSideProps`, because you don't want to
- * require authentication on your route, you might get a warning/error: "You should not access 'res' after getServerSideProps resolves".
- * You can work around this by wrapping your `getServerSideProps` in `withPageAuthRequired` using `authRequired: false`, this ensures
- * that the code that accesses `res` will run within the lifecycle of `getServerSideProps`, avoiding the warning/error eg:
+ * If you're using >=Next 12 and {@link getSession} or {@link getAccessToken} without `getServerSideProps`, because you
+ * don't want to require authentication on your route, you might get a warning/error: "You should not access 'res' after
+ * getServerSideProps resolves". You can work around this by wrapping your `getServerSideProps` in
+ * `withPageAuthRequired` using `authRequired: false`, this ensures that the code that accesses `res` will run within
+ * the lifecycle of `getServerSideProps`, avoiding the warning/error eg:
  *
  * ```js
  * // pages/page.js

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -42,6 +42,9 @@ const instance: SignInWithAuth0 = {
   },
   withPageAuthRequired() {
     throw new Error(serverSideOnly('withPageAuthRequired'));
+  },
+  getServerSidePropsWrapper() {
+    throw new Error(serverSideOnly('getServerSidePropsWrapper'));
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,9 @@ import {
   WithPageAuthRequired,
   GetServerSidePropsResultWithSession,
   WithPageAuthRequiredOptions,
-  PageRoute
+  PageRoute,
+  getServerSidePropsWrapperFactory,
+  GetServerSidePropsWrapper
 } from './helpers';
 import { InitAuth0, SignInWithAuth0 } from './instance';
 import version from './version';
@@ -77,6 +79,7 @@ export const _initAuth = (params?: ConfigParameters): SignInWithAuth0 & { sessio
   const getAccessToken = accessTokenFactory(nextConfig, getClient, sessionCache);
   const withApiAuthRequired = withApiAuthRequiredFactory(sessionCache);
   const withPageAuthRequired = withPageAuthRequiredFactory(nextConfig.routes.login, () => sessionCache);
+  const getServerSidePropsWrapper = getServerSidePropsWrapperFactory(() => sessionCache);
   const handleLogin = loginHandler(baseHandleLogin, nextConfig, baseConfig);
   const handleLogout = logoutHandler(baseHandleLogout);
   const handleCallback = callbackHandler(baseHandleCallback, nextConfig);
@@ -89,6 +92,7 @@ export const _initAuth = (params?: ConfigParameters): SignInWithAuth0 & { sessio
     getAccessToken,
     withApiAuthRequired,
     withPageAuthRequired,
+    getServerSidePropsWrapper,
     handleLogin,
     handleLogout,
     handleCallback,
@@ -107,6 +111,7 @@ export const getSession: GetSession = (...args) => getInstance().getSession(...a
 export const getAccessToken: GetAccessToken = (...args) => getInstance().getAccessToken(...args);
 export const withApiAuthRequired: WithApiAuthRequired = (...args) => getInstance().withApiAuthRequired(...args);
 export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSessionCache);
+export const getServerSidePropsWrapper: GetServerSidePropsWrapper = getServerSidePropsWrapperFactory(getSessionCache);
 export const handleLogin: HandleLogin = (...args) => getInstance().handleLogin(...args);
 export const handleLogout: HandleLogout = (...args) => getInstance().handleLogout(...args);
 export const handleCallback: HandleCallback = (...args) => getInstance().handleCallback(...args);
@@ -139,6 +144,7 @@ export {
   PageRoute,
   WithApiAuthRequired,
   WithPageAuthRequired,
+  GetServerSidePropsWrapper,
   SessionCache,
   GetSession,
   GetAccessToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,17 +50,17 @@ import { InitAuth0, SignInWithAuth0 } from './instance';
 import version from './version';
 import { getConfig, getLoginUrl, ConfigParameters } from './config';
 
-let instance: SignInWithAuth0;
+let instance: SignInWithAuth0 & { sessionCache: SessionCache };
 
-function getInstance(): SignInWithAuth0 {
+function getInstance(): SignInWithAuth0 & { sessionCache: SessionCache } {
   if (instance) {
     return instance;
   }
-  instance = initAuth0();
+  instance = _initAuth();
   return instance;
 }
 
-export const initAuth0: InitAuth0 = (params) => {
+export const _initAuth = (params?: ConfigParameters): SignInWithAuth0 & { sessionCache: SessionCache } => {
   const { baseConfig, nextConfig } = getConfig(params);
 
   // Init base layer (with base config)
@@ -76,7 +76,7 @@ export const initAuth0: InitAuth0 = (params) => {
   const getSession = sessionFactory(sessionCache);
   const getAccessToken = accessTokenFactory(nextConfig, getClient, sessionCache);
   const withApiAuthRequired = withApiAuthRequiredFactory(sessionCache);
-  const withPageAuthRequired = withPageAuthRequiredFactory(nextConfig.routes.login, getSession);
+  const withPageAuthRequired = withPageAuthRequiredFactory(nextConfig.routes.login, () => sessionCache);
   const handleLogin = loginHandler(baseHandleLogin, nextConfig, baseConfig);
   const handleLogout = logoutHandler(baseHandleLogout);
   const handleCallback = callbackHandler(baseHandleCallback, nextConfig);
@@ -84,6 +84,7 @@ export const initAuth0: InitAuth0 = (params) => {
   const handleAuth = handlerFactory({ handleLogin, handleLogout, handleCallback, handleProfile });
 
   return {
+    sessionCache,
     getSession,
     getAccessToken,
     withApiAuthRequired,
@@ -96,10 +97,16 @@ export const initAuth0: InitAuth0 = (params) => {
   };
 };
 
+export const initAuth0: InitAuth0 = (params) => {
+  const { sessionCache, ...publicApi } = _initAuth(params);
+  return publicApi;
+};
+
+const getSessionCache = () => getInstance().sessionCache;
 export const getSession: GetSession = (...args) => getInstance().getSession(...args);
 export const getAccessToken: GetAccessToken = (...args) => getInstance().getAccessToken(...args);
 export const withApiAuthRequired: WithApiAuthRequired = (...args) => getInstance().withApiAuthRequired(...args);
-export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSession);
+export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSessionCache);
 export const handleLogin: HandleLogin = (...args) => getInstance().handleLogin(...args);
 export const handleLogout: HandleLogout = (...args) => getInstance().handleLogout(...args);
 export const handleCallback: HandleCallback = (...args) => getInstance().handleCallback(...args);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,5 +1,5 @@
 import { GetSession, GetAccessToken } from './session';
-import { WithApiAuthRequired, WithPageAuthRequired } from './helpers';
+import { GetServerSidePropsWrapper, WithApiAuthRequired, WithPageAuthRequired } from './helpers';
 import { HandleAuth, HandleCallback, HandleLogin, HandleLogout, HandleProfile } from './handlers';
 import { ConfigParameters } from './auth0-session';
 
@@ -52,6 +52,12 @@ export interface SignInWithAuth0 {
    * Helper that adds auth to a Page Route
    */
   withPageAuthRequired: WithPageAuthRequired;
+
+  /**
+   * Wrap `getServerSideProps` to avoid accessing `res` after getServerSideProps resolves,
+   * see {@link GetServerSidePropsWrapper}
+   */
+  getServerSidePropsWrapper: GetServerSidePropsWrapper;
 
   /**
    * Create the main handlers for your api routes

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -30,6 +30,7 @@ export type SetupOptions = {
   discoveryOptions?: Record<string, string>;
   userInfoPayload?: Record<string, string>;
   userInfoToken?: string;
+  asyncProps?: boolean;
 };
 
 export const setup = async (
@@ -44,7 +45,8 @@ export const setup = async (
     getAccessTokenOptions,
     discoveryOptions,
     userInfoPayload = {},
-    userInfoToken = 'eyJz93a...k4laUWw'
+    userInfoToken = 'eyJz93a...k4laUWw',
+    asyncProps
   }: SetupOptions = {}
 ): Promise<string> => {
   discovery(config, discoveryOptions);
@@ -60,7 +62,8 @@ export const setup = async (
     getSession,
     getAccessToken,
     withApiAuthRequired,
-    withPageAuthRequired
+    withPageAuthRequired,
+    getServerSidePropsWrapper
   } = await initAuth0(config);
   (global as any).handleAuth = handleAuth.bind(null, {
     async callback(req, res) {
@@ -102,6 +105,8 @@ export const setup = async (
   (global as any).withPageAuthRequiredCSR = withPageAuthRequired;
   (global as any).getAccessToken = (req: NextApiRequest, res: NextApiResponse): Promise<GetAccessTokenResult> =>
     getAccessToken(req, res, getAccessTokenOptions);
+  (global as any).getServerSidePropsWrapper = getServerSidePropsWrapper;
+  (global as any).asyncProps = asyncProps;
   return start();
 };
 
@@ -114,6 +119,8 @@ export const teardown = async (): Promise<void> => {
   delete (global as any).withPageAuthRequired;
   delete (global as any).withPageAuthRequiredCSR;
   delete (global as any).getAccessToken;
+  delete (global as any).getServerSidePropsWrapper;
+  delete (global as any).asyncProps;
 };
 
 export const login = async (baseUrl: string): Promise<CookieJar> => {

--- a/tests/fixtures/test-app/next-env.d.ts
+++ b/tests/fixtures/test-app/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/tests/fixtures/test-app/pages/protected.tsx
+++ b/tests/fixtures/test-app/pages/protected.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NextPageContext } from 'next';
 
-export default function protectedPage({ user }): React.ReactElement {
+export default function protectedPage({ user }: { user?: { sub: string } }): React.ReactElement {
   return <div>Protected Page {user ? user.sub : ''}</div>;
 }
 

--- a/tests/fixtures/test-app/pages/protected.tsx
+++ b/tests/fixtures/test-app/pages/protected.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { NextPageContext } from 'next';
 
-export default function protectedPage(): React.ReactElement {
-  return <div>Protected Page</div>;
+export default function protectedPage({ user }): React.ReactElement {
+  return <div>Protected Page {user ? user.sub : ''}</div>;
 }
 
 export const getServerSideProps = (ctx: NextPageContext): any => (global as any).withPageAuthRequired()(ctx);

--- a/tests/fixtures/test-app/pages/wrapped-get-server-side-props.tsx
+++ b/tests/fixtures/test-app/pages/wrapped-get-server-side-props.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NextPageContext } from 'next';
+
+export default function wrappedGetServerSidePropsPage({
+  isAuthenticated
+}: {
+  isAuthenticated?: boolean;
+}): React.ReactElement {
+  return <div>isAuthenticated: {String(isAuthenticated)}</div>;
+}
+
+export const getServerSideProps = (_ctx: NextPageContext): any =>
+  (global as any).getServerSidePropsWrapper(async (ctx: NextPageContext) => {
+    const session = (global as any).getSession(ctx.req, ctx.res);
+    const asyncProps = (global as any).asyncProps;
+    const props = { isAuthenticated: !!session };
+    return { props: asyncProps ? Promise.resolve(props) : props };
+  })(_ctx);

--- a/tests/helpers/get-server-side-props-wrapper.test.ts
+++ b/tests/helpers/get-server-side-props-wrapper.test.ts
@@ -1,0 +1,53 @@
+import { login, setup, teardown } from '../fixtures/setup';
+import { withoutApi } from '../fixtures/default-settings';
+import { get } from '../auth0-session/fixtures/helpers';
+
+describe('get-server-side-props-wrapper', () => {
+  afterEach(teardown);
+
+  test('wrap getServerSideProps', async () => {
+    const baseUrl = await setup(withoutApi);
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/wrapped-get-server-side-props', { fullResponse: true });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/isAuthenticated: .*false/);
+  });
+
+  test('wrap getServerSideProps with session', async () => {
+    const baseUrl = await setup(withoutApi);
+    const cookieJar = await login(baseUrl);
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/wrapped-get-server-side-props', { fullResponse: true, cookieJar });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/isAuthenticated: .*true/);
+  });
+
+  test('wrap getServerSideProps with async props', async () => {
+    const baseUrl = await setup(withoutApi, { asyncProps: true });
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/wrapped-get-server-side-props', { fullResponse: true });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/isAuthenticated: .*false/);
+  });
+
+  test('wrap getServerSideProps with async props and session', async () => {
+    const baseUrl = await setup(withoutApi, { asyncProps: true });
+    const cookieJar = await login(baseUrl);
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/wrapped-get-server-side-props', { fullResponse: true, cookieJar });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/isAuthenticated: .*true/);
+  });
+});

--- a/tests/helpers/with-page-auth-required.test.ts
+++ b/tests/helpers/with-page-auth-required.test.ts
@@ -81,17 +81,6 @@ describe('with-page-auth-required ssr', () => {
     expect(url.searchParams.get('returnTo')).toEqual('/foo?bar=baz&qux=quux');
   });
 
-  test('allow access to a page with no auth required', async () => {
-    const baseUrl = await setup(withoutApi, { withPageAuthRequiredOptions: { authRequired: false } });
-
-    const {
-      res: { statusCode },
-      data
-    } = await get(baseUrl, '/protected', { fullResponse: true });
-    expect(statusCode).toBe(200);
-    expect(data).toMatch(/Protected Page/);
-  });
-
   test('allow access to a page with a valid session and async props', async () => {
     const baseUrl = await setup(withoutApi, {
       withPageAuthRequiredOptions: {
@@ -110,23 +99,5 @@ describe('with-page-auth-required ssr', () => {
     expect(data).toMatch(/Protected Page.*__test_sub__/);
     const [cookie] = headers['set-cookie'];
     expect(cookie).toMatch(/^appSession=/);
-  });
-
-  test('allow access to a page with a no auth required and async props', async () => {
-    const baseUrl = await setup(withoutApi, {
-      withPageAuthRequiredOptions: {
-        getServerSideProps() {
-          return Promise.resolve({ props: Promise.resolve({}) });
-        },
-        authRequired: false
-      }
-    });
-
-    const {
-      res: { statusCode },
-      data
-    } = await get(baseUrl, '/protected', { fullResponse: true });
-    expect(statusCode).toBe(200);
-    expect(data).toMatch(/Protected Page/);
   });
 });

--- a/tests/helpers/with-page-auth-required.test.ts
+++ b/tests/helpers/with-page-auth-required.test.ts
@@ -24,7 +24,7 @@ describe('with-page-auth-required ssr', () => {
       data
     } = await get(baseUrl, '/protected', { cookieJar, fullResponse: true });
     expect(statusCode).toBe(200);
-    expect(data).toMatch(/<div>Protected Page<\/div>/);
+    expect(data).toMatch(/Protected Page.*__test_sub__/);
   });
 
   test('accept a custom returnTo url', async () => {
@@ -79,5 +79,54 @@ describe('with-page-auth-required ssr', () => {
     expect(statusCode).toBe(307);
     const url = new URL(headers.location, baseUrl);
     expect(url.searchParams.get('returnTo')).toEqual('/foo?bar=baz&qux=quux');
+  });
+
+  test('allow access to a page with no auth required', async () => {
+    const baseUrl = await setup(withoutApi, { withPageAuthRequiredOptions: { authRequired: false } });
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/protected', { fullResponse: true });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/Protected Page/);
+  });
+
+  test('allow access to a page with a valid session and async props', async () => {
+    const baseUrl = await setup(withoutApi, {
+      withPageAuthRequiredOptions: {
+        getServerSideProps() {
+          return Promise.resolve({ props: Promise.resolve({}) });
+        }
+      }
+    });
+    const cookieJar = await login(baseUrl);
+
+    const {
+      res: { statusCode, headers },
+      data
+    } = await get(baseUrl, '/protected', { cookieJar, fullResponse: true });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/Protected Page.*__test_sub__/);
+    const [cookie] = headers['set-cookie'];
+    expect(cookie).toMatch(/^appSession=/);
+  });
+
+  test('allow access to a page with a no auth required and async props', async () => {
+    const baseUrl = await setup(withoutApi, {
+      withPageAuthRequiredOptions: {
+        getServerSideProps() {
+          return Promise.resolve({ props: Promise.resolve({}) });
+        },
+        authRequired: false
+      }
+    });
+
+    const {
+      res: { statusCode },
+      data
+    } = await get(baseUrl, '/protected', { fullResponse: true });
+    expect(statusCode).toBe(200);
+    expect(data).toMatch(/Protected Page/);
   });
 });

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -32,7 +32,7 @@ describe('SessionCache', () => {
   test('should create the session entry', () => {
     cache.create(req, res, session);
     expect(cache.get(req, res)).toEqual(session);
-    expect(cookieStore.save).toHaveBeenCalledWith(req, res, session);
+    expect(cookieStore.save).toHaveBeenCalledWith(req, res, session, undefined);
   });
 
   test('should delete the session entry', () => {


### PR DESCRIPTION
### Description

Next.js >=12 have started to issue a warning (`You should not access 'res' after getServerSideProps resolves.`), and in some cases an error, when you access the response object after `getServerSideProps` has run.

Because this SDK provides a rolling session by default, it writes to the response at the end of every request. It does this at the end of the request using [on-headers](https://github.com/jshttp/on-headers), which causes the warning because `on-headers` executes after `getServerSideProps` resolves.

We can fix this in `withAuthenticationRequired` by not using `on-headers` and writing to the headers just before `withAuthenticationRequired` completes, eg.

```js
async function withAuthenticationRequired({ getServerSideProps }) {
  session.get(disableOnHeaders=true) // read cookie and disable on-headers
  //  ... existing code ...
  session.save() // write cookie (because on-headers is disabled)
}
``` 

If you want to use `getSession` (and `getAccessToken`) without requiring auth on your route, you'll still need to use the `withAuthenticationRequired` wrapper, but you can do this now with the `authRequired: false` option. eg

```js
export const getServerSideProps = withAuthenticationRequired({
  authRequired: false,
  async getServerSideProps(ctx) {
    const session = getSession(ctx.req, ctx.res);
    if (session) {
      // user is logged in
    } else {
      // user is not logged in
    }
  }
});
```

I also fixed an issue in `withAuthenticationRequired` when `props` is a Promise, eg

```js
function getServerSideProps() {
  return { props: Promise.resolve({}) }
}
```

### References

https://nextjs.org/docs/messages/gssp-no-mutating-res
fixes #524 

### Testing

Run the basic example app and notice that there is no warning when visiting `/protected`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
