### PR TITLE
Add customisation of identityClaimFilter via env var

### DIFF
--- a/docs/interfaces/config.baseconfig.html
+++ b/docs/interfaces/config.baseconfig.html
@@ -336,7 +336,8 @@
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>Array value of claims to remove from the ID token before storing the cookie session.
-							Default is <code>[&#39;aud&#39;, &#39;iss&#39;, &#39;iat&#39;, &#39;exp&#39;, &#39;nbf&#39;, &#39;nonce&#39;, &#39;azp&#39;, &#39;auth_time&#39;, &#39;s_hash&#39;, &#39;at_hash&#39;, &#39;c_hash&#39; ]</code></p>
+							Default is <code>[&#39;aud&#39;, &#39;iss&#39;, &#39;iat&#39;, &#39;exp&#39;, &#39;nbf&#39;, &#39;nonce&#39;, &#39;azp&#39;, &#39;auth_time&#39;, &#39;s_hash&#39;, &#39;at_hash&#39;, &#39;c_hash&#39; ]</code>
+							You can also use the AUTH0_IDENTITY_CLAIM_FILTER environment variable.</p>
 						</div>
 					</div>
 				</section>

--- a/docs/modules/config.html
+++ b/docs/modules/config.html
@@ -140,6 +140,7 @@
 							<li><code>AUTH0_IDP_LOGOUT</code>: See <a href="../interfaces/config.baseconfig.html#idplogout">idpLogout</a></li>
 							<li><code>AUTH0_ID_TOKEN_SIGNING_ALG</code>: See <a href="../interfaces/config.baseconfig.html#idtokensigningalg">idTokenSigningAlg</a></li>
 							<li><code>AUTH0_LEGACY_SAME_SITE_COOKIE</code>: See <a href="../interfaces/config.baseconfig.html#legacysamesitecookie">legacySameSiteCookie</a></li>
+							<li><code>AUTH0_IDENTITY_CLAIM_FILTER</code>: See <a href="../interfaces/config.baseconfig.html#identityclaimfilter">identityClaimFilter</a></li>
 							<li><code>NEXT_PUBLIC_AUTH0_LOGIN</code>: See <a href="../interfaces/config.nextconfig.html#routes">NextConfig.routes</a></li>
 							<li><code>AUTH0_CALLBACK</code>: See <a href="../interfaces/config.baseconfig.html#routes">BaseConfig.routes</a></li>
 							<li><code>AUTH0_POST_LOGOUT_REDIRECT</code>: See <a href="../interfaces/config.baseconfig.html#routes">BaseConfig.routes</a></li>

--- a/src/config.ts
+++ b/src/config.ts
@@ -331,6 +331,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  * - `AUTH0_IDP_LOGOUT`: See {@link idpLogout}
  * - `AUTH0_ID_TOKEN_SIGNING_ALG`: See {@link idTokenSigningAlg}
  * - `AUTH0_LEGACY_SAME_SITE_COOKIE`: See {@link legacySameSiteCookie}
+ * - `AUTH0_IDENTITY_CLAIM_FILTER`: See {@link BaseConfig.identityClaimFilter}
  * - `NEXT_PUBLIC_AUTH0_LOGIN`: See {@link NextConfig.routes}
  * - `AUTH0_CALLBACK`: See {@link BaseConfig.routes}
  * - `AUTH0_POST_LOGOUT_REDIRECT`: See {@link BaseConfig.routes}
@@ -400,6 +401,12 @@ const num = (param?: string): number | undefined => (param === undefined || para
 /**
  * @ignore
  */
+const array = (param?: string): string[] | undefined =>
+  param === undefined || param === '' ? undefined : param.replace(/\s/g, '').split(',');
+
+/**
+ * @ignore
+ */
 export const getLoginUrl = (): string => {
   return process.env.NEXT_PUBLIC_AUTH0_LOGIN || '/api/auth/login';
 };
@@ -420,6 +427,7 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   const AUTH0_IDP_LOGOUT = process.env.AUTH0_IDP_LOGOUT;
   const AUTH0_ID_TOKEN_SIGNING_ALG = process.env.AUTH0_ID_TOKEN_SIGNING_ALG;
   const AUTH0_LEGACY_SAME_SITE_COOKIE = process.env.AUTH0_LEGACY_SAME_SITE_COOKIE;
+  const AUTH0_IDENTITY_CLAIM_FILTER = process.env.AUTH0_IDENTITY_CLAIM_FILTER;
   const AUTH0_CALLBACK = process.env.AUTH0_CALLBACK;
   const AUTH0_POST_LOGOUT_REDIRECT = process.env.AUTH0_POST_LOGOUT_REDIRECT;
   const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
@@ -454,6 +462,7 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
     auth0Logout: bool(AUTH0_IDP_LOGOUT, true),
     idTokenSigningAlg: AUTH0_ID_TOKEN_SIGNING_ALG,
     legacySameSiteCookie: bool(AUTH0_LEGACY_SAME_SITE_COOKIE),
+    identityClaimFilter: array(AUTH0_IDENTITY_CLAIM_FILTER),
     ...baseParams,
     authorizationParams: {
       response_type: 'code',

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,7 @@ export interface BaseConfig {
   /**
    * Array value of claims to remove from the ID token before storing the cookie session.
    * Default is `['aud', 'iss', 'iat', 'exp', 'nbf', 'nonce', 'azp', 'auth_time', 's_hash', 'at_hash', 'c_hash' ]`
+   * You can also use the AUTH0_IDENTITY_CLAIM_FILTER environment variable.
    */
   identityClaimFilter: string[];
 
@@ -331,7 +332,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  * - `AUTH0_IDP_LOGOUT`: See {@link idpLogout}
  * - `AUTH0_ID_TOKEN_SIGNING_ALG`: See {@link idTokenSigningAlg}
  * - `AUTH0_LEGACY_SAME_SITE_COOKIE`: See {@link legacySameSiteCookie}
- * - `AUTH0_IDENTITY_CLAIM_FILTER`: See {@link BaseConfig.identityClaimFilter}
+ * - `AUTH0_IDENTITY_CLAIM_FILTER`: See {@link identityClaimFilter}
  * - `NEXT_PUBLIC_AUTH0_LOGIN`: See {@link NextConfig.routes}
  * - `AUTH0_CALLBACK`: See {@link BaseConfig.routes}
  * - `AUTH0_POST_LOGOUT_REDIRECT`: See {@link BaseConfig.routes}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -159,7 +159,7 @@ describe('config params', () => {
   test('should populate arrays', () => {
     expect(
       getConfigWithEnv({
-        AUTH0_IDENTITY_CLAIM_FILTER: 'claim1,claim2,claim3',
+        AUTH0_IDENTITY_CLAIM_FILTER: 'claim1,claim2,claim3'
       }).baseConfig
     ).toMatchObject({
       identityClaimFilter: ['claim1', 'claim2', 'claim3']

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -156,6 +156,16 @@ describe('config params', () => {
     });
   });
 
+  test('should populate arrays', () => {
+    expect(
+      getConfigWithEnv({
+        AUTH0_IDENTITY_CLAIM_FILTER: 'claim1,claim2,claim3',
+      }).baseConfig
+    ).toMatchObject({
+      identityClaimFilter: ['claim1', 'claim2', 'claim3']
+    });
+  });
+
   test('passed in arguments should take precedence', () => {
     const { baseConfig, nextConfig } = getConfigWithEnv(
       {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add the ability to configure identityClaimFilter via an environment variable (AUTH0_IDENTITY_CLAIM_FILTER). This is specifically required to expose the auth_time claim which is filtered by default.

### References

This PR resolves https://github.com/auth0/nextjs-auth0/issues/677

### Testing

An additional test case has been created populating identityClaimFilter with an array of strings from the AUTH0_IDENTITY_CLAIM_FILTER environment variable containing a comma delimited string

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
