### PR TITLE
Native Organization Invitation Support

### DIFF
--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -7,6 +7,7 @@ import { encodeState } from '../hooks/get-login-state';
 import { ClientFactory } from '../client';
 import createDebug from '../utils/debug';
 import { htmlSafe } from '../../utils/errors';
+import { URLSearchParams } from 'url';
 
 const debug = createDebug('handlers');
 
@@ -32,10 +33,19 @@ export default function loginHandlerFactory(
       ...options
     };
 
+    // Ensure that the organization invitation query parameter carries on to the authorization URL
+    const parsedUrl = new URLSearchParams(req.url);
+    const organizationInvitationParams = {
+      invitation: opts.authorizationParams?.invitation || parsedUrl.get('invitation'),
+      organization: opts.authorizationParams?.organization || parsedUrl.get('organization'),
+      organization_name: opts.authorizationParams?.organization_name || parsedUrl.get('organization_name')
+    };
+
     // Ensure a redirect_uri, merge in configuration options, then passed-in options.
     opts.authorizationParams = {
       redirect_uri: getRedirectUri(config),
       ...config.authorizationParams,
+      ...organizationInvitationParams,
       ...(opts.authorizationParams || {})
     };
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The organization feature has been rolled out for quite some time now and there isn't any native support for it in the /api/auth/login endpoint.

This means that there is an inherent difference between the organization invitation you can generate from the Auth0 dashboard and the expected implementation in this SDK.

This PR adds native support for organization invitations by adding the invitation, organization and organization_name query params to the /authorize endpoint when provided to the /api/auth/login endpoint.

### References
https://github.com/auth0/nextjs-auth0/issues/701

### Testing
This can be tested by sending an invitation from the Auth0 console to the default login url and accepting the following invitation.
If the login UI is themed according to the inviting organization, the change worked.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
