### PR TITLE
Add Props and Query to GetServerSidePropsWrapper type

### DIFF
--- a/src/helpers/get-server-side-props-wrapper.ts
+++ b/src/helpers/get-server-side-props-wrapper.ts
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import { ParsedUrlQuery } from 'querystring';
 import SessionCache from '../session/cache';
 
 /**
@@ -30,7 +31,9 @@ import SessionCache from '../session/cache';
  *
  * @category Server
  */
-export type GetServerSidePropsWrapper = (getServerSideProps: GetServerSideProps) => GetServerSideProps;
+export type GetServerSidePropsWrapper<P = any, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
+  getServerSideProps: GetServerSideProps<P, Q>
+) => GetServerSideProps<P, Q>;
 
 /**
  * @ignore


### PR DESCRIPTION
### Description

So you can specify the props and type for `GetServerSideProps`

```typescript
const getPropsExample: GetServerSideProps<{ roles: string[] }, { userId: string }> = async (ctx) => {
  console.log(res.query.userId);
  return { props: { roles: ['foo'] } };
};
```

### References

fixes #675
