### PR TITLE
Improve errors [SDK-3552]

### DIFF
--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -4,7 +4,7 @@ import { AuthorizationParameters, HandleCallback as BaseHandleCallback } from '.
 import { Session } from '../session';
 import { assertReqRes } from '../utils/assert';
 import { NextConfig } from '../config';
-import { HandlerError } from '../utils/errors';
+import { CallbackHandlerError, HandlerErrorCause } from '../utils/errors';
 
 /**
  * Use this function for validating additional claims on the user's ID Token or adding removing items from
@@ -139,7 +139,7 @@ export default function handleCallbackFactory(handler: BaseHandleCallback, confi
         afterCallback: idTokenValidator(options.afterCallback, options.organization || config.organization)
       });
     } catch (e) {
-      throw new HandlerError(e);
+      throw new CallbackHandlerError(e as HandlerErrorCause);
     }
   };
 }

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -3,7 +3,7 @@ import { AuthorizationParameters, HandleLogin as BaseHandleLogin } from '../auth
 import toSafeRedirect from '../utils/url-helpers';
 import { assertReqRes } from '../utils/assert';
 import { BaseConfig, NextConfig } from '../config';
-import { HandlerError } from '../utils/errors';
+import { HandlerErrorCause, LoginHandlerError } from '../utils/errors';
 
 /**
  * Use this to store additional state for the user before they visit the Identity Provider to login.
@@ -142,7 +142,7 @@ export default function handleLoginFactory(
 
       return await handler(req, res, options);
     } catch (e) {
-      throw new HandlerError(e);
+      throw new LoginHandlerError(e as HandlerErrorCause);
     }
   };
 }

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -1,7 +1,7 @@
 import { NextApiResponse, NextApiRequest } from 'next';
 import { HandleLogout as BaseHandleLogout } from '../auth0-session';
 import { assertReqRes } from '../utils/assert';
-import { HandlerError } from '../utils/errors';
+import { HandlerErrorCause, LogoutHandlerError } from '../utils/errors';
 
 /**
  * Custom options to pass to logout.
@@ -34,7 +34,7 @@ export default function handleLogoutFactory(handler: BaseHandleLogout): HandleLo
       assertReqRes(req, res);
       return await handler(req, res, options);
     } catch (e) {
-      throw new HandlerError(e);
+      throw new LogoutHandlerError(e as HandlerErrorCause);
     }
   };
 }

--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -2,7 +2,7 @@ import { NextApiResponse, NextApiRequest } from 'next';
 import { ClientFactory } from '../auth0-session';
 import { SessionCache, Session, fromJson, GetAccessToken } from '../session';
 import { assertReqRes } from '../utils/assert';
-import { HandlerError } from '../utils/errors';
+import { ProfileHandlerError, HandlerErrorCause } from '../utils/errors';
 
 export type AfterRefetch = (req: NextApiRequest, res: NextApiResponse, session: Session) => Promise<Session> | Session;
 
@@ -85,7 +85,7 @@ export default function profileHandler(
 
       res.json(session.user);
     } catch (e) {
-      throw new HandlerError(e);
+      throw new ProfileHandlerError(e as HandlerErrorCause);
     }
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,16 @@ export {
   WithPageAuthRequiredProps
 } from './frontend';
 
-export { AccessTokenError, HandlerError } from './utils/errors';
+export {
+  AuthError,
+  AccessTokenErrorCode,
+  AccessTokenError,
+  HandlerError,
+  CallbackHandlerError,
+  LoginHandlerError,
+  LogoutHandlerError,
+  ProfileHandlerError
+} from './utils/errors';
 
 export {
   ConfigParameters,

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -95,11 +95,14 @@ export default function accessTokenFactory(
   return async (req, res, accessTokenRequest): Promise<GetAccessTokenResult> => {
     let session = sessionCache.get(req, res);
     if (!session) {
-      throw new AccessTokenError(AccessTokenErrorCode.NO_SESSION, 'The user does not have a valid session.');
+      throw new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, 'The user does not have a valid session.');
     }
 
     if (!session.accessToken && !session.refreshToken) {
-      throw new AccessTokenError(AccessTokenErrorCode.NO_ACCESS_TOKEN, 'The user does not have a valid access token.');
+      throw new AccessTokenError(
+        AccessTokenErrorCode.MISSING_ACCESS_TOKEN,
+        'The user does not have a valid access token.'
+      );
     }
 
     if (!session.accessTokenExpiresAt) {
@@ -141,7 +144,7 @@ export default function accessTokenFactory(
 
     if (accessTokenRequest?.refresh && !session.refreshToken) {
       throw new AccessTokenError(
-        AccessTokenErrorCode.NO_REFRESH_TOKEN,
+        AccessTokenErrorCode.MISSING_REFRESH_TOKEN,
         'A refresh token is required to refresh the access token, but none is present.'
       );
     }
@@ -181,7 +184,10 @@ export default function accessTokenFactory(
 
     // We don't have an access token.
     if (!session.accessToken) {
-      throw new AccessTokenError(AccessTokenErrorCode.NO_ACCESS_TOKEN, 'The user does not have a valid access token.');
+      throw new AccessTokenError(
+        AccessTokenErrorCode.MISSING_ACCESS_TOKEN,
+        'The user does not have a valid access token.'
+      );
     }
 
     // The access token is not expired and has sufficient scopes;

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { ClientFactory } from '../auth0-session';
-import { AccessTokenError } from '../utils/errors';
+import { AccessTokenError, AccessTokenErrorCode } from '../utils/errors';
 import { intersect, match } from '../utils/array';
 import { Session, SessionCache, fromTokenSet } from '../session';
 import { AuthorizationParameters, NextConfig } from '../config';
@@ -95,16 +95,16 @@ export default function accessTokenFactory(
   return async (req, res, accessTokenRequest): Promise<GetAccessTokenResult> => {
     let session = sessionCache.get(req, res);
     if (!session) {
-      throw new AccessTokenError('invalid_session', 'The user does not have a valid session.');
+      throw new AccessTokenError(AccessTokenErrorCode.NO_SESSION, 'The user does not have a valid session.');
     }
 
     if (!session.accessToken && !session.refreshToken) {
-      throw new AccessTokenError('invalid_session', 'The user does not have a valid access token.');
+      throw new AccessTokenError(AccessTokenErrorCode.NO_ACCESS_TOKEN, 'The user does not have a valid access token.');
     }
 
     if (!session.accessTokenExpiresAt) {
       throw new AccessTokenError(
-        'access_token_expired',
+        AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN,
         'Expiration information for the access token is not available. The user will need to sign in again.'
       );
     }
@@ -113,7 +113,7 @@ export default function accessTokenFactory(
       const persistedScopes = session.accessTokenScope;
       if (!persistedScopes || persistedScopes.length === 0) {
         throw new AccessTokenError(
-          'insufficient_scope',
+          AccessTokenErrorCode.INSUFFICIENT_SCOPE,
           'An access token with the requested scopes could not be provided. The user will need to sign in again.'
         );
       }
@@ -121,7 +121,7 @@ export default function accessTokenFactory(
       const matchingScopes = intersect(accessTokenRequest.scopes, persistedScopes.split(' '));
       if (!match(accessTokenRequest.scopes, [...matchingScopes])) {
         throw new AccessTokenError(
-          'insufficient_scope',
+          AccessTokenErrorCode.INSUFFICIENT_SCOPE,
           `Could not retrieve an access token with scopes "${accessTokenRequest.scopes.join(
             ' '
           )}". The user will need to sign in again.`
@@ -134,14 +134,14 @@ export default function accessTokenFactory(
     // Adding a skew of 1 minute to compensate.
     if (!session.refreshToken && session.accessTokenExpiresAt * 1000 - 60000 < Date.now()) {
       throw new AccessTokenError(
-        'access_token_expired',
+        AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN,
         'The access token expired and a refresh token is not available. The user will need to sign in again.'
       );
     }
 
     if (accessTokenRequest?.refresh && !session.refreshToken) {
       throw new AccessTokenError(
-        'no_refresh_token',
+        AccessTokenErrorCode.NO_REFRESH_TOKEN,
         'A refresh token is required to refresh the access token, but none is present.'
       );
     }
@@ -159,6 +159,7 @@ export default function accessTokenFactory(
       });
 
       // Update the session.
+      // WARNING: THIS THROWS
       const newSession = fromTokenSet(tokenSet, config);
       Object.assign(session, {
         ...newSession,
@@ -180,7 +181,7 @@ export default function accessTokenFactory(
 
     // We don't have an access token.
     if (!session.accessToken) {
-      throw new AccessTokenError('invalid_session', 'The user does not have a valid access token.');
+      throw new AccessTokenError(AccessTokenErrorCode.NO_ACCESS_TOKEN, 'The user does not have a valid access token.');
     }
 
     // The access token is not expired and has sufficient scopes;

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -162,7 +162,6 @@ export default function accessTokenFactory(
       });
 
       // Update the session.
-      // WARNING: THIS THROWS
       const newSession = fromTokenSet(tokenSet, config);
       Object.assign(session, {
         ...newSession,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,22 @@
 import { HttpError } from 'http-errors';
 
+// eslint-disable-next-line max-len
+// Basic escaping for putting untrusted data directly into the HTML body, per: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content
+export function htmlSafe(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function appendCause(errorMessage: string, cause?: Error): string {
+  if (!cause) return errorMessage;
+  const separator = errorMessage.endsWith('.') ? '' : '.';
+  return `${errorMessage}${separator} CAUSE: ${htmlSafe(cause.message)}`;
+}
+
 type AuthErrorOptions = {
   code: string;
   message: string;
@@ -14,6 +31,7 @@ export abstract class AuthError extends Error {
   public readonly cause?: Error;
   public readonly status?: number;
 
+  /* istanbul ignore next */
   constructor(options: AuthErrorOptions) {
     super(appendCause(options.message, options.cause));
     this.code = options.code;
@@ -47,23 +65,6 @@ export class AccessTokenError extends AuthError {
   }
 }
 
-// eslint-disable-next-line max-len
-// Basic escaping for putting untrusted data directly into the HTML body, per: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content
-export function htmlSafe(input: string): string {
-  return input
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-export function appendCause(errorMessage: string, cause?: Error): string {
-  if (!cause) return errorMessage;
-  const separator = errorMessage.endsWith('.') ? '' : '.';
-  return `${errorMessage}${separator} CAUSE: ${htmlSafe(cause.message)}`;
-}
-
 export type HandlerErrorCause = Error | AuthError | HttpError;
 
 type HandlerErrorOptions = {
@@ -88,11 +89,7 @@ export class HandlerError extends AuthError {
   /* istanbul ignore next */
   constructor(options: HandlerErrorOptions) {
     let status: number | undefined;
-
-    if ('status' in options.cause) {
-      status = options.cause.status;
-    }
-
+    if ('status' in options.cause) status = options.cause.status;
     super({ ...options, status });
   }
 }
@@ -101,12 +98,12 @@ export class CallbackHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_CALLBACK_HANDLER_FAILURE';
 
   /* istanbul ignore next */
-  constructor(error: HandlerErrorCause) {
+  constructor(cause: HandlerErrorCause) {
     super({
       code: CallbackHandlerError.code,
       message: 'Callback handler failed.',
       name: 'CallbackHandlerError',
-      cause: error
+      cause
     });
     Object.setPrototypeOf(this, CallbackHandlerError.prototype);
   }
@@ -116,12 +113,12 @@ export class LoginHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_LOGIN_HANDLER_FAILURE';
 
   /* istanbul ignore next */
-  constructor(error: HandlerErrorCause) {
+  constructor(cause: HandlerErrorCause) {
     super({
       code: LoginHandlerError.code,
       message: 'Login handler failed.',
       name: 'LoginHandlerError',
-      cause: error
+      cause
     });
     Object.setPrototypeOf(this, LoginHandlerError.prototype);
   }
@@ -131,12 +128,12 @@ export class LogoutHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_LOGOUT_HANDLER_FAILURE';
 
   /* istanbul ignore next */
-  constructor(error: HandlerErrorCause) {
+  constructor(cause: HandlerErrorCause) {
     super({
       code: LogoutHandlerError.code,
       message: 'Logout handler failed.',
       name: 'LogoutHandlerError',
-      cause: error
+      cause
     });
     Object.setPrototypeOf(this, LogoutHandlerError.prototype);
   }
@@ -146,12 +143,12 @@ export class ProfileHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_PROFILE_HANDLER_FAILURE';
 
   /* istanbul ignore next */
-  constructor(error: HandlerErrorCause) {
+  constructor(cause: HandlerErrorCause) {
     super({
       code: ProfileHandlerError.code,
       message: 'Profile handler failed.',
       name: 'ProfileHandlerError',
-      cause: error
+      cause
     });
     Object.setPrototypeOf(this, ProfileHandlerError.prototype);
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -11,6 +11,9 @@ export function htmlSafe(input: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * @ignore
+ */
 export function appendCause(errorMessage: string, cause?: Error): string {
   if (!cause) return errorMessage;
   const separator = errorMessage.endsWith('.') ? '' : '.';
@@ -25,10 +28,43 @@ type AuthErrorOptions = {
   status?: number;
 };
 
+/**
+ * The base class for all SDK errors.
+ *
+ * Because part of the error message can come from the OpenID Connect `error` query parameter we
+ * do some basic escaping which makes sure the default error handler is safe from XSS.
+ *
+ * If you write your own error handler, you should **not** render the error message
+ * without using a templating engine that will properly escape it for other HTML contexts first.
+ *
+ * Note that the error message of the {@link AuthError.cause | underlying error} is **not** escaped
+ * in any way, so do **not** render it without escaping it first!
+ *
+ * @category Server
+ */
 export abstract class AuthError extends Error {
+  /**
+   * A machine-readable error code that remains stable within a major version of the SDK. You
+   * should rely on this error code to handle errors. In contrast, the error message is not part of
+   * the API and can change anytime. Do **not** parse or otherwise rely on the error message to
+   * handle errors.
+   */
   public readonly code: string;
+
+  /**
+   * The error class name.
+   */
   public readonly name: string;
+
+  /**
+   * The underlying error, if any. The error message of this underlying error is **not** escaped in
+   * any way, so do **not** render it without escaping it first!
+   */
   public readonly cause?: Error;
+
+  /**
+   * The HTTP status code, if any.
+   */
   public readonly status?: number;
 
   /* istanbul ignore next */
@@ -41,6 +77,11 @@ export abstract class AuthError extends Error {
   }
 }
 
+/**
+ * Error codes for {@link AccessTokenError}.
+ *
+ * @category Server
+ */
 export enum AccessTokenErrorCode {
   MISSING_SESSION = 'ERR_MISSING_SESSION',
   MISSING_ACCESS_TOKEN = 'ERR_MISSING_ACCESS_TOKEN',
@@ -50,7 +91,14 @@ export enum AccessTokenErrorCode {
 }
 
 /**
- * The error thrown by {@link GetAccessToken}
+ * The error thrown by {@link GetAccessToken}.
+ *
+ * @see the {@link AuthError.code | code property} contains a machine-readable error code that
+ * remains stable within a major version of the SDK. You should rely on this error code to handle
+ * errors. In contrast, the error message is not part of the API and can change anytime. Do **not**
+ * parse or otherwise rely on the error message to handle errors.
+ *
+ * @see {@link AccessTokenErrorCode} for the list of all possible error codes.
  *
  * @category Server
  */
@@ -65,6 +113,9 @@ export class AccessTokenError extends AuthError {
   }
 }
 
+/**
+ * @ignore
+ */
 export type HandlerErrorCause = Error | AuthError | HttpError;
 
 type HandlerErrorOptions = {
@@ -75,13 +126,20 @@ type HandlerErrorOptions = {
 };
 
 /**
- * The error thrown by API route handlers.
+ * The base class for errors thrown by API route handlers. It extends {@link AuthError}.
  *
- * Because the error message can come from the OpenID Connect `error` query parameter we
+ * Because part of the error message can come from the OpenID Connect `error` query parameter we
  * do some basic escaping which makes sure the default error handler is safe from XSS.
  *
  * If you write your own error handler, you should **not** render the error message
  * without using a templating engine that will properly escape it for other HTML contexts first.
+ *
+ * @see the {@link AuthError.cause | cause property} contains the underlying error.
+ * The error message of this underlying error is **not** escaped in any way, so do **not** render
+ * it without escaping it first!
+ *
+ * @see the {@link AuthError.status | status property} contains the HTTP status code of the error,
+ * if any.
  *
  * @category Server
  */
@@ -94,6 +152,24 @@ export class HandlerError extends AuthError {
   }
 }
 
+/**
+ * The error thrown by the callback API route handler. It extends {@link HandlerError}.
+ *
+ * Because part of the error message can come from the OpenID Connect `error` query parameter we
+ * do some basic escaping which makes sure the default error handler is safe from XSS.
+ *
+ * If you write your own error handler, you should **not** render the error message
+ * without using a templating engine that will properly escape it for other HTML contexts first.
+ *
+ * @see the {@link AuthError.cause | cause property} contains the underlying error.
+ * The error message of this underlying error is **not** escaped in any way, so do **not** render
+ * it without escaping it first!
+ *
+ * @see the {@link AuthError.status | status property} contains the HTTP status code of the error,
+ * if any.
+ *
+ * @category Server
+ */
 export class CallbackHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_CALLBACK_HANDLER_FAILURE';
 
@@ -109,6 +185,12 @@ export class CallbackHandlerError extends HandlerError {
   }
 }
 
+/**
+ * The error thrown by the login API route handler. It extends {@link HandlerError}.
+ *
+ * @see the {@link AuthError.cause | cause property} contains the underlying error.
+ * @category Server
+ */
 export class LoginHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_LOGIN_HANDLER_FAILURE';
 
@@ -124,6 +206,12 @@ export class LoginHandlerError extends HandlerError {
   }
 }
 
+/**
+ * The error thrown by the logout API route handler. It extends {@link HandlerError}.
+ *
+ * @see the {@link AuthError.cause | cause property} contains the underlying error.
+ * @category Server
+ */
 export class LogoutHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_LOGOUT_HANDLER_FAILURE';
 
@@ -139,6 +227,12 @@ export class LogoutHandlerError extends HandlerError {
   }
 }
 
+/**
+ * The error thrown by the profile API route handler. It extends {@link HandlerError}.
+ *
+ * @see the {@link AuthError.cause | cause property} contains the underlying error.
+ * @category Server
+ */
 export class ProfileHandlerError extends HandlerError {
   public static readonly code: string = 'ERR_PROFILE_HANDLER_FAILURE';
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -24,9 +24,9 @@ export abstract class AuthError extends Error {
 }
 
 export enum AccessTokenErrorCode {
-  NO_SESSION = 'ERR_NO_SESSION',
-  NO_ACCESS_TOKEN = 'ERR_NO_ACCESS_TOKEN',
-  NO_REFRESH_TOKEN = 'ERR_NO_REFRESH_TOKEN',
+  MISSING_SESSION = 'ERR_MISSING_SESSION',
+  MISSING_ACCESS_TOKEN = 'ERR_MISSING_ACCESS_TOKEN',
+  MISSING_REFRESH_TOKEN = 'ERR_MISSING_REFRESH_TOKEN',
   EXPIRED_ACCESS_TOKEN = 'ERR_EXPIRED_ACCESS_TOKEN',
   INSUFFICIENT_SCOPE = 'ERR_INSUFFICIENT_SCOPE'
 }
@@ -64,6 +64,15 @@ export function appendCause(errorMessage: string, cause?: Error): string {
   return `${errorMessage}${separator} CAUSE: ${htmlSafe(cause.message)}`;
 }
 
+export type HandlerErrorCause = Error | AuthError | HttpError;
+
+type HandlerErrorOptions = {
+  code: string;
+  message: string;
+  name: string;
+  cause: HandlerErrorCause;
+};
+
 /**
  * The error thrown by API route handlers.
  *
@@ -76,23 +85,74 @@ export function appendCause(errorMessage: string, cause?: Error): string {
  * @category Server
  */
 export class HandlerError extends AuthError {
-  public static readonly code: string = 'ERR_HANDLER_FAILURE';
-
   /* istanbul ignore next */
-  constructor(error: Error | AuthError | HttpError) {
+  constructor(options: HandlerErrorOptions) {
     let status: number | undefined;
 
-    if ('status' in error) {
-      status = error.status;
+    if ('status' in options.cause) {
+      status = options.cause.status;
     }
 
+    super({ ...options, status });
+  }
+}
+
+export class CallbackHandlerError extends HandlerError {
+  public static readonly code: string = 'ERR_CALLBACK_HANDLER_FAILURE';
+
+  /* istanbul ignore next */
+  constructor(error: HandlerErrorCause) {
     super({
-      code: HandlerError.code,
-      message: 'API route handler failed.',
-      name: 'HandlerError',
-      cause: error,
-      status
+      code: CallbackHandlerError.code,
+      message: 'Callback handler failed.',
+      name: 'CallbackHandlerError',
+      cause: error
     });
-    Object.setPrototypeOf(this, HandlerError.prototype);
+    Object.setPrototypeOf(this, CallbackHandlerError.prototype);
+  }
+}
+
+export class LoginHandlerError extends HandlerError {
+  public static readonly code: string = 'ERR_LOGIN_HANDLER_FAILURE';
+
+  /* istanbul ignore next */
+  constructor(error: HandlerErrorCause) {
+    super({
+      code: LoginHandlerError.code,
+      message: 'Login handler failed.',
+      name: 'LoginHandlerError',
+      cause: error
+    });
+    Object.setPrototypeOf(this, LoginHandlerError.prototype);
+  }
+}
+
+export class LogoutHandlerError extends HandlerError {
+  public static readonly code: string = 'ERR_LOGOUT_HANDLER_FAILURE';
+
+  /* istanbul ignore next */
+  constructor(error: HandlerErrorCause) {
+    super({
+      code: LogoutHandlerError.code,
+      message: 'Logout handler failed.',
+      name: 'LogoutHandlerError',
+      cause: error
+    });
+    Object.setPrototypeOf(this, LogoutHandlerError.prototype);
+  }
+}
+
+export class ProfileHandlerError extends HandlerError {
+  public static readonly code: string = 'ERR_PROFILE_HANDLER_FAILURE';
+
+  /* istanbul ignore next */
+  constructor(error: HandlerErrorCause) {
+    super({
+      code: ProfileHandlerError.code,
+      message: 'Profile handler failed.',
+      name: 'ProfileHandlerError',
+      cause: error
+    });
+    Object.setPrototypeOf(this, ProfileHandlerError.prototype);
   }
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -99,7 +99,6 @@ export enum AccessTokenErrorCode {
  * parse or otherwise rely on the error message to handle errors.
  *
  * @see {@link AccessTokenErrorCode} for the list of all possible error codes.
- *
  * @category Server
  */
 export class AccessTokenError extends AuthError {

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -282,7 +282,7 @@ describe('login handler', () => {
     });
   });
 
-  test('should escape html in errors', async () => {
+  test('should escape html in error message', async () => {
     const baseUrl = await setup(withoutApi, { discoveryOptions: { error: '<script>alert("xss")</script>' } });
 
     await expect(get(baseUrl, '/api/auth/login', { fullResponse: true })).rejects.toThrow(

--- a/tests/handlers/logout.test.ts
+++ b/tests/handlers/logout.test.ts
@@ -104,6 +104,8 @@ describe('logout handler', () => {
 
     const res = await fetch(`${baseUrl}/api/auth/logout?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
-    expect(await res.text()).toEqual('&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;');
+    expect(await res.text()).toEqual(
+      'API route handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
+    );
   });
 });

--- a/tests/handlers/logout.test.ts
+++ b/tests/handlers/logout.test.ts
@@ -104,8 +104,6 @@ describe('logout handler', () => {
 
     const res = await fetch(`${baseUrl}/api/auth/logout?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
-    expect(await res.text()).toEqual(
-      'API route handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
-    );
+    expect(await res.text()).toEqual('Logout handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;');
   });
 });

--- a/tests/handlers/logout.test.ts
+++ b/tests/handlers/logout.test.ts
@@ -99,9 +99,8 @@ describe('logout handler', () => {
     });
   });
 
-  test('should escape html in errors', async () => {
+  test('should escape html in error message', async () => {
     const baseUrl = await setup(withoutApi);
-
     const res = await fetch(`${baseUrl}/api/auth/logout?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
     expect(await res.text()).toEqual('Logout handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;');

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -160,7 +160,7 @@ describe('profile handler', () => {
     const res = await fetch(`${baseUrl}/api/auth/me?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
     expect(await res.text()).toEqual(
-      'API route handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
+      'Profile handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
     );
   });
 });

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -159,6 +159,8 @@ describe('profile handler', () => {
 
     const res = await fetch(`${baseUrl}/api/auth/me?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
-    expect(await res.text()).toEqual('&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;');
+    expect(await res.text()).toEqual(
+      'API route handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
+    );
   });
 });

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -154,9 +154,8 @@ describe('profile handler', () => {
     await expect(get(baseUrl, '/api/auth/me', { cookieJar })).rejects.toThrowError('some validation error');
   });
 
-  test('should escape html in errors', async () => {
+  test('should escape html in error message', async () => {
     const baseUrl = await setup(withoutApi);
-
     const res = await fetch(`${baseUrl}/api/auth/me?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
 
     expect(await res.text()).toEqual(

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,8 +1,8 @@
-import { AccessTokenError, HandlerError } from '../../src/utils/errors';
+import { AccessTokenError, AccessTokenErrorCode, HandlerError } from '../../src/utils/errors';
 
 describe('errors', () => {
   test('should be instance of themselves', () => {
-    expect(new AccessTokenError('code', 'message')).toBeInstanceOf(AccessTokenError);
+    expect(new AccessTokenError(AccessTokenErrorCode.NO_SESSION, 'message')).toBeInstanceOf(AccessTokenError);
     expect(new HandlerError(new Error('message'))).toBeInstanceOf(HandlerError);
   });
 });

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,8 +1,35 @@
-import { AccessTokenError, AccessTokenErrorCode, HandlerError } from '../../src/utils/errors';
+import {
+  AccessTokenError,
+  AccessTokenErrorCode,
+  AuthError,
+  CallbackHandlerError,
+  HandlerError,
+  LoginHandlerError,
+  LogoutHandlerError,
+  ProfileHandlerError
+} from '../../src/utils/errors';
 
 describe('errors', () => {
   test('should be instance of themselves', () => {
-    expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, 'message')).toBeInstanceOf(AccessTokenError);
-    expect(new HandlerError(new Error('message'))).toBeInstanceOf(HandlerError);
+    expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, '')).toBeInstanceOf(AccessTokenError);
+    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(CallbackHandlerError);
+    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(LoginHandlerError);
+    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(LogoutHandlerError);
+    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(ProfileHandlerError);
+  });
+
+  test('should be instance of AuthError', () => {
+    expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, '')).toBeInstanceOf(AuthError);
+    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(AuthError);
+    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(AuthError);
+    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(AuthError);
+    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(AuthError);
+  });
+
+  test('should be instance of HandlerError', () => {
+    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
+    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
+    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
+    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
   });
 });

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -1,6 +1,7 @@
 import {
   AccessTokenError,
   AccessTokenErrorCode,
+  appendCause,
   AuthError,
   CallbackHandlerError,
   HandlerError,
@@ -9,27 +10,181 @@ import {
   ProfileHandlerError
 } from '../../src/utils/errors';
 
-describe('errors', () => {
-  test('should be instance of themselves', () => {
+describe('appendCause', () => {
+  test('should append the cause error message', () => {
+    const message = 'foo';
+    const cause = new Error('bar');
+
+    expect(appendCause(message, cause)).toEqual(`${message}. CAUSE: ${cause.message}`);
+  });
+
+  test('should escape the cause error message', () => {
+    const message = 'foo';
+    const cause = new Error('&<>"\'');
+
+    expect(appendCause(message, cause)).toEqual(`${message}. CAUSE: &amp;&lt;&gt;&quot;&#39;`);
+  });
+
+  test('should not add a period if there is one already', () => {
+    const message = 'foo.';
+    const cause = new Error('bar');
+
+    expect(appendCause(message, cause)).toEqual(`${message} CAUSE: ${cause.message}`);
+  });
+
+  test('should return the error message when there is no cause', () => {
+    const message = 'foo';
+
+    expect(appendCause(message, undefined)).toEqual(message);
+  });
+});
+
+describe('AccessTokenError', () => {
+  test('should be instance of itself', () => {
     expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, '')).toBeInstanceOf(AccessTokenError);
-    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(CallbackHandlerError);
-    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(LoginHandlerError);
-    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(LogoutHandlerError);
-    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(ProfileHandlerError);
   });
 
   test('should be instance of AuthError', () => {
     expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, '')).toBeInstanceOf(AuthError);
-    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(AuthError);
-    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(AuthError);
-    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(AuthError);
-    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(AuthError);
+  });
+
+  test('should set all properties', () => {
+    const message = 'foo';
+    const error = new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, message);
+
+    expect(error.code).toEqual(AccessTokenErrorCode.MISSING_SESSION);
+    expect(error.message).toEqual(message);
+    expect(error.name).toEqual('AccessTokenError');
+    expect(error.cause).toBeUndefined();
+    expect(error.status).toBeUndefined();
+  });
+});
+
+describe('HandlerError', () => {
+  test('should not be instance of itself', () => {
+    expect(new HandlerError({ code: '', message: '', name: '', cause: new Error() })).not.toBeInstanceOf(HandlerError);
+  });
+
+  test('should set all required properties', () => {
+    const code = 'foo';
+    const message = 'bar';
+    const name = 'baz';
+    const cause = new Error('qux');
+    const error = new HandlerError({ code, message, name, cause });
+
+    expect(error.code).toEqual(code);
+    expect(error.message).toEqual(`${message}. CAUSE: ${cause.message}`);
+    expect(error.name).toEqual(name);
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toBeUndefined();
+  });
+
+  test('should set status', () => {
+    const cause: Error & { status?: number } = new Error();
+    cause.status = 400;
+    const error = new HandlerError({ code: '', message: '', name: '', cause });
+
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toEqual(cause.status);
+  });
+});
+
+describe('CallbackHandlerError', () => {
+  test('should be instance of itself', () => {
+    expect(new CallbackHandlerError(new Error())).toBeInstanceOf(CallbackHandlerError);
   });
 
   test('should be instance of HandlerError', () => {
-    expect(new CallbackHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
-    expect(new LoginHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
-    expect(new LogoutHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
-    expect(new ProfileHandlerError(new Error(''))).toBeInstanceOf(HandlerError);
+    expect(new CallbackHandlerError(new Error())).toBeInstanceOf(HandlerError);
+  });
+
+  test('should be instance of AuthError', () => {
+    expect(new CallbackHandlerError(new Error())).toBeInstanceOf(AuthError);
+  });
+
+  test('should set all properties', () => {
+    const cause = new Error('foo');
+    const error = new CallbackHandlerError(cause);
+
+    expect(error.code).toEqual(CallbackHandlerError.code);
+    expect(error.message).toEqual(`Callback handler failed. CAUSE: ${cause.message}`);
+    expect(error.name).toEqual('CallbackHandlerError');
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toBeUndefined();
+  });
+});
+
+describe('LoginHandlerError', () => {
+  test('should be instance of itself', () => {
+    expect(new LoginHandlerError(new Error())).toBeInstanceOf(LoginHandlerError);
+  });
+
+  test('should be instance of HandlerError', () => {
+    expect(new LoginHandlerError(new Error())).toBeInstanceOf(HandlerError);
+  });
+
+  test('should be instance of AuthError', () => {
+    expect(new LoginHandlerError(new Error())).toBeInstanceOf(AuthError);
+  });
+
+  test('should set all properties', () => {
+    const cause = new Error('foo');
+    const error = new LoginHandlerError(cause);
+
+    expect(error.code).toEqual(LoginHandlerError.code);
+    expect(error.message).toEqual(`Login handler failed. CAUSE: ${cause.message}`);
+    expect(error.name).toEqual('LoginHandlerError');
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toBeUndefined();
+  });
+});
+
+describe('LogoutHandlerError', () => {
+  test('should be instance of itself', () => {
+    expect(new LogoutHandlerError(new Error())).toBeInstanceOf(LogoutHandlerError);
+  });
+
+  test('should be instance of HandlerError', () => {
+    expect(new LogoutHandlerError(new Error())).toBeInstanceOf(HandlerError);
+  });
+
+  test('should be instance of AuthError', () => {
+    expect(new LogoutHandlerError(new Error())).toBeInstanceOf(AuthError);
+  });
+
+  test('should set all properties', () => {
+    const cause = new Error('foo');
+    const error = new LogoutHandlerError(cause);
+
+    expect(error.code).toEqual(LogoutHandlerError.code);
+    expect(error.message).toEqual(`Logout handler failed. CAUSE: ${cause.message}`);
+    expect(error.name).toEqual('LogoutHandlerError');
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toBeUndefined();
+  });
+});
+
+describe('ProfileHandlerError', () => {
+  test('should be instance of itself', () => {
+    expect(new ProfileHandlerError(new Error())).toBeInstanceOf(ProfileHandlerError);
+  });
+
+  test('should be instance of HandlerError', () => {
+    expect(new ProfileHandlerError(new Error())).toBeInstanceOf(HandlerError);
+  });
+
+  test('should be instance of AuthError', () => {
+    expect(new ProfileHandlerError(new Error())).toBeInstanceOf(AuthError);
+  });
+
+  test('should set all properties', () => {
+    const cause = new Error('foo');
+    const error = new ProfileHandlerError(cause);
+
+    expect(error.code).toEqual(ProfileHandlerError.code);
+    expect(error.message).toEqual(`Profile handler failed. CAUSE: ${cause.message}`);
+    expect(error.name).toEqual('ProfileHandlerError');
+    expect(error.cause).toEqual(cause);
+    expect(error.status).toBeUndefined();
   });
 });

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -50,9 +50,9 @@ describe('AccessTokenError', () => {
 
   test('should set all properties', () => {
     const message = 'foo';
-    const error = new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, message);
+    const error = new AccessTokenError(AccessTokenErrorCode.MISSING_ACCESS_TOKEN, message);
 
-    expect(error.code).toEqual(AccessTokenErrorCode.MISSING_SESSION);
+    expect(error.code).toEqual(AccessTokenErrorCode.MISSING_ACCESS_TOKEN);
     expect(error.message).toEqual(message);
     expect(error.name).toEqual('AccessTokenError');
     expect(error.cause).toBeUndefined();

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -2,7 +2,7 @@ import { AccessTokenError, AccessTokenErrorCode, HandlerError } from '../../src/
 
 describe('errors', () => {
   test('should be instance of themselves', () => {
-    expect(new AccessTokenError(AccessTokenErrorCode.NO_SESSION, 'message')).toBeInstanceOf(AccessTokenError);
+    expect(new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, 'message')).toBeInstanceOf(AccessTokenError);
     expect(new HandlerError(new Error('message'))).toBeInstanceOf(HandlerError);
   });
 });


### PR DESCRIPTION
⚠️ **This PR contains breaking changes**

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR reworks the SDK errors to:

1. Improve error handling.
2. Set up a base that better accommodates typed errors. Individual error classes for specific common errors are not included in this PR, but are very simple to add.

#### Underlying errors
Now, SDK errors can inherit from the base `AuthError`, which contains a `cause?` property for an underlying error. This way, errors can wrap another error simply by populating this property. The message of the 'wrapped' error will be automatically appended to the message of the 'wrapper' error (and labeled accordingly), which makes it easily discoverable and actionable by the developer.

#### Error codes
SDK errors that inherit from `AuthError` will need to specify a machine-readable `code`. Developers can rely on error codes to identify specific errors. Unlike error messages, codes are part of the SDK API and will remain stable within a major version of the SDK. The error codes follow the `ERR_SOMETHING` Node.js convention.

#### Error names
SDK errors that inherit from `AuthError` will need to specify a value for the `name` property (typically the error class name). This value will show up when printing an error with `console.log(error)`, making it easier for the developer to identify the error.

#### API handler-specific errors
Before, `HandlerError` was the single catch-all error for all errors produced by an API handler. Now every handler has its own error:
- `CallbackHandlerError` for the errors of the callback handler
- `LoginHandlerError` for the errors of the login handler
- `LogoutHandlerError` for the errors of the logout handler
- `ProfileHandlerError` for the errors of the profile handler

This makes it possible for handler-specific errors to feature handler-specific codes. The end result is that every handler will only throw errors of a single type, with a machine-readable code, and a single wrapped error. Which greatly simplifies error handling.