### PR TITLE
Add testing utility for generating session cookies [SDK-3569]

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "files": [
     "dist",
     "src",
-    "testing.js"
+    "testing.js",
+    "testing.d.ts"
   ],
   "engines": {
     "node": "^10.13.0 || >=12.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "testing.js"
   ],
   "engines": {
     "node": "^10.13.0 || >=12.0.0"

--- a/src/auth0-session/cookie-store.ts
+++ b/src/auth0-session/cookie-store.ts
@@ -46,7 +46,7 @@ export default class CookieStore {
     return this.keys;
   }
 
-  private async encrypt(payload: jose.JWTPayload, { iat, uat, exp }: Header): Promise<string> {
+  public async encrypt(payload: jose.JWTPayload, { iat, uat, exp }: Header): Promise<string> {
     const [key] = await this.getKeys();
     return await new jose.EncryptJWT({ ...payload }).setProtectedHeader({ alg, enc, uat, iat, exp }).encrypt(key);
   }

--- a/src/helpers/testing.ts
+++ b/src/helpers/testing.ts
@@ -1,39 +1,7 @@
 import { Config as BaseConfig, CookieStore } from '../auth0-session';
-import { CookieConfig } from '../config';
 import { Session } from '../session';
+import { GenerateSessionCookieConfig } from '../../testing';
 
-/**
- * Configuration parameters used by ({@link generateSessionCookie}.
- */
-export type GenerateSessionCookieConfig = {
-  /**
-   * The secret used to derive an encryption key for the session cookie.
-   *
-   * **IMPORTANT**: you must use the same value as in the SDK configuration.
-   * See {@link ConfigParameters.secret}.
-   */
-  secret: string;
-
-  /**
-   * Integer value, in seconds, used as the duration of the session cookie.
-   * Defaults to `604800` seconds (7 days).
-   */
-  duration?: number;
-} & Partial<CookieConfig>;
-
-/**
- * Generates an encrypted session cookie that can be used to mock the Auth0
- * authentication flow in e2e tests.
- *
- * **IMPORTANT**: this utility can only run in Node.js, **not in the browser**.
- * For example, if you're using [Cypress](https://www.cypress.io/), you can
- * wrap it in a [task](https://docs.cypress.io/api/commands/task) and then
- * invoke the task from a test or a custom command.
- *
- * @param {Session} session The user's session.
- * @param {GenerateSessionCookieConfig} config Configuration parameters for the session cookie.
- * @return {String}
- */
 export const generateSessionCookie = async (
   session: Partial<Session>,
   config: GenerateSessionCookieConfig

--- a/src/helpers/testing.ts
+++ b/src/helpers/testing.ts
@@ -1,0 +1,47 @@
+import { Config as BaseConfig, CookieStore } from '../auth0-session';
+import { CookieConfig } from '../config';
+import { Session } from '../session';
+
+/**
+ * Configuration parameters used by ({@link generateSessionCookie}.
+ */
+export type GenerateSessionCookieConfig = {
+  /**
+   * The secret used to derive an encryption key for the session cookie.
+   *
+   * **IMPORTANT**: you must use the same value as in the SDK configuration.
+   * See {@link ConfigParameters.secret}.
+   */
+  secret: string;
+
+  /**
+   * Integer value, in seconds, used as the duration of the session cookie.
+   * Defaults to `604800` seconds (7 days).
+   */
+  duration?: number;
+} & Partial<CookieConfig>;
+
+/**
+ * Generates an encrypted session cookie that can be used to mock the Auth0
+ * authentication flow in e2e tests.
+ *
+ * **IMPORTANT**: this utility can only run in Node.js, **not in the browser**.
+ * For example, if you're using [Cypress](https://www.cypress.io/), you can
+ * wrap it in a [task](https://docs.cypress.io/api/commands/task) and then
+ * invoke the task from a test or a custom command.
+ *
+ * @param {Session} session The user's session.
+ * @param {GenerateSessionCookieConfig} config Configuration parameters for the session cookie.
+ * @return {String}
+ */
+export const generateSessionCookie = async (
+  session: Partial<Session>,
+  config: GenerateSessionCookieConfig
+): Promise<string> => {
+  const weekInSeconds = 7 * 24 * 60 * 60;
+  const { secret, duration: absoluteDuration = weekInSeconds, ...cookie } = config;
+  const cookieStoreConfig = { secret, session: { absoluteDuration, cookie } };
+  const cookieStore = new CookieStore(cookieStoreConfig as BaseConfig);
+  const epoch = (Date.now() / 1000) | 0;
+  return cookieStore.encrypt(session, { iat: epoch, uat: epoch, exp: epoch + absoluteDuration });
+};

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -24,7 +24,7 @@ export type GenerateSessionCookieConfig = {
  * Generates an encrypted session cookie that can be used to mock the Auth0
  * authentication flow in e2e tests.
  *
- * **IMPORTANT**: this utility can only run in Node.js, **not in the browser**.
+ * **IMPORTANT**: this utility can only run on Node.js, **not on the browser**.
  * For example, if you're using [Cypress](https://www.cypress.io/), you can
  * wrap it in a [task](https://docs.cypress.io/api/commands/task) and then
  * invoke the task from a test or a custom command.

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -1,0 +1,39 @@
+import type { CookieConfig } from './dist/config';
+import type { Session } from './dist/session';
+
+/**
+ * Configuration parameters used by ({@link generateSessionCookie}.
+ */
+export type GenerateSessionCookieConfig = {
+  /**
+   * The secret used to derive an encryption key for the session cookie.
+   *
+   * **IMPORTANT**: you must use the same value as in the SDK configuration.
+   * See {@link ConfigParameters.secret}.
+   */
+  secret: string;
+
+  /**
+   * Integer value, in seconds, used as the duration of the session cookie.
+   * Defaults to `604800` seconds (7 days).
+   */
+  duration?: number;
+} & Partial<CookieConfig>;
+
+/**
+ * Generates an encrypted session cookie that can be used to mock the Auth0
+ * authentication flow in e2e tests.
+ *
+ * **IMPORTANT**: this utility can only run in Node.js, **not in the browser**.
+ * For example, if you're using [Cypress](https://www.cypress.io/), you can
+ * wrap it in a [task](https://docs.cypress.io/api/commands/task) and then
+ * invoke the task from a test or a custom command.
+ *
+ * @param {Session} session The user's session.
+ * @param {GenerateSessionCookieConfig} config Configuration parameters for the session cookie.
+ * @return {String}
+ */
+export declare function generateSessionCookie(
+  session: Partial<Session>,
+  config: GenerateSessionCookieConfig
+): Promise<string>;

--- a/testing.js
+++ b/testing.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/helpers/testing');

--- a/tests/helpers/testing.test.ts
+++ b/tests/helpers/testing.test.ts
@@ -1,0 +1,79 @@
+import CookieStore from '../../src/auth0-session/cookie-store';
+import { generateSessionCookie } from '../../src/helpers/testing';
+
+jest.mock('../../src/auth0-session/cookie-store');
+
+const encryptMock = jest.spyOn(CookieStore.prototype, 'encrypt');
+const weekInSeconds = 7 * 24 * 60 * 60;
+
+describe('generate-session-cookie', () => {
+  test('use the provided secret', async () => {
+    await generateSessionCookie({}, { secret: '__test_secret__' });
+    expect(CookieStore).toHaveBeenCalledWith(expect.objectContaining({ secret: '__test_secret__' }));
+  });
+
+  test('use the default session configuration values', async () => {
+    await generateSessionCookie({}, { secret: '' });
+    expect(CookieStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: { absoluteDuration: weekInSeconds, cookie: {} }
+      })
+    );
+  });
+
+  test('use the provided session configuration values', async () => {
+    await generateSessionCookie(
+      {},
+      {
+        secret: '',
+        duration: 1000,
+        domain: '__test_domain__',
+        path: '__test_path__',
+        transient: true,
+        httpOnly: false,
+        secure: false,
+        sameSite: 'none'
+      }
+    );
+    expect(CookieStore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: {
+          absoluteDuration: 1000,
+          cookie: {
+            domain: '__test_domain__',
+            path: '__test_path__',
+            transient: true,
+            httpOnly: false,
+            secure: false,
+            sameSite: 'none'
+          }
+        }
+      })
+    );
+  });
+
+  test('use the provided session', async () => {
+    await generateSessionCookie({ user: { foo: 'bar' } }, { secret: '' });
+    expect(encryptMock).toHaveBeenCalledWith({ user: { foo: 'bar' } }, expect.anything());
+  });
+
+  test('use the current time for the header values', async () => {
+    const now = Date.now();
+    const current = (now / 1000) | 0;
+    const clock = jest.useFakeTimers('modern');
+    clock.setSystemTime(now);
+    await generateSessionCookie({}, { secret: '' });
+    expect(encryptMock).toHaveBeenCalledWith(expect.anything(), {
+      iat: current,
+      uat: current,
+      exp: current + weekInSeconds
+    });
+    clock.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('return the encrypted cookie', async () => {
+    encryptMock.mockResolvedValueOnce('foo');
+    expect(generateSessionCookie({}, { secret: '' })).resolves.toBe('foo');
+  });
+});


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds a the `generateSessionCookie` helper function for generating session cookies, which can be used to mock the Auth0 authentication flow in e2e tests.

#### Cypress Example

`generateSessionCookie` can only run on Node.js, not on the browser, so it must be wrapped in a Cypress [task](https://docs.cypress.io/api/commands/task):

```ts
/// <reference types="cypress" />

import { Session } from '../../node_modules/@auth0/nextjs-auth0';
import { generateSessionCookie, GenerateSessionCookieConfig } from '../../node_modules/@auth0/nextjs-auth0/testing';

module.exports = (on: any) => {
  on('task', {
    getSessionCookie(params: { session: Session; config: GenerateSessionCookieConfig }) {
      const { session, config } = params;
      return generateSessionCookie(session, config);
    }
  });
};
```

That task can be invoked from a custom command:

```ts
/// <reference types="cypress" />

const cookieName = 'appSession';

Cypress.Commands.add('login', (email: string, password: string) => {
  const tokenEndpoint = `${Cypress.env('AUTH0_ISSUER_BASE_URL')}oauth/token`;
  const clientId = Cypress.env('AUTH0_CLIENT_ID');
  const clientSecret = Cypress.env('AUTH0_CLIENT_SECRET');
  const audience = Cypress.env('AUTH0_AUDIENCE');
  const scope = Cypress.env('AUTH0_SCOPE');
  const cookieSecret = Cypress.env('AUTH0_SECRET');

  const options = {
    body: {
      client_id: clientId,
      client_secret: clientSecret,
      audience: audience,
      scope,
      username: email,
      password,
      grant_type: 'http://auth0.com/oauth/grant-type/password-realm',
      realm: 'Username-Password-Authentication'
    },
    headers: {
      'Content-Type': 'application/json'
    },
    method: 'POST',
    url: tokenEndpoint
  };

  // Use the Resource Owner Password Flow to get the test user's access token
  cy.request(options).then(async ({ body }) => {
    const { access_token: accessToken } = body;

    // Invoke the task
    cy.task('getSessionCookie', {
      session: { accessToken, user: { email } },
      config: { secret: cookieSecret }
    }).then((cookie) => {
      // Set the cookie
      cy.setCookie(cookieName, cookie as string);
    });
  });
});

Cypress.Commands.add('logout', () => {
  cy.clearCookie(cookieName);
});
```

Then, this custom command can be used on test suites to log the test user in:

```ts
before(() => {
  cy.login(EMAIL, PASSWORD);
  cy.visit('/');
});

after(() => {
  cy.logout();
});
```

### 📎 References

Fixes https://github.com/auth0/nextjs-auth0/issues/335 https://github.com/auth0/nextjs-auth0/issues/548

### 🎯 Testing

Besides adding unit tests, the changes were tested manually on the [sample app](https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01):

<img width="448" alt="Screen Shot 2022-09-10 at 02 37 38" src="https://user-images.githubusercontent.com/5055789/189470827-3bec75cc-726d-40ba-b1f9-c3f930f9162a.png">