### PR TITLE
Fix intermittent build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start:basic": "npm run dev --prefix=examples/basic-example",
     "start:kitchen-sink": "npm run dev --prefix=examples/kitchen-sink-example",
     "start:kitchen-sink-local": "npm run dev:local --prefix=examples/kitchen-sink-example",
-    "test": "jest tests --coverage --maxWorkers=10",
+    "test": "jest tests --coverage --maxWorkers=4",
     "test:watch": "jest --coverage --watch",
     "test:kitchen-sink": "start-server-and-test start:kitchen-sink http-get://localhost:3000 cypress:run",
     "test:kitchen-sink:watch": "start-server-and-test start:kitchen-sink 3000 cypress:open",


### PR DESCRIPTION
Reducing `maxWorkers` stopped it failing intermittently when I tested on SSH
