### PR TITLE
[SDK-3559] Default error handler

### DIFF
--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -7,6 +7,7 @@ Guide to migrating from `1.x` to `2.x`
 - [`getServerSidePropsWrapper` has been removed](#getserversidepropswrapper-has-been-removed)
 - [Profile API route no longer returns a 401](#profile-api-route-no-longer-returns-a-401)
 - [The ID token is no longer stored by default](#the-id-token-is-no-longer-stored-by-default)
+- [Override default error handler](#override-default-error-handler)
 
 ## `getSession` now returns a `Promise`
 
@@ -113,3 +114,45 @@ Previously the ID token would be stored in the session cookie, making the cookie
 Now the SDK will not store it by default. If you had been using hooks to strip it away, you can safely remove those.
 
 You can choose to store it by setting either the `session.storeIDToken` config property or the `AUTH0_SESSION_STORE_ID_TOKEN` environment variable to `true`.
+
+## Override default error handler
+
+You can now set the default error handler for the auth routes in a single place.
+
+```js
+export default handleAuth({
+  async login(req, res) {
+    try {
+      await handleLogin(req, res);
+    } catch (error) {
+      errorLogger(error);
+      res.status(error.status || 500).end();
+    }
+  },
+  async callback(req, res) {
+    try {
+      await handleLogin(req, res);
+    } catch (error) {
+      errorLogger(error);
+      res.status(error.status || 500).end();
+    }
+  }
+  // ...
+});
+```
+
+### After
+
+```js
+export default handleAuth({
+  onError(req, res, error) {
+    errorLogger(error);
+    // You can finish the response yourself if you want to customise
+    // the status code or redirect the user
+    // res.writeHead(302, {
+    //     Location: '/cusotm-error-page'
+    // });
+    // res.end();
+  }
+});
+```

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -147,10 +147,10 @@ export default handleAuth({
 export default handleAuth({
   onError(req, res, error) {
     errorLogger(error);
-    // You can finish the response yourself if you want to customise
+    // You can finish the response yourself if you want to customize
     // the status code or redirect the user
     // res.writeHead(302, {
-    //     Location: '/cusotm-error-page'
+    //     Location: '/custom-error-page'
     // });
     // res.end();
   }

--- a/examples/kitchen-sink-example/pages/api/auth/[auth0].ts
+++ b/examples/kitchen-sink-example/pages/api/auth/[auth0].ts
@@ -1,3 +1,8 @@
 import { handleAuth } from '@auth0/nextjs-auth0';
 
-export default handleAuth();
+export default handleAuth({
+  onError(req, res, error) {
+    console.error(error);
+    res.status(error.status || 500).end('Check the console for the error');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
       "!<rootDir>/src/index.ts",
       "!<rootDir>/src/middleware.ts",
       "!<rootDir>/src/instance.ts",
-      "!<rootDir>/src/handlers/auth.ts",
       "!<rootDir>/src/auth0-session/config.ts",
       "!<rootDir>/src/auth0-session/index.ts",
       "!<rootDir>/src/auth0-session/session-cache.ts"

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,4 +2,4 @@ export { default as callbackHandler, HandleCallback, CallbackOptions, AfterCallb
 export { default as loginHandler, HandleLogin, LoginOptions, GetLoginState } from './login';
 export { default as logoutHandler, HandleLogout, LogoutOptions } from './logout';
 export { default as profileHandler, HandleProfile, ProfileOptions, AfterRefetch } from './profile';
-export { default as handlerFactory, Handlers, HandleAuth } from './auth';
+export { default as handlerFactory, Handlers, HandleAuth, OnError } from './auth';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ import {
   ProfileOptions,
   CallbackOptions,
   AfterCallback,
-  AfterRefetch
+  AfterRefetch,
+  OnError
 } from './handlers';
 import {
   sessionFactory,
@@ -166,5 +167,6 @@ export {
   AfterRefetch,
   LoginOptions,
   LogoutOptions,
-  GetLoginState
+  GetLoginState,
+  OnError
 };

--- a/tests/fixtures/global.d.ts
+++ b/tests/fixtures/global.d.ts
@@ -1,0 +1,17 @@
+declare global {
+  namespace NodeJS {
+    interface Global {
+      getSession?: Function;
+      updateUser?: Function;
+      handleAuth?: Function;
+      withApiAuthRequired?: Function;
+      withPageAuthRequired?: Function;
+      withPageAuthRequiredCSR?: Function;
+      getAccessToken?: Function;
+      asyncProps?: boolean;
+      onError?: Function;
+    }
+  }
+}
+
+export {};

--- a/tests/fixtures/test-app/pages/api/access-token.ts
+++ b/tests/fixtures/test-app/pages/api/access-token.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function accessTokenHandler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   try {
-    const json = await (global as any).getAccessToken(req, res);
+    const json = await global.getAccessToken(req, res);
     res.status(200).json(json);
   } catch (error) {
     res.statusMessage = error.message;

--- a/tests/fixtures/test-app/pages/api/access-token.ts
+++ b/tests/fixtures/test-app/pages/api/access-token.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function accessTokenHandler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   try {
-    const json = await global.getAccessToken(req, res);
+    const json = await global.getAccessToken?.(req, res);
     res.status(200).json(json);
   } catch (error) {
     res.statusMessage = error.message;

--- a/tests/fixtures/test-app/pages/api/auth/[...auth0].ts
+++ b/tests/fixtures/test-app/pages/api/auth/[...auth0].ts
@@ -1,1 +1,1 @@
-export default (...args) => global.handleAuth()(...args);
+export default (...args: any) => global.handleAuth?.()(...args);

--- a/tests/fixtures/test-app/pages/api/auth/[...auth0].ts
+++ b/tests/fixtures/test-app/pages/api/auth/[...auth0].ts
@@ -1,1 +1,1 @@
-export default (global as any).handleAuth();
+export default (...args) => global.handleAuth()(...args);

--- a/tests/fixtures/test-app/pages/api/protected.ts
+++ b/tests/fixtures/test-app/pages/api/protected.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-export default global.withApiAuthRequired(function protectedApiRoute(_req: NextApiRequest, res: NextApiResponse) {
+export default global.withApiAuthRequired?.(function protectedApiRoute(_req: NextApiRequest, res: NextApiResponse) {
   res.status(200).json({ foo: 'bar' });
 });

--- a/tests/fixtures/test-app/pages/api/protected.ts
+++ b/tests/fixtures/test-app/pages/api/protected.ts
@@ -1,8 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-export default (global as any).withApiAuthRequired(function protectedApiRoute(
-  _req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default global.withApiAuthRequired(function protectedApiRoute(_req: NextApiRequest, res: NextApiResponse) {
   res.status(200).json({ foo: 'bar' });
 });

--- a/tests/fixtures/test-app/pages/api/session.ts
+++ b/tests/fixtures/test-app/pages/api/session.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function sessionHandler(req: NextApiRequest, res: NextApiResponse) {
-  const json = await global.getSession(req, res);
+  const json = await global.getSession?.(req, res);
   res.status(200).json(json);
 }

--- a/tests/fixtures/test-app/pages/api/session.ts
+++ b/tests/fixtures/test-app/pages/api/session.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function sessionHandler(req: NextApiRequest, res: NextApiResponse) {
-  const json = await (global as any).getSession(req, res);
+  const json = await global.getSession(req, res);
   res.status(200).json(json);
 }

--- a/tests/fixtures/test-app/pages/api/update-user.ts
+++ b/tests/fixtures/test-app/pages/api/update-user.ts
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function sessionHandler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await global.getSession(req, res);
+  const session = await global.getSession?.(req, res);
   const updated = { ...session?.user, ...req.body?.user };
-  await global.updateUser(req, res, updated);
+  await global.updateUser?.(req, res, updated);
   res.status(200).json(updated);
 }

--- a/tests/fixtures/test-app/pages/api/update-user.ts
+++ b/tests/fixtures/test-app/pages/api/update-user.ts
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function sessionHandler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await (global as any).getSession(req, res);
+  const session = await global.getSession(req, res);
   const updated = { ...session?.user, ...req.body?.user };
-  await (global as any).updateUser(req, res, updated);
+  await global.updateUser(req, res, updated);
   res.status(200).json(updated);
 }

--- a/tests/fixtures/test-app/pages/csr-protected.tsx
+++ b/tests/fixtures/test-app/pages/csr-protected.tsx
@@ -3,7 +3,7 @@ import { NextPageContext } from 'next';
 
 // eslint-disable-next-line react/prop-types
 export default function protectedPage(): React.ReactElement {
-  return global.withPageAuthRequiredCSR(() => <div>Protected Page</div>);
+  return global.withPageAuthRequiredCSR?.(() => <div>Protected Page</div>);
 }
 
-export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired()(ctx);
+export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired?.()(ctx);

--- a/tests/fixtures/test-app/pages/csr-protected.tsx
+++ b/tests/fixtures/test-app/pages/csr-protected.tsx
@@ -3,7 +3,7 @@ import { NextPageContext } from 'next';
 
 // eslint-disable-next-line react/prop-types
 export default function protectedPage(): React.ReactElement {
-  return (global as any).withPageAuthRequiredCSR(() => <div>Protected Page</div>);
+  return global.withPageAuthRequiredCSR(() => <div>Protected Page</div>);
 }
 
-export const getServerSideProps = (ctx: NextPageContext): any => (global as any).withPageAuthRequired()(ctx);
+export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired()(ctx);

--- a/tests/fixtures/test-app/pages/global.d.ts
+++ b/tests/fixtures/test-app/pages/global.d.ts
@@ -1,0 +1,1 @@
+import '../../global';

--- a/tests/fixtures/test-app/pages/protected.tsx
+++ b/tests/fixtures/test-app/pages/protected.tsx
@@ -5,4 +5,4 @@ export default function protectedPage({ user }: { user?: { sub: string } }): Rea
   return <div>Protected Page {user ? user.sub : ''}</div>;
 }
 
-export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired()(ctx);
+export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired?.()(ctx);

--- a/tests/fixtures/test-app/pages/protected.tsx
+++ b/tests/fixtures/test-app/pages/protected.tsx
@@ -5,4 +5,4 @@ export default function protectedPage({ user }: { user?: { sub: string } }): Rea
   return <div>Protected Page {user ? user.sub : ''}</div>;
 }
 
-export const getServerSideProps = (ctx: NextPageContext): any => (global as any).withPageAuthRequired()(ctx);
+export const getServerSideProps = (ctx: NextPageContext): any => global.withPageAuthRequired()(ctx);

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -1,0 +1,70 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { ArgumentsOf } from 'ts-jest';
+import { withoutApi } from '../fixtures/default-settings';
+import { setup, teardown } from '../fixtures/setup';
+import { get } from '../auth0-session/fixtures/helpers';
+import { initAuth0, OnError } from '../../src';
+
+const handlerError = (status = 400, error = 'foo', error_description = 'bar') =>
+  expect.objectContaining({
+    status,
+    cause: expect.objectContaining({ error, error_description })
+  });
+
+describe('auth handler', () => {
+  afterEach(teardown);
+
+  test('accept custom error handler', async () => {
+    const onError = jest.fn<void, ArgumentsOf<OnError>>((_req, res) => res.end());
+    const baseUrl = await setup(withoutApi, { onError });
+    await get(baseUrl, '/api/auth/callback?error=foo&error_description=bar');
+    expect(onError).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), handlerError());
+  });
+
+  test('use default error handler', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
+    delete global.onError;
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(get(baseUrl, '/api/auth/callback?error=foo&error_description=bar')).rejects.toThrow('Bad Request');
+    expect(console.error).toHaveBeenCalledWith(new Error('Callback handler failed. CAUSE: foo (bar)'));
+  });
+
+  test('finish response if custom error does not', async () => {
+    const onError = jest.fn();
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth.bind(null, { onError });
+    await expect(
+      get(baseUrl, '/api/auth/callback?error=foo&error_description=bar', { fullResponse: true })
+    ).rejects.toThrow('Internal Server Error');
+    expect(onError).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), handlerError());
+  });
+
+  test('finish response with custom error status', async () => {
+    const onError = jest.fn<void, ArgumentsOf<OnError>>((_req, res) => res.status(418));
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth.bind(null, { onError });
+    await expect(
+      get(baseUrl, '/api/auth/callback?error=foo&error_description=bar', { fullResponse: true })
+    ).rejects.toThrow("I'm a Teapot");
+    expect(onError).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), handlerError());
+  });
+
+  test('return 500 for unexpected error', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
+    delete global.onError;
+    jest.spyOn(console, 'error').mockImplementation((error) => {
+      delete error.status;
+    });
+    await expect(get(baseUrl, '/api/auth/callback?error=foo&error_description=bar')).rejects.toThrow(
+      'Internal Server Error'
+    );
+  });
+
+  test('return 404 for unknown routes', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
+    await expect(get(baseUrl, '/api/auth/foo')).rejects.toThrow('Not Found');
+  });
+});

--- a/tests/handlers/logout.test.ts
+++ b/tests/handlers/logout.test.ts
@@ -1,18 +1,8 @@
 import { parse } from 'cookie';
-import { parse as parseUrl, URL } from 'url';
+import { parse as parseUrl } from 'url';
 import { withoutApi } from '../fixtures/default-settings';
 import { get } from '../auth0-session/fixtures/helpers';
 import { setup, teardown, login } from '../fixtures/setup';
-import { IncomingMessage } from 'http';
-
-jest.mock('../../src/utils/assert', () => ({
-  assertReqRes(req: IncomingMessage) {
-    if (req.url?.includes('error=')) {
-      const url = new URL(req.url, 'http://example.com');
-      throw new Error(url.searchParams.get('error') as string);
-    }
-  }
-}));
 
 describe('logout handler', () => {
   afterEach(teardown);
@@ -98,12 +88,5 @@ describe('logout handler', () => {
       'Max-Age': '0',
       Path: '/'
     });
-  });
-
-  test('should escape html in error message', async () => {
-    const baseUrl = await setup(withoutApi);
-    const res = await fetch(`${baseUrl}/api/auth/logout?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
-
-    expect(await res.text()).toEqual('Logout handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;');
   });
 });

--- a/tests/handlers/profile.test.ts
+++ b/tests/handlers/profile.test.ts
@@ -5,17 +5,6 @@ import { get } from '../auth0-session/fixtures/helpers';
 import { setup, teardown, login } from '../fixtures/setup';
 import { Session, AfterCallback } from '../../src';
 import { makeIdToken } from '../auth0-session/fixtures/cert';
-import { IncomingMessage } from 'http';
-import { URL } from 'url';
-
-jest.mock('../../src/utils/assert', () => ({
-  assertReqRes(req: IncomingMessage) {
-    if (req.url?.includes('error=')) {
-      const url = new URL(req.url, 'http://example.com');
-      throw new Error(url.searchParams.get('error') as string);
-    }
-  }
-}));
 
 describe('profile handler', () => {
   afterEach(teardown);
@@ -152,14 +141,5 @@ describe('profile handler', () => {
     const cookieJar = await login(baseUrl);
 
     await expect(get(baseUrl, '/api/auth/me', { cookieJar })).rejects.toThrowError('some validation error');
-  });
-
-  test('should escape html in error message', async () => {
-    const baseUrl = await setup(withoutApi);
-    const res = await fetch(`${baseUrl}/api/auth/me?error=%3Cscript%3Ealert(%27xss%27)%3C%2Fscript%3E`);
-
-    expect(await res.text()).toEqual(
-      'Profile handler failed. CAUSE: &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;'
-    );
   });
 });


### PR DESCRIPTION

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Add a default `onError` handler and set the default handler to just print the status (and log the error)

### 🎯 Testing

```bash
$ npm run start:kitchen-sink
# Visit http://localhost:api/auth/callback?error=foo&error_description=bar
```