### PR TITLE
Add support for configuring the built-in handlers [SDK-3566]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      //"env": { "NODE_ENV": "test" },
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "disableOptimisticBPs": true,
+      "runtimeExecutable": "/usr/local/bin/node"
+    }
+  ]
+}

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -196,4 +196,4 @@ export default handleAuth({
 });
 ```
 
- You can still override any built-in handler if needed. Pass either a custom handler function to override it, or just an options object to configure it.
+You can still override any built-in handler if needed. Pass either a custom handler function to override it, or just an options object to configure it.

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -8,6 +8,7 @@ Guide to migrating from `1.x` to `2.x`
 - [Profile API route no longer returns a 401](#profile-api-route-no-longer-returns-a-401)
 - [The ID token is no longer stored by default](#the-id-token-is-no-longer-stored-by-default)
 - [Override default error handler](#override-default-error-handler)
+- [Configure built-in handlers without overriding them](#configure-built-in-handlers-without-overriding-them)
 
 ## `getSession` now returns a `Promise`
 
@@ -119,6 +120,8 @@ You can choose to store it by setting either the `session.storeIDToken` config p
 
 You can now set the default error handler for the auth routes in a single place.
 
+### Before
+
 ```js
 export default handleAuth({
   async login(req, res) {
@@ -156,3 +159,41 @@ export default handleAuth({
   }
 });
 ```
+
+## Configure built-in handlers without overriding them
+
+Previously it was not possible to dynamically configure the built-in handlers. For example, to pass a `connection` parameter to the login handler, you had to override it.
+
+### Before
+
+```js
+export default handleAuth({
+  async login(req, res) {
+    try {
+      await handleLogin(req, res, {
+        authorizationParams: {
+          connection: 'github'
+        },
+      });
+    } catch (error) {
+      // ...
+    }
+  }
+});
+```
+
+### After
+
+Now you can simply pass an options object to configure the built-in handler instead.
+
+```js
+export default handleAuth({
+  login: {
+    authorizationParams: {
+      connection: 'github'
+    }
+  }
+});
+```
+
+ You can still override any built-in handler if needed. Pass either a custom handler function to override it, or just an options object to configure it.

--- a/examples/kitchen-sink-example/pages/api/auth/[auth0].ts
+++ b/examples/kitchen-sink-example/pages/api/auth/[auth0].ts
@@ -1,6 +1,27 @@
 import { handleAuth } from '@auth0/nextjs-auth0';
 
 export default handleAuth({
+  login: {
+    authorizationParams: { scope: 'openid email offline_access' },
+    getLoginState() {
+      return { foo: 'bar' };
+    }
+  },
+  logout: { returnTo: 'https://example.com/foo' },
+  callback: {
+    async afterCallback(req, res, session) {
+      console.log('After callback!!');
+      return session;
+    },
+    authorizationParams: { scope: 'openid email' }
+  },
+  profile: {
+    refetch: true,
+    async afterRefetch(req, res, session) {
+      console.log('After refetch!!');
+      return session;
+    }
+  },
   onError(req, res, error) {
     console.error(error);
     res.status(error.status || 500).end('Check the console for the error');

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -28,7 +28,7 @@ import { CallbackHandlerError, HandlerErrorCause } from '../utils/errors';
  *     try {
  *       await handleCallback(req, res, { afterCallback });
  *     } catch (error) {
- *       res.status(error.status || 500).end(error.message);
+ *       res.status(error.status || 500).end();
  *     }
  *   }
  * });
@@ -51,7 +51,7 @@ import { CallbackHandlerError, HandlerErrorCause } from '../utils/errors';
  *     try {
  *       await handleCallback(req, res, { afterCallback });
  *     } catch (error) {
- *       res.status(error.status || 500).end(error.message);
+ *       res.status(error.status || 500).end();
  *     }
  *   }
  * });
@@ -91,7 +91,8 @@ export interface CallbackOptions {
   organization?: string;
 
   /**
-   * This is useful for sending custom query parameters in the body of the code exchange request for use in rules.
+   * This is useful for sending custom query parameters in the body of the code exchange request
+   * for use in Actions/Rules.
    */
   authorizationParams?: Partial<AuthorizationParameters>;
 }

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -21,7 +21,7 @@ import { HandlerErrorCause, LoginHandlerError } from '../utils/errors';
  *     try {
  *       await handleLogin(req, res, { getLoginState });
  *     } catch (error) {
- *       res.status(error.status || 500).end(error.message);
+ *       res.status(error.status || 500).end();
  *     }
  *   }
  * });
@@ -57,6 +57,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    *     }
    *   }
    * });
+   * ```
    */
   connection?: string;
 
@@ -80,6 +81,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    *     }
    *   }
    * });
+   * ```
    */
   connection_scope?: string;
 
@@ -106,13 +108,13 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    *       }
    *     });
    *   } catch (error) {
-   *     res.status(error.status || 500).end(error.message);
+   *     res.status(error.status || 500).end();
    *   }
    * } ;
    * ```
    *
    * Your invite url can then take the format:
-   * `https://example.com/api/invite?invitation=invitation_id&organization=org_id`
+   * `https://example.com/api/invite?invitation=invitation_id&organization=org_id`.
    */
   invitation?: string;
 

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -62,30 +62,20 @@ export const setup = async (
   jwksEndpoint(config, jwks);
   codeExchange(config, await makeIdToken({ iss: 'https://acme.auth0.local/', ...idTokenClaims }));
   userInfo(config, userInfoToken, userInfoPayload);
-  const {
-    handleAuth,
-    handleCallback,
-    handleLogin,
-    handleLogout,
-    handleProfile,
-    getSession,
-    updateUser,
-    getAccessToken,
-    withApiAuthRequired,
-    withPageAuthRequired
-  } = await initAuth0(config);
+  const { handleAuth, getSession, updateUser, getAccessToken, withApiAuthRequired, withPageAuthRequired } =
+    await initAuth0(config);
   const handlers: Partial<Handlers> = { onError };
   if (callbackOptions) {
-    handlers.callback = (req, res) => handleCallback(req, res, callbackOptions);
+    handlers.callback = callbackOptions;
   }
   if (loginOptions) {
-    handlers.login = (req, res) => handleLogin(req, res, loginOptions);
+    handlers.login = loginOptions;
   }
   if (logoutOptions) {
-    handlers.logout = (req, res) => handleLogout(req, res, logoutOptions);
+    handlers.logout = logoutOptions;
   }
   if (profileOptions) {
-    handlers.profile = (req, res) => handleProfile(req, res, profileOptions);
+    handlers.profile = profileOptions;
   }
   global.handleAuth = handleAuth.bind(null, handlers);
   global.getSession = getSession;

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -2,8 +2,12 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { ArgumentsOf } from 'ts-jest';
 import { withoutApi } from '../fixtures/default-settings';
 import { setup, teardown } from '../fixtures/setup';
-import { get } from '../auth0-session/fixtures/helpers';
-import { initAuth0, OnError } from '../../src';
+import { get, post } from '../auth0-session/fixtures/helpers';
+import { CallbackOptions, initAuth0, LoginOptions, LogoutOptions, OnError, ProfileOptions } from '../../src';
+import * as loginHandler from '../../src/handlers/login';
+import * as logoutHandler from '../../src/handlers/logout';
+import * as callbackHandler from '../../src/handlers/callback';
+import * as profileHandler from '../../src/handlers/profile';
 
 const handlerError = (status = 400, error = 'foo', error_description = 'bar') =>
   expect.objectContaining({
@@ -12,6 +16,28 @@ const handlerError = (status = 400, error = 'foo', error_description = 'bar') =>
   });
 
 describe('auth handler', () => {
+  afterEach(teardown);
+
+  test('return 500 for unexpected error', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
+    delete global.onError;
+    jest.spyOn(console, 'error').mockImplementation((error) => {
+      delete error.status;
+    });
+    await expect(get(baseUrl, '/api/auth/callback?error=foo&error_description=bar')).rejects.toThrow(
+      'Internal Server Error'
+    );
+  });
+
+  test('return 404 for unknown routes', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
+    await expect(get(baseUrl, '/api/auth/foo')).rejects.toThrow('Not Found');
+  });
+});
+
+describe('custom error handler', () => {
   afterEach(teardown);
 
   test('accept custom error handler', async () => {
@@ -25,6 +51,7 @@ describe('auth handler', () => {
     const baseUrl = await setup(withoutApi);
     global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
     delete global.onError;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     jest.spyOn(console, 'error').mockImplementation(() => {});
     await expect(get(baseUrl, '/api/auth/callback?error=foo&error_description=bar')).rejects.toThrow('Bad Request');
     expect(console.error).toHaveBeenCalledWith(new Error('Callback handler failed. CAUSE: foo (bar)'));
@@ -49,22 +76,46 @@ describe('auth handler', () => {
     ).rejects.toThrow("I'm a Teapot");
     expect(onError).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), handlerError());
   });
+});
 
-  test('return 500 for unexpected error', async () => {
-    const baseUrl = await setup(withoutApi);
-    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
-    delete global.onError;
-    jest.spyOn(console, 'error').mockImplementation((error) => {
-      delete error.status;
-    });
-    await expect(get(baseUrl, '/api/auth/callback?error=foo&error_description=bar')).rejects.toThrow(
-      'Internal Server Error'
-    );
+describe('custom options', () => {
+  const spyHandler = jest.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+    res.end();
   });
 
-  test('return 404 for unknown routes', async () => {
-    const baseUrl = await setup(withoutApi);
-    global.handleAuth = (await initAuth0(withoutApi)).handleAuth;
-    await expect(get(baseUrl, '/api/auth/foo')).rejects.toThrow('Not Found');
+  afterEach(teardown);
+
+  test('accept custom login options', async () => {
+    jest.spyOn(loginHandler, 'default').mockImplementation(() => spyHandler);
+    const loginOptions: LoginOptions = {
+      authorizationParams: { scope: 'openid' }
+    };
+    const baseUrl = await setup(withoutApi, { loginOptions });
+    await get(baseUrl, '/api/auth/login');
+    expect(spyHandler).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), loginOptions);
+  });
+
+  test('accept custom logout options', async () => {
+    jest.spyOn(logoutHandler, 'default').mockImplementation(() => spyHandler);
+    const logoutOptions: LogoutOptions = { returnTo: 'https://example.com' };
+    const baseUrl = await setup(withoutApi, { logoutOptions });
+    await get(baseUrl, '/api/auth/logout');
+    expect(spyHandler).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), logoutOptions);
+  });
+
+  test('accept custom callback options', async () => {
+    jest.spyOn(callbackHandler, 'default').mockImplementation(() => spyHandler);
+    const callbackOptions: CallbackOptions = { authorizationParams: { scope: 'openid' } };
+    const baseUrl = await setup(withoutApi, { callbackOptions });
+    await post(baseUrl, '/api/auth/callback', { body: {} });
+    expect(spyHandler).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), callbackOptions);
+  });
+
+  test('accept custom profile options', async () => {
+    jest.spyOn(profileHandler, 'default').mockImplementation(() => spyHandler);
+    const profileOptions: ProfileOptions = { refetch: true };
+    const baseUrl = await setup(withoutApi, { profileOptions });
+    await post(baseUrl, '/api/auth/me', { body: {} });
+    expect(spyHandler).toHaveBeenCalledWith(expect.any(IncomingMessage), expect.any(ServerResponse), profileOptions);
   });
 });


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently it's not possible to dynamically configure the built-in handlers. For example, to pass a `connection` parameter to the login handler, it's necessary to override it. 

#### Before

```js
export default handleAuth({
  async login(req, res) {
    try {
      await handleLogin(req, res, {
        authorizationParams: {
          connection: 'github'
        },
      });
    } catch (error) {
      // ...
    }
  }
});
```

This PR allows to pass option objects to configure the built-in handlers, without having to override them.

#### After

```js
export default handleAuth({
  login: {
    authorizationParams: {
      connection: 'github'
    }
  }
});
```

It's still possible to override the built-in handlers by passing custom handler functions.

### 🎯 Testing

Besides adding unit tests, this change was tested manually in the kitchen sink example app.