### PR TITLE
[SDK-3553] Improved callback errors

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,10 +1,10 @@
 # Frequently Asked Questions
 
-1. [Why do I get a `checks.state argument is missing` error when logging in from different tabs?](#1-why-do-i-get-a-checks.state-argument-is-missing-error-if-i-try-to-log-in-from-different-tabs)
+1. [Why do I get a `state mismatch` error when logging in from different tabs?](#1-why-do-i-get-a-state-mismatch-error-if-i-try-to-log-in-from-different-tabs)
 
-## 1. Why do I get a `checks.state argument is missing` error if I try to log in from different tabs?
+## 1. Why do I get a `state mismatch` error if I try to log in from different tabs?
 
-Every time you initiate login, the SDK stores in cookies some transient state (`nonce`, `state`, `code_verifier`) necessary to verify the callback request from Auth0. Initiating login concurrently from different tabs will result in that state being overwritten in each subsequent tab. Once the login is completed in some tab, the SDK will compare the state in the callback with the state stored in the cookies. As the cookies were overwritten, the values will not match (except for the tab that initiated login the last) and the SDK will return the `checks.state argument is missing` error.
+Every time you initiate login, the SDK stores in cookies some transient state (`nonce`, `state`, `code_verifier`) necessary to verify the callback request from Auth0. Initiating login concurrently from different tabs will result in that state being overwritten in each subsequent tab. Once the login is completed in some tab, the SDK will compare the state in the callback with the state stored in the cookies. As the cookies were overwritten, the values will not match (except for the tab that initiated login the last) and the SDK will return the `state mismatch` error.
 
 For example:
 

--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -7,6 +7,13 @@ import TransientStore from '../transient-store';
 import { decodeState } from '../hooks/get-login-state';
 import { SessionCache } from '../session-cache';
 import { htmlSafe } from '../../utils/errors';
+import {
+  ApplicationError,
+  IdentityProviderError,
+  MissingStateCookieError,
+  MissingStateParamError
+} from '../utils/errors';
+import type { errors } from 'openid-client';
 
 function getRedirectUri(config: Config): string {
   return urlJoin(config.baseURL, config.routes.callback);
@@ -38,13 +45,24 @@ export default function callbackHandlerFactory(
 
     let expectedState;
     let tokenSet;
-    try {
-      const callbackParams = client.callbackParams(req);
-      expectedState = await transientCookieHandler.read('state', req, res);
-      const max_age = await transientCookieHandler.read('max_age', req, res);
-      const code_verifier = await transientCookieHandler.read('code_verifier', req, res);
-      const nonce = await transientCookieHandler.read('nonce', req, res);
 
+    const callbackParams = client.callbackParams(req);
+
+    if (!callbackParams.state) {
+      throw createHttpError(404, new MissingStateParamError());
+    }
+
+    expectedState = await transientCookieHandler.read('state', req, res);
+
+    if (!expectedState) {
+      throw createHttpError(400, new MissingStateCookieError());
+    }
+
+    const max_age = await transientCookieHandler.read('max_age', req, res);
+    const code_verifier = await transientCookieHandler.read('code_verifier', req, res);
+    const nonce = await transientCookieHandler.read('nonce', req, res);
+
+    try {
       tokenSet = await client.callback(
         redirectUri,
         callbackParams,
@@ -57,11 +75,13 @@ export default function callbackHandlerFactory(
         { exchangeBody: options?.authorizationParams }
       );
     } catch (err) {
-      throw createHttpError(400, err.message, {
-        error: err.error,
-        error_description: err.error_description,
-        openidState: decodeState(expectedState)
-      });
+      if (err instanceof errors.OPError) {
+        err = new IdentityProviderError(err);
+      }
+      if (err instanceof errors.RPError) {
+        err = new ApplicationError(err);
+      }
+      throw createHttpError(400, err, { openIdState: decodeState(expectedState) });
     }
 
     const openidState: { returnTo?: string } = decodeState(expectedState as string) as ValidState;

--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import urlJoin from 'url-join';
 import createHttpError from 'http-errors';
+import { errors } from 'openid-client';
 import { AuthorizationParameters, Config } from '../config';
 import { ClientFactory } from '../client';
 import TransientStore from '../transient-store';
@@ -13,7 +14,6 @@ import {
   MissingStateCookieError,
   MissingStateParamError
 } from '../utils/errors';
-import type { errors } from 'openid-client';
 
 function getRedirectUri(config: Config): string {
   return urlJoin(config.baseURL, config.routes.callback);

--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -43,7 +43,6 @@ export default function callbackHandlerFactory(
     const client = await getClient();
     const redirectUri = options?.redirectUri || getRedirectUri(config);
 
-    let expectedState;
     let tokenSet;
 
     const callbackParams = client.callbackParams(req);
@@ -52,7 +51,7 @@ export default function callbackHandlerFactory(
       throw createHttpError(404, new MissingStateParamError());
     }
 
-    expectedState = await transientCookieHandler.read('state', req, res);
+    const expectedState = await transientCookieHandler.read('state', req, res);
 
     if (!expectedState) {
       throw createHttpError(400, new MissingStateCookieError());

--- a/src/auth0-session/index.ts
+++ b/src/auth0-session/index.ts
@@ -1,4 +1,10 @@
 export { default as NodeCookies, Cookies } from './utils/cookies';
+export {
+  MissingStateParamError,
+  MissingStateCookieError,
+  IdentityProviderError,
+  ApplicationError
+} from './utils/errors';
 export { default as CookieStore } from './cookie-store';
 export { default as TransientStore } from './transient-store';
 export { Config, SessionConfig, CookieConfig, LoginOptions, LogoutOptions, AuthorizationParameters } from './config';

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -1,0 +1,49 @@
+import type { errors } from 'openid-client';
+
+export class MissingStateParamError extends Error {
+  static message =
+    'This endpoint must be called as part of the login flow (with a state parameter from the initial authorization request).';
+
+  constructor() {
+    /* c8 ignore next */
+    super(MissingStateParamError.message);
+  }
+}
+
+export class MissingStateCookieError extends Error {
+  static message =
+    'The cookie dropped by the login request cannot be found, check the url of the login request, the url of this callback request and your cookie config.';
+
+  constructor() {
+    /* c8 ignore next */
+    super(MissingStateCookieError.message);
+  }
+}
+
+export class ApplicationError extends Error {
+  constructor(rpError: errors.RPError) {
+    /* c8 ignore next */
+    super(rpError.message);
+  }
+}
+
+export class IdentityProviderError extends Error {
+  /**
+   * The 'error_description' parameter from the AS response (Warning: this can contain user input and is not escaped in any way).
+   */
+  errorDescription?: string;
+  /**
+   * The 'error' parameter from the AS response  (Warning: this can contain user input and is not escaped in any way).
+   */
+  error?: string;
+
+  /**
+   * Warning: the message can contain user input and is not escaped in any way.
+   */
+  constructor(rpError: errors.OPError) {
+    /* c8 ignore next */
+    super(rpError.message);
+    this.error = rpError.error;
+    this.errorDescription = rpError.error_description;
+  }
+}

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -34,8 +34,8 @@ export class ApplicationError extends Error {
 
 export class IdentityProviderError extends Error {
   /**
-   * The 'error_description' parameter from the AS response
-   * (Warning: this can contain user input and is not escaped in any way).
+   * The 'error_description' parameter from the AS response.
+   * **WARNING** This can contain user input and is not escaped in any way.
    */
   errorDescription?: string;
   /**
@@ -44,7 +44,7 @@ export class IdentityProviderError extends Error {
   error?: string;
 
   /**
-   * Warning: the message can contain user input and is not escaped in any way.
+   * **WARNING** The message can contain user input and is not escaped in any way.
    */
   constructor(rpError: errors.OPError) {
     /* c8 ignore next */

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -2,7 +2,8 @@ import type { errors } from 'openid-client';
 
 export class MissingStateParamError extends Error {
   static message =
-    'This endpoint must be called as part of the login flow (with a state parameter from the initial authorization request).';
+    'This endpoint must be called as part of the login flow (with a state parameter from the initial' +
+    'authorization request).';
 
   constructor() {
     /* c8 ignore next */
@@ -12,7 +13,8 @@ export class MissingStateParamError extends Error {
 
 export class MissingStateCookieError extends Error {
   static message =
-    'The cookie dropped by the login request cannot be found, check the url of the login request, the url of this callback request and your cookie config.';
+    'The cookie dropped by the login request cannot be found, check the url of the login request, the url of' +
+    'this callback request and your cookie config.';
 
   constructor() {
     /* c8 ignore next */
@@ -29,7 +31,8 @@ export class ApplicationError extends Error {
 
 export class IdentityProviderError extends Error {
   /**
-   * The 'error_description' parameter from the AS response (Warning: this can contain user input and is not escaped in any way).
+   * The 'error_description' parameter from the AS response
+   * (Warning: this can contain user input and is not escaped in any way).
    */
   errorDescription?: string;
   /**

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -3,7 +3,7 @@ import type { errors } from 'openid-client';
 export class MissingStateParamError extends Error {
   static message =
     'This endpoint must be called as part of the login flow (with a state parameter from the initial' +
-    'authorization request).';
+    ' authorization request).';
 
   constructor() {
     /* c8 ignore next */
@@ -14,7 +14,7 @@ export class MissingStateParamError extends Error {
 export class MissingStateCookieError extends Error {
   static message =
     'The cookie dropped by the login request cannot be found, check the url of the login request, the url of' +
-    'this callback request and your cookie config.';
+    ' this callback request and your cookie config.';
 
   constructor() {
     /* c8 ignore next */

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -8,6 +8,7 @@ export class MissingStateParamError extends Error {
   constructor() {
     /* c8 ignore next */
     super(MissingStateParamError.message);
+    Object.setPrototypeOf(this, MissingStateParamError.prototype);
   }
 }
 
@@ -19,6 +20,7 @@ export class MissingStateCookieError extends Error {
   constructor() {
     /* c8 ignore next */
     super(MissingStateCookieError.message);
+    Object.setPrototypeOf(this, MissingStateCookieError.prototype);
   }
 }
 
@@ -26,6 +28,7 @@ export class ApplicationError extends Error {
   constructor(rpError: errors.RPError) {
     /* c8 ignore next */
     super(rpError.message);
+    Object.setPrototypeOf(this, ApplicationError.prototype);
   }
 }
 
@@ -48,5 +51,6 @@ export class IdentityProviderError extends Error {
     super(rpError.message);
     this.error = rpError.error;
     this.errorDescription = rpError.error_description;
+    Object.setPrototypeOf(this, IdentityProviderError.prototype);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,13 @@ export {
 } from './utils/errors';
 
 export {
+  MissingStateCookieError,
+  MissingStateParamError,
+  IdentityProviderError,
+  ApplicationError
+} from './auth0-session';
+
+export {
   ConfigParameters,
   HandleAuth,
   HandleLogin,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -34,7 +34,7 @@ type AuthErrorOptions = {
  * Because part of the error message can come from the OpenID Connect `error` query parameter we
  * do some basic escaping which makes sure the default error handler is safe from XSS.
  *
- * **IMPORTANT** If you write your own error handler, you should **not** render the error message
+ * **IMPORTANT** If you write your own error handler, you should **not** render the error
  * without using a templating engine that will properly escape it for other HTML contexts first.
  *
  * Note that the error message of the {@link AuthError.cause | underlying error} is **not** escaped
@@ -59,8 +59,7 @@ export abstract class AuthError extends Error {
   /**
    * The underlying error, if any.
    *
-   * **IMPORTANT** The error message of this underlying error is **not** escaped in
-   * any way, so do **not** render it without escaping it first!
+   * **IMPORTANT** This underlying error is **not** escaped in any way, so do **not** render it without escaping it first!
    */
   public readonly cause?: Error;
 
@@ -136,7 +135,7 @@ type HandlerErrorOptions = {
  * without using a templating engine that will properly escape it for other HTML contexts first.
  *
  * @see the {@link AuthError.cause | cause property} contains the underlying error.
- * **IMPORTANT** The error message of this underlying error is **not** escaped in any way, so do **not** render
+ * **IMPORTANT** This underlying error is **not** escaped in any way, so do **not** render
  * it without escaping it first!
  *
  * @see the {@link AuthError.status | status property} contains the HTTP status code of the error,
@@ -163,7 +162,7 @@ export class HandlerError extends AuthError {
  * without using a templating engine that will properly escape it for other HTML contexts first.
  *
  * @see the {@link AuthError.cause | cause property} contains the underlying error.
- * **IMPORTANT** The error message of this underlying error is **not** escaped in any way, so do **not** render
+ * **IMPORTANT** this underlying error is **not** escaped in any way, so do **not** render
  * it without escaping it first!
  *
  * @see the {@link AuthError.status | status property} contains the HTTP status code of the error,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -59,7 +59,8 @@ export abstract class AuthError extends Error {
   /**
    * The underlying error, if any.
    *
-   * **IMPORTANT** This underlying error is **not** escaped in any way, so do **not** render it without escaping it first!
+   * **IMPORTANT** This underlying error is **not** escaped in any way,
+   * so do **not** render it without escaping it first!
    */
   public readonly cause?: Error;
 

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -23,7 +23,7 @@ describe('callback', () => {
       baseURL
     );
 
-    await expect(post(baseURL, '/callback', { body: {}, cookieJar })).rejects.toThrowError(
+    await expect(post(baseURL, '/callback', { body: {}, cookieJar })).rejects.toThrow(
       'This endpoint must be called as part of the login flow (with a state parameter from the initial authorization request).'
     );
   });

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -24,7 +24,7 @@ describe('callback', () => {
     );
 
     await expect(post(baseURL, '/callback', { body: {}, cookieJar })).rejects.toThrowError(
-      'state missing from the response'
+      'This endpoint must be called as part of the login flow (with a state parameter from the initial authorization request).'
     );
   });
 
@@ -39,7 +39,9 @@ describe('callback', () => {
         },
         cookieJar: new CookieJar()
       })
-    ).rejects.toThrowError('checks.state argument is missing');
+    ).rejects.toThrowError(
+      'The cookie dropped by the login request cannot be found, check the url of the login request, the url of this callback request and your cookie config.'
+    );
   });
 
   it("should error when state doesn't match", async () => {
@@ -171,7 +173,9 @@ describe('callback', () => {
         },
         cookieJar
       })
-    ).rejects.toThrowError('checks.state argument is missing');
+    ).rejects.toThrowError(
+      'The cookie dropped by the login request cannot be found, check the url of the login request, the url of this callback request and your cookie config.'
+    );
   });
 
   it('should error for expired ID token', async () => {

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -36,7 +36,7 @@ export type SetupOptions = {
   asyncProps?: boolean;
 };
 
-const defaultOnError: OnError = (_req, res, error) => {
+export const defaultOnError: OnError = (_req, res, error) => {
   res.statusMessage = error.message;
   res.status(error.status || 500).end(error.message);
 };


### PR DESCRIPTION
### 📋 Changes

Improve errors from callback handler:

- better explanation when the login request's state cookie is not found in the callback request
- better explanation (and 404) when the callback request is called when not part of the login dance
- error types for RP and OP errors
