### PR TITLE
Shouldn't serve routes for object builtins

### DIFF
--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -153,7 +153,7 @@ export default function handlerFactory({
       route = Array.isArray(route) ? route[0] : /* c8 ignore next */ route;
 
       try {
-        const handler = route && customHandlers[route];
+        const handler = route && customHandlers.hasOwnProperty(route) && customHandlers[route];
         if (handler) {
           await handler(req, res);
         } else {

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -38,6 +38,12 @@ describe('auth handler', () => {
     global.handleAuth = initAuth0(withoutApi).handleAuth;
     await expect(get(baseUrl, '/api/auth/foo')).rejects.toThrow('Not Found');
   });
+
+  test('return 404 for unknown routes including builtin props', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = initAuth0(withoutApi).handleAuth;
+    await expect(get(baseUrl, '/api/auth/__proto__')).rejects.toThrow('Not Found');
+  });
 });
 
 describe('custom error handler', () => {


### PR DESCRIPTION
### 📋 Changes

Noticed while testing that we're serving routes for js builtins (like `__proto__`)

`/api/auth/__proto__` should return 404 (currently returning 500)
