### PR TITLE
[ASEC-892] Change insecure cookie from warning to error

### DIFF
--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -37,16 +37,9 @@ const paramsSchema = Joi.object({
       sameSite: Joi.string().valid('lax', 'strict', 'none').optional().default('lax'),
       secure: Joi.when(Joi.ref('/baseURL'), {
         is: Joi.string().pattern(isHttps),
-        then: Joi.boolean()
-          .default(true)
-          .custom((value, { warn }) => {
-            if (!value) warn('insecure.cookie');
-            return value;
-          })
-          .messages({
-            'insecure.cookie':
-              "Setting your cookie to insecure when over https is not recommended, I hope you know what you're doing."
-          }),
+        then: Joi.boolean().valid(true).default(true).messages({
+          'any.only': 'Cookies must be secure when base url is https.'
+        }),
         otherwise: Joi.boolean().valid(false).default(false).messages({
           'any.only': 'Cookies set with the `Secure` property wont be attached to http requests'
         })

--- a/tests/auth0-session/config.test.ts
+++ b/tests/auth0-session/config.test.ts
@@ -294,7 +294,7 @@ describe('Config', () => {
           }
         }
       })
-    ).toThrowError('"session.cookie.secure" must be a boolean');
+    ).toThrowError('Cookies must be secure when base url is https.');
   });
 
   it('should fail when app session cookie sameSite is invalid', function () {

--- a/tests/auth0-session/cookie-store.test.ts
+++ b/tests/auth0-session/cookie-store.test.ts
@@ -223,18 +223,6 @@ describe('CookieStore', () => {
     });
   });
 
-  it('should set custom secure option on https', async () => {
-    const baseURL = await setup({ ...defaultConfig, session: { cookie: { secure: false } } }, { https: true });
-    const appSession = await encrypted();
-    const cookieJar = toCookieJar({ appSession }, baseURL);
-    await get(baseURL, '/session', { cookieJar });
-    const [cookie] = cookieJar.getCookiesSync(baseURL);
-    expect(cookie).toMatchObject({
-      sameSite: 'lax',
-      secure: false
-    });
-  });
-
   it('should set custom sameSite option on https', async () => {
     const baseURL = await setup({ ...defaultConfig, session: { cookie: { sameSite: 'none' } } }, { https: true });
     const appSession = await encrypted();

--- a/tests/auth0-session/transient-store.test.ts
+++ b/tests/auth0-session/transient-store.test.ts
@@ -67,20 +67,6 @@ describe('TransientStore', () => {
     expect(cookie?.secure).toEqual(true);
   });
 
-  it('should override the secure setting when specified', async () => {
-    const baseURL = await setup(defaultConfig, (req: IncomingMessage, res: ServerResponse) =>
-      transientStore.save('test_key', req, res, { sameSite: 'lax', value: 'foo' })
-    );
-    const transientStore = new TransientStore(
-      getConfig({ ...defaultConfig, baseURL, session: { cookie: { secure: false } } })
-    );
-    const cookieJar = new CookieJar();
-    const { value } = await get(baseURL, '/', { cookieJar });
-    const cookie = getCookie('test_key', cookieJar, baseURL);
-    expect(value).toEqual('foo');
-    expect(cookie?.secure).toEqual(false);
-  });
-
   it('should set cookie to not secure when baseURL protocol is http and SameSite=Lax', async () => {
     const baseURL = await setup(
       defaultConfig,


### PR DESCRIPTION
### 📋 Changes

Remove the option to set an insecure cookie in secure context (when baseUrl is https)
