### PR TITLE
At error cause to AT error when it's from a failed grant

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,8 @@
 import { NextMiddleware, NextRequest, NextResponse } from 'next/server';
 import { default as CookieStore } from './auth0-session/cookie-store';
 import MiddlewareCookies from './utils/middleware-cookies';
-import { SessionCache, Session } from './session/';
+import Session from './session/session';
+import SessionCache from './session/cache';
 import {
   WithMiddlewareAuthRequired,
   default as withMiddlewareAuthRequiredFactory

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -81,7 +81,8 @@ export enum AccessTokenErrorCode {
   MISSING_ACCESS_TOKEN = 'ERR_MISSING_ACCESS_TOKEN',
   MISSING_REFRESH_TOKEN = 'ERR_MISSING_REFRESH_TOKEN',
   EXPIRED_ACCESS_TOKEN = 'ERR_EXPIRED_ACCESS_TOKEN',
-  INSUFFICIENT_SCOPE = 'ERR_INSUFFICIENT_SCOPE'
+  INSUFFICIENT_SCOPE = 'ERR_INSUFFICIENT_SCOPE',
+  FAILED_REFRESH_GRANT = 'ERR_FAILED_REFRESH_GRANT'
 }
 
 /**
@@ -96,9 +97,9 @@ export enum AccessTokenErrorCode {
  * @category Server
  */
 export class AccessTokenError extends AuthError {
-  constructor(code: AccessTokenErrorCode, message: string) {
+  constructor(code: AccessTokenErrorCode, message: string, cause?: Error) {
     /* c8 ignore next */
-    super({ code: code, message: message, name: 'AccessTokenError' });
+    super({ code: code, message: message, name: 'AccessTokenError', cause });
 
     // Capturing stack trace, excluding constructor call from it.
     Error.captureStackTrace(this, this.constructor);

--- a/tests/fixtures/oidc-nocks.ts
+++ b/tests/fixtures/oidc-nocks.ts
@@ -120,6 +120,17 @@ export async function refreshTokenExchange(
     });
 }
 
+export async function failedRefreshTokenExchange(
+  params: ConfigParameters,
+  refreshToken: string,
+  payload: Record<string, unknown>,
+  status = 401
+): Promise<nock.Scope> {
+  return nock(`${params.issuerBaseURL}`)
+    .post('/oauth/token', `grant_type=refresh_token&refresh_token=${refreshToken}`)
+    .reply(status, payload);
+}
+
 export async function refreshTokenRotationExchange(
   params: ConfigParameters,
   refreshToken: string,


### PR DESCRIPTION
### 📋 Changes

When the access token error comes from a failed grant request we should create an `AccessTokenError` with an `IdentityProvider` error as a cause

### 📎 References

fixes #872 