### PR TITLE
Fix edge cookie support for Next < 13.0.1

### DIFF
--- a/src/utils/middleware-cookies.ts
+++ b/src/utils/middleware-cookies.ts
@@ -12,6 +12,15 @@ export default class MiddlewareCookies extends Cookies {
   }
 
   getAll(req: NextRequest): Record<string, string> {
-    return req.cookies.getAll().reduce((memo, { name, value }) => ({ ...memo, [name]: value }), {});
+    const { cookies } = req;
+    if (typeof cookies.getAll === 'function') {
+      return req.cookies.getAll().reduce((memo, { name, value }) => ({ ...memo, [name]: value }), {});
+    }
+    // Edge cookies before Next 13.0.1 have no `getAll` and extend `Map`.
+    const legacyCookies = cookies as unknown as Map<string, string>;
+    return Array.from(legacyCookies.keys()).reduce((memo: { [key: string]: string }, key) => {
+      memo[key] = legacyCookies.get(key) as string;
+      return memo;
+    }, {});
   }
 }

--- a/tests/utils/middleware-cookies.test.ts
+++ b/tests/utils/middleware-cookies.test.ts
@@ -14,6 +14,16 @@ describe('cookie', () => {
     expect(new MiddlewareCookies().getAll(req)).toMatchObject({ foo: 'bar', bar: 'baz' });
   });
 
+  it('should get all cookies in Next < 13.0.1', async () => {
+    const req = {
+      cookies: new Map([
+        ['foo', 'bar'],
+        ['bar', 'baz']
+      ])
+    } as unknown as NextRequest;
+    expect(new MiddlewareCookies().getAll(req)).toMatchObject({ foo: 'bar', bar: 'baz' });
+  });
+
   it('should get a cookie by name', async () => {
     const [req] = setup({ headers: { cookie: 'foo=bar; bar=baz;' } });
     expect(new MiddlewareCookies().getAll(req)['foo']).toEqual('bar');


### PR DESCRIPTION
### 📋 Changes

In order to support Next <13.0.1 we need to support the old way Edge cookies were defined (as a Map) an addition to the new way they're defined (with `getAll`)

### 📎 References

fixes #899 
https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/cookie.ts#L144-L154
https://github.com/vercel/next.js/pull/41526

