### PR TITLE
WithMiddlewareAuthRequired should return 401 for /api routes

### DIFF
--- a/examples/kitchen-sink-example/middleware.ts
+++ b/examples/kitchen-sink-example/middleware.ts
@@ -3,5 +3,5 @@ import { withMiddlewareAuthRequired } from '@auth0/nextjs-auth0/middleware';
 export default withMiddlewareAuthRequired();
 
 export const config = {
-  matcher: '/profile-mw'
+  matcher: ['/profile-mw', '/api/hello-world-mw']
 };

--- a/examples/kitchen-sink-example/pages/api/hello-world-mw.ts
+++ b/examples/kitchen-sink-example/pages/api/hello-world-mw.ts
@@ -1,0 +1,3 @@
+export default async function helloWorld(req, res) {
+  res.status(200).json({ text: 'Hello World!' });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -308,6 +308,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
   routes: {
     callback: string;
     login: string;
+    unauthorized: string;
   };
 }
 
@@ -522,7 +523,8 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   const nextConfig = {
     routes: {
       ...baseConfig.routes,
-      login: baseParams.routes?.login || getLoginUrl()
+      login: baseParams.routes?.login || getLoginUrl(),
+      unauthorized: baseParams.routes?.unauthorized || '/api/auth/401'
     },
     identityClaimFilter: baseConfig.identityClaimFilter,
     organization: organization || AUTH0_ORGANIZATION

--- a/src/helpers/with-middleware-auth-required.ts
+++ b/src/helpers/with-middleware-auth-required.ts
@@ -49,14 +49,14 @@ export type WithMiddlewareAuthRequired = (middleware?: NextMiddleware) => NextMi
  * @ignore
  */
 export default function withMiddlewareAuthRequiredFactory(
-  { login, callback }: { login: string; callback: string },
+  { login, callback, unauthorized }: { login: string; callback: string; unauthorized: string },
   getSessionCache: () => SessionCache<NextRequest, NextResponse>
 ): WithMiddlewareAuthRequired {
   return function withMiddlewareAuthRequired(middleware?): NextMiddleware {
     return async function wrappedMiddleware(...args) {
       const [req] = args;
       const { pathname, origin } = req.nextUrl;
-      const ignorePaths = [login, callback, '/_next', '/favicon.ico'];
+      const ignorePaths = [login, callback, unauthorized, '/_next', '/favicon.ico'];
       if (ignorePaths.some((p) => pathname.startsWith(p))) {
         return;
       }
@@ -66,6 +66,9 @@ export default function withMiddlewareAuthRequiredFactory(
       const authRes = NextResponse.next();
       const session = await sessionCache.get(req, authRes);
       if (!session?.user) {
+        if (pathname.startsWith('/api')) {
+          return NextResponse.rewrite(new URL(unauthorized, origin), { status: 401 });
+        }
         return NextResponse.redirect(
           new URL(`${login}?returnTo=${encodeURIComponent(req.nextUrl.toString())}`, origin)
         );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -92,7 +92,8 @@ describe('config params', () => {
       routes: {
         login: '/api/auth/login',
         callback: '/api/auth/callback',
-        postLogoutRedirect: ''
+        postLogoutRedirect: '',
+        unauthorized: '/api/auth/401'
       },
       organization: undefined
     });

--- a/tests/handlers/auth.test.ts
+++ b/tests/handlers/auth.test.ts
@@ -44,6 +44,12 @@ describe('auth handler', () => {
     global.handleAuth = initAuth0(withoutApi).handleAuth;
     await expect(get(baseUrl, '/api/auth/__proto__')).rejects.toThrow('Not Found');
   });
+
+  test('return unauthorized for /401 route', async () => {
+    const baseUrl = await setup(withoutApi);
+    global.handleAuth = initAuth0(withoutApi).handleAuth;
+    await expect(get(baseUrl, '/api/auth/401')).rejects.toThrow('Unauthorized');
+  });
 });
 
 describe('custom error handler', () => {

--- a/tests/helpers/with-middleware-auth-required.test.ts
+++ b/tests/helpers/with-middleware-auth-required.test.ts
@@ -55,6 +55,21 @@ describe('with-middleware-auth-required', () => {
     expect(redirect.searchParams.get('returnTo')).toEqual('http://example.com/');
   });
 
+  test('require auth on anonymous requests to api routes', async () => {
+    const res = await setup({ url: 'http://example.com/api/foo' });
+    expect(res.status).toEqual(401);
+    expect(res.headers.get('x-middleware-rewrite')).toEqual('http://example.com/api/auth/401');
+  });
+
+  test('require auth on anonymous requests to api routes with custom 401', async () => {
+    const res = await setup({
+      url: 'http://example.com/api/foo',
+      config: { ...withoutApi, routes: { unauthorized: '/api/foo-401' } }
+    });
+    expect(res.status).toEqual(401);
+    expect(res.headers.get('x-middleware-rewrite')).toEqual('http://example.com/api/foo-401');
+  });
+
   test('return to previous url', async () => {
     const res = await setup({ url: 'http://example.com/foo/bar?baz=hello' });
     const redirect = new URL(res.headers.get('location') as string);

--- a/tests/session/session.test.ts
+++ b/tests/session/session.test.ts
@@ -3,6 +3,8 @@ import { fromJson, fromTokenSet } from '../../src/session';
 import { makeIdToken } from '../auth0-session/fixtures/cert';
 import { Session } from '../../src';
 
+const routes = { login: '', callback: '', postLogoutRedirect: '', unauthorized: '' };
+
 describe('session', () => {
   test('should construct a session with a user', async () => {
     expect(new Session({ foo: 'bar' }).user).toEqual({ foo: 'bar' });
@@ -13,7 +15,7 @@ describe('session', () => {
       expect(
         fromTokenSet(new TokenSet({ id_token: await makeIdToken({ foo: 'bar', bax: 'qux' }) }), {
           identityClaimFilter: ['baz'],
-          routes: { login: '', callback: '', postLogoutRedirect: '' }
+          routes
         }).user
       ).toEqual({
         aud: '__test_client_id__',
@@ -32,7 +34,7 @@ describe('session', () => {
       expect(
         fromTokenSet(new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }), {
           identityClaimFilter: ['baz'],
-          routes: { login: '', callback: '', postLogoutRedirect: '' }
+          routes
         }).idToken
       ).toBeUndefined();
     });
@@ -49,7 +51,7 @@ describe('session', () => {
             cookie: { transient: false, httpOnly: false, sameSite: 'lax' }
           },
           identityClaimFilter: ['baz'],
-          routes: { login: '', callback: '', postLogoutRedirect: '' }
+          routes
         }).idToken
       ).not.toBeUndefined();
     });


### PR DESCRIPTION
### 📋 Changes

`/api` routes protected by `withMiddlewareAuthRequired` should respond with a 401 for unauthenticated routes (currently it just expects UI pages so only responds with temporary redirects to the login page)

Since middleware can't respond with a body - the recommended way to do this in Next.js middleware is to create a stub api route and rewrite to that

### 📎 References

https://nextjs.org/docs/messages/returning-response-body-in-middleware
fixes #903

### 🎯 Testing

```bash
$ npm run start:kitchen-sink
$ curl -I http://localhost:3000/api/hello-world-mw
HTTP/1.1 401 Unauthorized
```