### PR TITLE
docs(helpers): `withPageAuthRequired`

### DIFF
--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -40,17 +40,16 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  *
  * ```js
  * // pages/protected-page.js
- * import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+ * import { getSession, withPageAuthRequired } from '@auth0/nextjs-auth0';
  *
  * export default function ProtectedPage({ user, customProp }) {
  *   return <div>Protected content</div>;
  * }
  *
  * export const getServerSideProps = withPageAuthRequired({
- *   returnTo: '/foo',
+ *   // returnTo: '/unauthorized',
  *   async getServerSideProps(ctx) {
- *     // access the user session
- *     const session = getSession(ctx.req, ctx.res);
+ *     // const session = await getSession(ctx);
  *     return { props: { customProp: 'bar' } };
  *   }
  * });

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -49,7 +49,7 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  * export const getServerSideProps = withPageAuthRequired({
  *   // returnTo: '/unauthorized',
  *   async getServerSideProps(ctx) {
- *     // const session = await getSession(ctx);
+ *     // const session = await getSession(ctx.req, ctx.res);
  *     return { props: { customProp: 'bar' } };
  *   }
  * });

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -49,6 +49,7 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  * export const getServerSideProps = withPageAuthRequired({
  *   // returnTo: '/unauthorized',
  *   async getServerSideProps(ctx) {
+ *     // access the user session if needed
  *     // const session = await getSession(ctx.req, ctx.res);
  *     return { props: { customProp: 'bar' } };
  *   }

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -51,7 +51,11 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  *   async getServerSideProps(ctx) {
  *     // access the user session if needed
  *     // const session = await getSession(ctx.req, ctx.res);
- *     return { props: { customProp: 'bar' } };
+ *     return { 
+ *       props: { 
+ *         // customProp: 'bar',
+ *       }
+ *     };
  *   }
  * });
  * ```


### PR DESCRIPTION
Comments out non-default settings included in the example in case users copy-paste (will default to `returnTo: "/api/auth/login"`, and not assign the `session` variable). Also ensures the promise is resolved in thee example via `await getSession(ctx)`.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Enhances docs for `withPageAuthRequired()`, specifically the example as rendered at https://auth0.github.io/nextjs-auth0/modules/helpers_with_page_auth_required.html.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
