### PR TITLE
fix: remove _next from withMiddlewareAuthRequired ignorePaths

### DIFF
--- a/src/helpers/with-middleware-auth-required.ts
+++ b/src/helpers/with-middleware-auth-required.ts
@@ -56,7 +56,7 @@ export default function withMiddlewareAuthRequiredFactory(
     return async function wrappedMiddleware(...args) {
       const [req] = args;
       const { pathname, origin } = req.nextUrl;
-      const ignorePaths = [login, callback, unauthorized, '/_next', '/favicon.ico'];
+      const ignorePaths = [login, callback, unauthorized, '/favicon.ico'];
       if (ignorePaths.some((p) => pathname.startsWith(p))) {
         return;
       }


### PR DESCRIPTION
This closes https://github.com/auth0/nextjs-auth0/issues/977.

Users can still use `export const config` to protect specific routes and bypass _next.

Manually tested.
