### PR TITLE
Correct API file name

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -26,7 +26,7 @@ AUTH0_CLIENT_ID='CLIENT_ID'
 AUTH0_CLIENT_SECRET='CLIENT_SECRET'
 ```
 
-Create a [dynamic API route handler](https://nextjs.org/docs/api-routes/dynamic-api-routes) at `/pages/api/auth/[...auth0].js`.
+Create a [dynamic API route handler](https://nextjs.org/docs/api-routes/dynamic-api-routes) at `/pages/api/auth/[auth0].js`.
 
 ```js
 import { handleAuth } from '@auth0/nextjs-auth0';


### PR DESCRIPTION
I don't know the rationale concretely, but `/pages/api/auth/[...auth0].js` failed to start and `/pages/api/auth/[auth0].js` can work.
