### PR TITLE
Allow client to pass screen_hint and login_hint via params or url params

### DIFF
--- a/src/client/with-page-auth-required.tsx
+++ b/src/client/with-page-auth-required.tsx
@@ -3,6 +3,7 @@ import React, { ComponentType, useEffect } from 'react';
 
 import { useConfig } from './use-config';
 import { useUser, UserProfile } from './use-user';
+import querystring, { stringify } from 'querystring';
 
 /**
  * @ignore
@@ -30,6 +31,29 @@ export interface WithPageAuthRequiredOptions {
    * Add a path to return the user to after login.
    */
   returnTo?: string;
+  /**
+   * ```js
+   * withPageAuthRequired(Profile, {
+   *   screenHint: 'signup'
+   * });
+   * ```
+   *
+   * Provides a hint to Auth0 as to what flow should be displayed. The default behavior is to show a
+   * login page but you can override this by passing 'signup' to show the signup page instead.
+   * This only affects the New Universal Login Experience.
+   */
+  screenHint?: string;
+  /**
+   * ```js
+   * withPageAuthRequired(Profile, {
+   *   loginHint: 'test@test.com'
+   * });
+   * ```
+   *
+   * You can specify the login_hint when redirecting to Auth0, and it will be used to populate
+   * the username/email field for the login or signup page.
+   */
+  loginHint?: string;
   /**
    * ```js
    * withPageAuthRequired(Profile, {
@@ -98,7 +122,17 @@ const withPageAuthRequired: WithPageAuthRequired = (Component, options = {}) => 
         returnToPath = returnTo;
       }
 
-      window.location.assign(`${loginUrl}?returnTo=${encodeURIComponent(returnToPath)}`);
+      const params = querystring.parse(location.search);
+      const loginHint = options.loginHint || params.loginHint;
+      const screenHint = options.screenHint || params.screenHint;
+
+      const query = {
+        returnTo: returnToPath,
+        ...(loginHint ? { loginHint } : {}),
+        ...(screenHint ? { screenHint } : {})
+      };
+
+      window.location.assign(`${loginUrl}?${stringify(query)}`);
     }, [user, error, isLoading]);
 
     if (error) return onError(error);

--- a/src/helpers/with-middleware-auth-required.ts
+++ b/src/helpers/with-middleware-auth-required.ts
@@ -1,5 +1,6 @@
 import { NextMiddleware, NextRequest, NextResponse } from 'next/server';
 import { SessionCache } from '../session';
+import querystring, { stringify } from 'querystring';
 
 /**
  * Protect your pages with Next.js Middleware. For example:
@@ -69,9 +70,13 @@ export default function withMiddlewareAuthRequiredFactory(
         if (pathname.startsWith('/api')) {
           return NextResponse.rewrite(new URL(unauthorized, origin), { status: 401 });
         }
-        return NextResponse.redirect(
-          new URL(`${login}?returnTo=${encodeURIComponent(req.nextUrl.toString())}`, origin)
-        );
+        const { loginHint, screenHint } = querystring.parse(req.nextUrl.search);
+        const q = {
+          returnTo: req.nextUrl.toString(),
+          ...(loginHint ? { loginHint } : {}),
+          ...(screenHint ? { screenHint } : {})
+        };
+        return NextResponse.redirect(new URL(`${login}?${stringify(q)}`, origin));
       }
       const res = await (middleware && middleware(...args));
 

--- a/tests/frontend/with-page-auth-required.test.tsx
+++ b/tests/frontend/with-page-auth-required.test.tsx
@@ -159,4 +159,22 @@ describe('with-page-auth-required csr', () => {
     expect(url.searchParams.get('screenHint')).toEqual('signup');
     expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
   });
+
+  it('prefers loginHint and screenHint options to url params', async () => {
+    (global as any).fetch = fetchUserErrorMock;
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage, {
+      screenHint: 'signup',
+      loginHint: 'test@test.com'
+    });
+    window.location.search = 'screenHint=login&loginHint=other@test.com';
+
+    render(<ProtectedPage />, { wrapper: withUserProvider() });
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalled();
+    });
+    const url = new URL((window.location.assign as jest.Mock).mock.calls[0][0], 'https://example.com');
+    expect(url.searchParams.get('screenHint')).toEqual('signup');
+    expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
+  });
 });

--- a/tests/frontend/with-page-auth-required.test.tsx
+++ b/tests/frontend/with-page-auth-required.test.tsx
@@ -144,4 +144,19 @@ describe('with-page-auth-required csr', () => {
     const url = new URL((window.location.assign as jest.Mock).mock.calls[0][0], 'https://example.com');
     expect(url.searchParams.get('returnTo')).toEqual('/foo?bar=baz&qux=quux');
   });
+
+  it('should forward loginHint and screenHint querystring parameters', async () => {
+    (global as any).fetch = fetchUserErrorMock;
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+    window.location.search = 'screenHint=signup&loginHint=test@test.com';
+
+    render(<ProtectedPage />, { wrapper: withUserProvider() });
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalled();
+    });
+    const url = new URL((window.location.assign as jest.Mock).mock.calls[0][0], 'https://example.com');
+    expect(url.searchParams.get('screenHint')).toEqual('signup');
+    expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
+  });
 });

--- a/tests/helpers/with-middleware-auth-required.test.ts
+++ b/tests/helpers/with-middleware-auth-required.test.ts
@@ -80,6 +80,17 @@ describe('with-middleware-auth-required', () => {
     expect(redirect.searchParams.get('returnTo')).toEqual('http://example.com/foo/bar?baz=hello');
   });
 
+  test('forward loginHint and screenHint querystring parameters', async () => {
+    const res = await setup({ url: 'http://example.com/foo/bar?baz=hello&loginHint=test@test.com&screenHint=signup' });
+    const redirect = new URL(res.headers.get('location') as string);
+    expect(redirect).toMatchObject({
+      hostname: 'example.com',
+      pathname: '/api/auth/login'
+    });
+    expect(redirect.searchParams.get('loginHint')).toEqual('test@test.com');
+    expect(redirect.searchParams.get('screenHint')).toEqual('signup');
+  });
+
   test('should ignore static urls', async () => {
     const res = await setup({ url: 'http://example.com/_next/style.css' });
     expect(res).toBeUndefined();

--- a/tests/helpers/with-page-auth-required.test.ts
+++ b/tests/helpers/with-page-auth-required.test.ts
@@ -107,6 +107,17 @@ describe('with-page-auth-required ssr', () => {
     expect(url.searchParams.get('returnTo')).toEqual('/foo?bar=baz&qux=quux');
   });
 
+  test('should forward loginHint and screenHint querystring parameters', async () => {
+    const baseUrl = await setup(withoutApi, { withPageAuthRequiredOptions: { returnTo: '/foo?bar=baz&qux=quux' } });
+    const {
+      res: { statusCode, headers }
+    } = await get(baseUrl, '/protected?screenHint=signup&loginHint=test@test.com', { fullResponse: true });
+    expect(statusCode).toBe(307);
+    const url = new URL(headers.location, baseUrl);
+    expect(url.searchParams.get('screenHint')).toEqual('signup');
+    expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
+  });
+
   test('allow access to a page with a valid session and async props', async () => {
     const baseUrl = await setup(withoutApi, {
       withPageAuthRequiredOptions: {

--- a/tests/helpers/with-page-auth-required.test.ts
+++ b/tests/helpers/with-page-auth-required.test.ts
@@ -118,6 +118,23 @@ describe('with-page-auth-required ssr', () => {
     expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
   });
 
+  test('prefers loginHint and screenHint options to url params', async () => {
+    const baseUrl = await setup(withoutApi, {
+      withPageAuthRequiredOptions: {
+        returnTo: '/foo?bar=baz&qux=quux',
+        loginHint: 'test@test.com',
+        screenHint: 'signup'
+      }
+    });
+    const {
+      res: { statusCode, headers }
+    } = await get(baseUrl, '/protected?screenHint=login&loginHint=other@test.com', { fullResponse: true });
+    expect(statusCode).toBe(307);
+    const url = new URL(headers.location, baseUrl);
+    expect(url.searchParams.get('screenHint')).toEqual('signup');
+    expect(url.searchParams.get('loginHint')).toEqual('test@test.com');
+  });
+
   test('allow access to a page with a valid session and async props', async () => {
     const baseUrl = await setup(withoutApi, {
       withPageAuthRequiredOptions: {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->
Added the ability to pass `screenHint` and `loginHint` to the login url so that they can be passed in `authorizationParams` to auth0 `handleLogin`


```
    const ProtectedPage = withPageAuthRequired(MyPage, {
      screenHint: 'signup',
      loginHint: 'test@test.com'
    });

```

### 📎 References
Fixes #180

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
