### PR TITLE
Remove type from export in d.ts files

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -1,1 +1,1 @@
-export type * from './dist/client';
+export * from './dist/client';

--- a/edge.d.ts
+++ b/edge.d.ts
@@ -1,1 +1,1 @@
-export type * from './dist/edge';
+export * from './dist/edge';

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -1,1 +1,1 @@
-export type * from './dist/helpers/testing';
+export * from './dist/helpers/testing';


### PR DESCRIPTION
### 📋 Changes

Removes the `type` from the `export` in the d.ts files, as in TypeScript 5.0.0 this is [now a supported thing](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#support-for-export-type) so it causes the imported values to be unusable. It seems like previous versions of TypeScript just ignored the `type` and would treat the import as a value.

### 📎 References

Fixes #1035

### 🎯 Testing

Can be tested by installing [the nightly TS extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next), enabling it per the docs and opening one of the provided samples in the linked issue, it should be flagged in the editor and then removing the `export type` from `node_modules` should unflag it
