### PR TITLE
fix: no caching client side /auth/me

### DIFF
--- a/src/client/use-user.tsx
+++ b/src/client/use-user.tsx
@@ -178,7 +178,9 @@ type UserProviderState = {
 const userFetcher: UserFetcher = async (url) => {
   let response;
   try {
-    response = await fetch(url);
+    response = await fetch(url, {
+      cache: 'no-store'
+    });
   } catch {
     throw new RequestError(0); // Network error
   }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

A while ago, this PR fixed the profile fetch's cache: https://github.com/auth0/nextjs-auth0/pull/233

But the client's `/auth/me` fetch is still not using any cache option,
which leads to an issue that the user can't be redirected to the re-login page when the token has been expired even if they reload a page. 

We found on our app that the library is calling `/auth/me` successfully with `200` **when the token has been actually expired**.

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
