### PR TITLE
Fix issue where storeIDToken config not used by getAccessToken

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -342,6 +342,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
     login: string;
     unauthorized: string;
   };
+  session: Pick<SessionConfig, 'storeIDToken'>;
 }
 
 /**
@@ -565,7 +566,8 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
       unauthorized: baseParams.routes?.unauthorized || '/api/auth/401'
     },
     identityClaimFilter: baseConfig.identityClaimFilter,
-    organization: organization || AUTH0_ORGANIZATION
+    organization: organization || AUTH0_ORGANIZATION,
+    session: { storeIDToken: baseConfig.session.storeIDToken }
   };
 
   return { baseConfig, nextConfig };

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -68,7 +68,7 @@ export function fromTokenSet(tokenSet: TokenSet, config: Config | NextConfig): S
   });
 
   const { id_token, access_token, scope, expires_at, refresh_token, ...remainder } = tokenSet;
-  const storeIDToken = 'session' in config ? config.session.storeIDToken : true;
+  const storeIDToken = config.session.storeIDToken;
 
   return Object.assign(
     new Session({ ...claims }),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -97,7 +97,10 @@ describe('config params', () => {
         postLogoutRedirect: '',
         unauthorized: '/api/auth/401'
       },
-      organization: undefined
+      organization: undefined,
+      session: {
+        storeIDToken: true
+      }
     });
   });
 

--- a/tests/session/get-access-token.test.ts
+++ b/tests/session/get-access-token.test.ts
@@ -291,6 +291,27 @@ describe('get access token', () => {
     expect(newAccessTokenScope).toBeUndefined();
   });
 
+  test('should retrieve a new access token and update the session based on the storeIDToken config', async () => {
+    await refreshTokenExchange(withApi, 'GEbRxBN...edjnXbL', {}, 'new-token');
+    const baseUrl = await setup(
+      { ...withApi, session: { storeIDToken: false } },
+      {
+        getAccessTokenOptions: {
+          refresh: true
+        }
+      }
+    );
+    const cookieJar = await login(baseUrl);
+    const session = await get(baseUrl, '/api/session', { cookieJar });
+    expect(session.idToken).toBeUndefined();
+    const { accessToken } = await get(baseUrl, '/api/access-token', { cookieJar });
+    expect(accessToken).toEqual('new-token');
+    const newSession = await get(baseUrl, '/api/session', {
+      cookieJar
+    });
+    expect(newSession.idToken).toBeUndefined();
+  });
+
   test('should pass custom auth params in refresh grant request body', async () => {
     const idToken = await makeIdToken({
       iss: `${withApi.issuerBaseURL}/`,

--- a/tests/session/session.test.ts
+++ b/tests/session/session.test.ts
@@ -15,7 +15,8 @@ describe('session', () => {
       expect(
         fromTokenSet(new TokenSet({ id_token: await makeIdToken({ foo: 'bar', bax: 'qux' }) }), {
           identityClaimFilter: ['baz'],
-          routes
+          routes,
+          session: { storeIDToken: true }
         }).user
       ).toEqual({
         aud: '__test_client_id__',
@@ -34,7 +35,8 @@ describe('session', () => {
       expect(
         fromTokenSet(new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }), {
           identityClaimFilter: ['baz'],
-          routes
+          routes,
+          session: { storeIDToken: true }
         }).idToken
       ).toBeDefined();
     });


### PR DESCRIPTION
### 📋 Changes

Fix an issue where `storeIDToken` config was not honoured by the new session from refreshing an access token.

### 📎 References

See https://github.com/auth0/nextjs-auth0/issues/1085#issuecomment-1448621662

### 🎯 Testing

```js
// AUTH0_SESSION_STORE_ID_TOKEN=false
const oldSession = await getSession(ctx.req, ctx.res);
assertEqual(oldSession.idToken, undefined);
const accessToken = await getAccessToken(ctx.req, ctx.res, { refresh: true });
const newSession = await getSession(ctx.req, ctx.res);
assertEqual(newSession.idToken, undefined); 💥 
```