### PR TITLE
[SDK-3887] Always honor auth0Logout config

### DIFF
--- a/src/auth0-session/client.ts
+++ b/src/auth0-session/client.ts
@@ -109,8 +109,12 @@ export default function get(config: Config, { name, version }: Telemetry): Clien
     );
     client[custom.clock_tolerance] = config.clockTolerance;
 
-    if (config.idpLogout && !issuer.end_session_endpoint) {
-      if (config.auth0Logout || (url.parse(issuer.metadata.issuer).hostname as string).match('\\.auth0\\.com$')) {
+    if (config.idpLogout) {
+      if (
+        config.auth0Logout ||
+        ((url.parse(issuer.metadata.issuer).hostname as string).match('\\.auth0\\.com$') &&
+          config.auth0Logout !== false)
+      ) {
         Object.defineProperty(client, 'endSessionUrl', {
           value(params: EndSessionParameters) {
             const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
@@ -128,7 +132,7 @@ export default function get(config: Config, { name, version }: Telemetry): Clien
             return url.format(parsedUrl);
           }
         });
-      } else {
+      } else if (!issuer.end_session_endpoint) {
         debug('the issuer does not support RP-Initiated Logout');
       }
     }

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -21,7 +21,7 @@ export interface Config {
   /**
    * Boolean value to enable Auth0's logout feature.
    */
-  auth0Logout: boolean;
+  auth0Logout?: boolean;
 
   /**
    * URL parameters used when redirecting users to the authorization server to log in.

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -53,7 +53,7 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
-  auth0Logout: Joi.boolean().optional().default(false),
+  auth0Logout: Joi.boolean().optional(),
   authorizationParams: Joi.object({
     response_type: Joi.string().optional().valid('id_token', 'code id_token', 'code').default('id_token'),
     scope: Joi.string()

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export interface BaseConfig {
    * Boolean value to enable Auth0's proprietary logout feature.
    * Since this SDK is for Auth0, it's set to `true`by default.
    */
-  auth0Logout: boolean;
+  auth0Logout?: boolean;
 
   /**
    *  URL parameters used when redirecting users to the authorization server to log in.

--- a/tests/auth0-session/client.test.ts
+++ b/tests/auth0-session/client.test.ts
@@ -105,6 +105,66 @@ describe('clientFactory', function () {
     expect(client.id_token_signed_response_alg).toEqual('RS256');
   });
 
+  it('should use discovered logout endpoint by default', async function () {
+    const client = await getClient({ ...defaultConfig, idpLogout: true });
+    expect(client.endSessionUrl({})).toEqual('https://op.example.com/session/end?client_id=__test_client_id__');
+  });
+
+  it('should use auth0 logout endpoint if configured', async function () {
+    const client = await getClient({ ...defaultConfig, idpLogout: true, auth0Logout: true });
+    expect(client.endSessionUrl({})).toEqual('https://op.example.com/v2/logout?client_id=__test_client_id__');
+  });
+
+  it('should use auth0 logout endpoint if domain is auth0.com', async function () {
+    nock('https://foo.auth0.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, { ...wellKnown, issuer: 'https://foo.auth0.com/' });
+    const client = await getClient({ ...defaultConfig, idpLogout: true, issuerBaseURL: 'https://foo.auth0.com' });
+    expect(client.endSessionUrl({})).toEqual('https://foo.auth0.com/v2/logout?client_id=__test_client_id__');
+  });
+
+  it('should use auth0 logout endpoint if domain is auth0.com and configured', async function () {
+    nock('https://foo.auth0.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, { ...wellKnown, issuer: 'https://foo.auth0.com/' });
+    const client = await getClient({
+      ...defaultConfig,
+      issuerBaseURL: 'https://foo.auth0.com',
+      idpLogout: true,
+      auth0Logout: true
+    });
+    expect(client.endSessionUrl({})).toEqual('https://foo.auth0.com/v2/logout?client_id=__test_client_id__');
+  });
+
+  it('should not use discovered logout endpoint if domain is auth0.com but configured with auth0logout false', async function () {
+    nock('https://foo.auth0.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        ...wellKnown,
+        issuer: 'https://foo.auth0.com/',
+        end_session_endpoint: 'https://foo.auth0.com/oidc/logout'
+      });
+    const client = await getClient({
+      ...defaultConfig,
+      issuerBaseURL: 'https://foo.auth0.com',
+      idpLogout: true,
+      auth0Logout: false
+    });
+    expect(client.endSessionUrl({})).toEqual('https://foo.auth0.com/oidc/logout?client_id=__test_client_id__');
+  });
+
+  it('should create client with no end_session_endpoint', async function () {
+    nock('https://op2.example.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        ...wellKnown,
+        issuer: 'https://op2.example.com',
+        end_session_endpoint: undefined
+      });
+    const client = await getClient({ ...defaultConfig, issuerBaseURL: 'https://op2.example.com' });
+    expect(() => client.endSessionUrl({})).toThrowError();
+  });
+
   it('should create custom logout for auth0', async function () {
     nock('https://test.eu.auth0.com')
       .get('/.well-known/openid-configuration')

--- a/tests/auth0-session/client.test.ts
+++ b/tests/auth0-session/client.test.ts
@@ -136,7 +136,7 @@ describe('clientFactory', function () {
     expect(client.endSessionUrl({})).toEqual('https://foo.auth0.com/v2/logout?client_id=__test_client_id__');
   });
 
-  it('should not use discovered logout endpoint if domain is auth0.com but configured with auth0logout false', async function () {
+  it('should use discovered logout endpoint if domain is auth0.com but configured with auth0logout false', async function () {
     nock('https://foo.auth0.com')
       .get('/.well-known/openid-configuration')
       .reply(200, {

--- a/tests/auth0-session/config.test.ts
+++ b/tests/auth0-session/config.test.ts
@@ -64,12 +64,10 @@ describe('Config', () => {
     });
   });
 
-  it('auth0Logout and idpLogout should default to false', () => {
+  it('auth0Logout should default to undefined and idpLogout should default to false', () => {
     const config = getConfig(defaultConfig);
-    expect(config).toMatchObject({
-      auth0Logout: false,
-      idpLogout: false
-    });
+    expect(config.idpLogout).toBe(false);
+    expect(config.auth0Logout).toBeUndefined();
   });
 
   it('should not set auth0Logout to true when idpLogout is true', () => {
@@ -77,10 +75,8 @@ describe('Config', () => {
       ...defaultConfig,
       idpLogout: true
     });
-    expect(config).toMatchObject({
-      auth0Logout: false,
-      idpLogout: true
-    });
+    expect(config.idpLogout).toBe(true);
+    expect(config.auth0Logout).toBeUndefined();
   });
 
   it('should set default route paths', () => {


### PR DESCRIPTION
See https://github.com/auth0/express-openid-connect/pull/447

### Description

The OIDC RP Initiated Logout endpoint is incompatible with Auth0's proprietary logout. Make sure this SDK does not use it if `auth0Logout` is configured and an `end_session_endpoint` is Discovered in the OIDC Discovery document.

### Testing

If `auth0Logout` is true -> use v2/logout regardless of discovery
If `auth0Logout` is false -> use discovered endpoint or nothing
If `auth0Logout` is not set -> use v2/logout regardless of discovery (this is different from express as this is an auth0 SDK)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch