### PR TITLE
Update stateful session cookie expiry on set

### DIFF
--- a/src/auth0-session/session/stateful-session.ts
+++ b/src/auth0-session/session/stateful-session.ts
@@ -87,11 +87,11 @@ export class StatefulSession<
     if (!sessionId) {
       sessionId = await genId!(req);
       debug('generated new session id %o', sessionId);
-      const cookieValue = await generateCookieValue(sessionName, sessionId, keys[0]);
-      cookieSetter.set(sessionName, cookieValue, cookieOptions);
-      cookieSetter.commit(res);
     }
     debug('set session %o', sessionId);
+    const cookieValue = await generateCookieValue(sessionName, sessionId, keys[0]);
+    cookieSetter.set(sessionName, cookieValue, cookieOptions);
+    cookieSetter.commit(res);
     await this.store.set(sessionId, {
       header: { iat, uat, exp },
       data: session

--- a/tests/auth0-session/session/stateful-session.test.ts
+++ b/tests/auth0-session/session/stateful-session.test.ts
@@ -76,6 +76,17 @@ describe('StatefulSession', () => {
     await store.set('foo', await getPayload());
     const baseURL = await setup(config);
     const cookieJar = await toSignedCookieJar({ appSession: 'foo' }, baseURL);
+    const [cookie] = await cookieJar.getCookies(baseURL);
+    const expires = cookie.expires;
+    await get(baseURL, '/session', { cookieJar });
+    const [updatedCookie] = await cookieJar.getCookies(baseURL);
+    expect(updatedCookie.expires > expires);
+  });
+
+  it('should update the cookie expiry when setting an existing session', async () => {
+    await store.set('foo', await getPayload());
+    const baseURL = await setup(config);
+    const cookieJar = await toSignedCookieJar({ appSession: 'foo' }, baseURL);
     const session = await get(baseURL, '/session', { cookieJar });
     expect(session).toMatchObject({
       id_token: expect.any(String),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [N/A] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently stateful session cookies are not being updated on server interaction. The session expiry is being extended (according the the exp being sent to the session store) but without updating the cookie, this change is not having any effect. When the cookie expires, the session is lost.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Implement a stateful session store. Open the Application tab in Chrome dev tools and find the session cookie. Refresh the page. Confirm that the cookie expiry increased in line with header.exp in the stored data

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
