### PR TITLE
feat: add optional session param to genId function

### DIFF
--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -208,7 +208,10 @@ export interface SessionConfig {
    *
    * **IMPORTANT** You must use a suitably unique value to prevent collisions.
    */
-  genId?: <Req = any>(req: Req) => string | Promise<string>;
+  genId?: <Req = any, SessionType extends { [key: string]: any } = { [key: string]: any }>(
+    req: Req,
+    session: SessionType
+  ) => string | Promise<string>;
 
   /**
    * If you want your session duration to be rolling, resetting everytime the

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -31,7 +31,7 @@ const paramsSchema = Joi.object({
     autoSave: Joi.boolean().optional().default(true),
     name: Joi.string().token().optional().default('appSession'),
     store: Joi.object().optional(),
-    genId: Joi.function().maxArity(1).when(Joi.ref('store'), { then: Joi.required() }),
+    genId: Joi.function().maxArity(2).when(Joi.ref('store'), { then: Joi.required() }),
     storeIDToken: Joi.boolean().optional().default(true),
     cookie: Joi.object({
       domain: Joi.string().optional(),

--- a/src/auth0-session/session/stateful-session.ts
+++ b/src/auth0-session/session/stateful-session.ts
@@ -85,7 +85,7 @@ export class StatefulSession<
     }
 
     if (!sessionId) {
-      sessionId = await genId!(req);
+      sessionId = await genId!(req, session);
       debug('generated new session id %o', sessionId);
     }
     debug('set session %o', sessionId);

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,7 +218,10 @@ export interface SessionConfig {
    * **IMPORTANT** If you override this, you must use a suitable value from your platform to
    * prevent collisions. For example, for Node: `require('crypto').randomBytes(16).toString('hex')`.
    */
-  genId?: <Req = any>(req: Req) => string | Promise<string>;
+  genId?: <Req = any, SessionType extends { [key: string]: any } = { [key: string]: any }>(
+    req: Req,
+    session: SessionType
+  ) => string | Promise<string>;
 
   /**
    * If you want your session duration to be rolling, resetting everytime the

--- a/tests/stateful-session.test.ts
+++ b/tests/stateful-session.test.ts
@@ -98,4 +98,15 @@ describe('next stateful session', () => {
     expect(Object.keys(store)).toHaveLength(1);
     expect(cookieJar.getCookieStringSync(baseUrl)).toMatch(/^appSession=foo\..+/);
   });
+
+  it('should provide current user session to custom session id generator', async () => {
+    const genId = jest.fn().mockImplementation((_req, session) => session.user.nickname);
+    const baseURL = await setup({ ...config, session: { ...config.session, genId } });
+    const cookieJar = await login(baseURL);
+    const genIdParams = genId.mock.calls.at(0);
+    expect(genIdParams.length).toEqual(2);
+    expect('idToken' in genIdParams.at(1)).toBeTruthy();
+    expect('user' in genIdParams.at(1)).toBeTruthy();
+    expect(cookieJar.getCookieStringSync(baseURL)).toMatch(/^appSession=__test_nickname__\..+/);
+  });
 });


### PR DESCRIPTION

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

Typedoc needs to be run, I can't run it, links are generated wrong (to PSoltes repo)

### 📋 Changes

Adds session as param to `genId` function, to better link session store keys to exact user sessions.

### 📎 References

https://github.com/auth0/nextjs-auth0/issues/1024

### 🎯 Testing

Use second param in genId function. Create a key for session, that is contained in eg. user object (nickname, email). I recommend encrypting this info, if sensitive to user.
