### PR TITLE
Add prefixed url env for preview deploys on middleware

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -96,17 +96,21 @@ Configure the following environment variables when importing your project or in 
 
 For preview deployments you will either want to assign this to:
 
-- **Automatic Deployment URL:** For example `project-d418mhwf5-team.vercel.app` which is defined by the `VERCEL_URL` environment variable.
-- **Automatic Branch URL:** For example `project-git-update-team.vercel.app` which can be constructed using `${VERCEL_GIT_REPO_SLUG}-git-${VERCEL_GIT_COMMIT_REF}-${VERCEL_GIT_REPO_OWNER}.vercel.app`
+- **Automatic Deployment URL:** For example `project-d418mhwf5-team.vercel.app` which is the `VERCEL_URL` environment variable.
+- **Automatic Branch URL:** For example `project-git-update-team.vercel.app` which is the `VERCEL_BRANCH_URL` environment variable.
 
 See here for more information about Vercel's Automatic Urls: https://vercel.com/docs/concepts/deployments/automatic-urls
 
-To do this, make sure **Automatically expose System Environment Variables** is checked in **Settings > Environment Variables** and assign either the Automatic Deployment URL or the Automatic Branch URL to `AUTH0_BASE_URL` in your `.env.production` file. For example:
+To do this, make sure **Automatically expose System Environment Variables** is checked in **Settings > Environment Variables** and assign either the Automatic Deployment URL (`VERCEL_URL`) or the Automatic Branch URL (`VERCEL_BRANCH_URL`) to `NEXT_PUBLIC_AUTH0_BASE_URL` in your `.env.production` file. For example:
 
 ```shell
 # .env.production
-AUTH0_BASE_URL=$VERCEL_URL
+NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_URL
 ```
+
+> <strong>Note:</strong> The `NEXT_PUBLIC_` prefix is used so you can specify the base URL in your middleware. You must be on version `2.6.0` or later of this SDK to use `NEXT_PUBLIC_AUTH0_BASE_URL`.
+
+> <strong>Note:</strong> Long URLs (> 63 characters) will get truncated by Vercel. See: https://vercel.com/docs/concepts/deployments/generated-urls#truncation
 
 Unlike other `.env` files, You will need to check in `.env.production` so it should **not** contain any secrets. See how we define `.env.production` in the [kitchen-sink example app](./kitchen-sink-example/.env.production).
 

--- a/examples/kitchen-sink-example/.env.production
+++ b/examples/kitchen-sink-example/.env.production
@@ -1,8 +1,10 @@
-# Set the baseUrl for the SDK to the Vercel "Automatic Branch URL" for Preview deploys. Use `${VERCEL_URL}` if you
-# would rather use the 'Automatic Deployment URL' (see: https://vercel.com/changelog/urls-are-becoming-consistent)
+# For preview deploys, set the baseUrl for the SDK to:
+#  - Automatic Deployment URL: `VERCEL__URL` e.g. project-d418mhwf5-team.vercel.app
+#  - Automatic Branch URL: `VERCEL_BRANCH_URL` e.g. project-git-update-team.vercel.app
 #
 # For production deploys from the main branch or custom domains which are assigned to a specific branch (see https://vercel.com/docs/custom-domains#assigning-a-domain-to-a-git-branch)
 # you can assign the `AUTH0_BASE_URL` in the 'Environment Variables' section of your project's settings page which will override this.
 #
 # This file should be checked in so should NOT contain any secrets
-AUTH0_BASE_URL=${VERCEL_GIT_REPO_SLUG}-git-${VERCEL_GIT_COMMIT_REF}-${VERCEL_GIT_REPO_OWNER}.vercel.app
+# The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a ``.env.production` file to assign a Vercel preview URl to this SDK's base URL.
+NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_BRANCH_URL

--- a/examples/kitchen-sink-example/.env.production
+++ b/examples/kitchen-sink-example/.env.production
@@ -6,5 +6,5 @@
 # you can assign the `AUTH0_BASE_URL` in the 'Environment Variables' section of your project's settings page which will override this.
 #
 # This file should be checked in so should NOT contain any secrets
-# The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a `.env.production` file to assign a Vercel preview URl to this SDK's base URL.
+# The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a `.env.production` file to assign a Vercel preview URL to this SDK's base URL.
 NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_BRANCH_URL

--- a/examples/kitchen-sink-example/.env.production
+++ b/examples/kitchen-sink-example/.env.production
@@ -6,5 +6,5 @@
 # you can assign the `AUTH0_BASE_URL` in the 'Environment Variables' section of your project's settings page which will override this.
 #
 # This file should be checked in so should NOT contain any secrets
-# The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a ``.env.production` file to assign a Vercel preview URl to this SDK's base URL.
+# The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a `.env.production` file to assign a Vercel preview URl to this SDK's base URL.
 NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_BRANCH_URL

--- a/examples/kitchen-sink-example/.env.production
+++ b/examples/kitchen-sink-example/.env.production
@@ -1,6 +1,6 @@
 # For preview deploys, set the baseUrl for the SDK to:
-#  - Automatic Deployment URL: `VERCEL__URL` e.g. project-d418mhwf5-team.vercel.app
-#  - Automatic Branch URL: `VERCEL_BRANCH_URL` e.g. project-git-update-team.vercel.app
+#  - Automatic Deployment URL: `VERCEL__URL` for example project-d418mhwf5-team.vercel.app
+#  - Automatic Branch URL: `VERCEL_BRANCH_URL` for example project-git-update-team.vercel.app
 #
 # For production deploys from the main branch or custom domains which are assigned to a specific branch (see https://vercel.com/docs/custom-domains#assigning-a-domain-to-a-git-branch)
 # you can assign the `AUTH0_BASE_URL` in the 'Environment Variables' section of your project's settings page which will override this.

--- a/examples/kitchen-sink-example/pages/api/shows.ts
+++ b/examples/kitchen-sink-example/pages/api/shows.ts
@@ -6,10 +6,8 @@ export default withApiAuthRequired(async function shows(req, res) {
       scopes: ['read:shows']
     });
 
-    const baseURL =
-      process.env.AUTH0_BASE_URL?.indexOf('http') === 0
-        ? process.env.AUTH0_BASE_URL
-        : `https://${process.env.AUTH0_BASE_URL}`;
+    const baseUrlOrDomain = process.env.AUTH0_BASE_URL || process.env.NEXT_PUBLIC_AUTH0_BASE_URL;
+    const baseURL = baseUrlOrDomain?.indexOf('http') === 0 ? baseUrlOrDomain : `https://${baseUrlOrDomain}`;
 
     // This is a contrived example, normally your external API would exist on another domain.
     const response = await fetch(baseURL + '/api/my/shows', {

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,8 @@ export interface BaseConfig {
    * You can also use the `AUTH0_BASE_URL` environment variable.
    * If you provide a domain, we will prefix it with `https://`. This can be useful when assigning it to
    * `VERCEL_URL` for Vercel deploys.
+   *
+   * `NEXT_PUBLIC_AUTH0_BASE_URL` will also be checked if `AUTH0_BASE_URL` is not defined.
    */
   baseURL: string;
 
@@ -487,7 +489,7 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   // Don't use destructuring here so that the `DefinePlugin` can replace any env vars specified in `next.config.js`
   const AUTH0_SECRET = process.env.AUTH0_SECRET;
   const AUTH0_ISSUER_BASE_URL = process.env.AUTH0_ISSUER_BASE_URL;
-  const AUTH0_BASE_URL = process.env.AUTH0_BASE_URL;
+  const AUTH0_BASE_URL = process.env.AUTH0_BASE_URL || process.env.NEXT_PUBLIC_AUTH0_BASE_URL;
   const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID;
   const AUTH0_CLIENT_SECRET = process.env.AUTH0_CLIENT_SECRET;
   const AUTH0_CLOCK_TOLERANCE = process.env.AUTH0_CLOCK_TOLERANCE;


### PR DESCRIPTION
### 📋 Changes

Add `NEXT_PUBLIC_AUTH0_BASE_URL` env var, which will be picked up when `AUTH0_BASE_URL` is not available.

This is useful when you want to assign a Vercel preview URL to the SDK's base URL in your `.env.production`.

The `NEXT_PUBLIC_` prefix is required for Middleware because it evaluates the env vars at build time and

### 📎 References

https://nextjs.org/docs/pages/api-reference/edge#environment-variables
fixes #1106