### PR TITLE
VERCEL_BRANCH_URL is no longer set

### DIFF
--- a/examples/kitchen-sink-example/.env.production
+++ b/examples/kitchen-sink-example/.env.production
@@ -7,4 +7,4 @@
 #
 # This file should be checked in so should NOT contain any secrets
 # The `NEXT_PUBLIC_` prefix is only required when you want to use middleware and a `.env.production` file to assign a Vercel preview URL to this SDK's base URL.
-NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_BRANCH_URL
+NEXT_PUBLIC_AUTH0_BASE_URL=$VERCEL_URL


### PR DESCRIPTION
You have to use `VERCEL_URL`, since `VERCEL_BRANCH_URL` is deprecated.