### PR TITLE
Fix issue where api wrapper was overwriting session update in api

### DIFF
--- a/src/helpers/with-api-auth-required.ts
+++ b/src/helpers/with-api-auth-required.ts
@@ -122,7 +122,9 @@ const appRouteHandlerFactory =
     const apiRes: NextResponse | Response = await apiRoute(req, params);
     const nextApiRes: NextResponse = apiRes instanceof NextResponse ? apiRes : new NextResponse(apiRes.body, apiRes);
     for (const cookie of res.cookies.getAll()) {
-      nextApiRes.cookies.set(cookie);
+      if (!nextApiRes.cookies.get(cookie.name)) {
+        nextApiRes.cookies.set(cookie);
+      }
     }
     return nextApiRes;
   };

--- a/tests/fixtures/app-router-helpers.ts
+++ b/tests/fixtures/app-router-helpers.ts
@@ -82,7 +82,9 @@ export const getResponse = async ({
 
 export const getSession = async (config: any, res: NextResponse) => {
   const req = new NextRequest('https://example.com');
-  res.cookies.getAll().forEach(({ name, value }: { name: string; value: string }) => req.cookies.set(name, value));
+  res.cookies
+    .getAll()
+    .forEach(({ name, value }: { name: string; value: string }) => value && req.cookies.set(name, value));
 
   const store = new StatelessSession(getConfig(config).baseConfig);
   const [session] = await store.read(new Auth0NextRequest(req));


### PR DESCRIPTION
### 📋 Changes

`withApiAuthRequired` was overwriting any session updated in the api handler

### 📎 References

See https://github.com/auth0/nextjs-auth0/issues/1235#issuecomment-1594185552
