### PR TITLE
[SDK-4318] Enable responses from custom middleware

### DIFF
--- a/src/helpers/with-middleware-auth-required.ts
+++ b/src/helpers/with-middleware-auth-required.ts
@@ -82,13 +82,13 @@ export default function withMiddlewareAuthRequiredFactory(
       const res = await (middleware && middleware(...args));
 
       if (res) {
-        const headers = new Headers(res.headers);
-        const cookies = headers.get('set-cookie')?.split(', ') || [];
-        const authCookies = authRes.headers.get('set-cookie')?.split(', ') || [];
-        if (cookies.length || authCookies.length) {
-          headers.set('set-cookie', [...authCookies, ...cookies].join(', '));
+        const nextRes = new NextResponse(res.body, res);
+        for (const cookie of authRes.cookies.getAll()) {
+          if (!nextRes.cookies.get(cookie.name)) {
+            nextRes.cookies.set(cookie);
+          }
         }
-        return NextResponse.next({ ...res, status: res.status, headers });
+        return nextRes;
       } else {
         return authRes;
       }


### PR DESCRIPTION
### 📋 Changes

Enable responses from `withMiddlewareAuthRequired` custom middleware. eg

```js
import { withMiddlewareAuthRequired } from '@auth0/nextjs-auth0/edge';

export default withMiddlewareAuthRequired(() => NextResponse.json({ hello: 'world' }));
```

(Also including a fix for https://github.com/auth0/nextjs-auth0/issues/1253 for the beta)

### 📎 References

fixes https://github.com/auth0/nextjs-auth0/issues/1150

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
