### PR TITLE
Support Organization Name

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -347,7 +347,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
    * Log users in to a specific organization.
    *
    * This will specify an `organization` parameter in your user's login request and will add a step to validate
-   * the `org_id` claim in your user's ID token.
+   * the `org_id` or `org_name` claim in your user's ID token.
    *
    * If your app supports multiple organizations, you should take a look at {@link AuthorizationParams.organization}.
    */

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -203,7 +203,7 @@ const idTokenValidator =
   (afterCallback?: AfterCallback, organization?: string): AfterCallback =>
   (req, res, session, state) => {
     if (organization) {
-      if (organization.indexOf('org_') === 0) {
+      if (organization.startsWith('org_')) {
         assert(session.user.org_id, 'Organization Id (org_id) claim must be a string present in the ID token');
         assert.equal(
           session.user.org_id,

--- a/src/handlers/callback.ts
+++ b/src/handlers/callback.ts
@@ -203,13 +203,23 @@ const idTokenValidator =
   (afterCallback?: AfterCallback, organization?: string): AfterCallback =>
   (req, res, session, state) => {
     if (organization) {
-      assert(session.user.org_id, 'Organization Id (org_id) claim must be a string present in the ID token');
-      assert.equal(
-        session.user.org_id,
-        organization,
-        `Organization Id (org_id) claim value mismatch in the ID token; ` +
-          `expected "${organization}", found "${session.user.org_id}"`
-      );
+      if (organization.indexOf('org_') === 0) {
+        assert(session.user.org_id, 'Organization Id (org_id) claim must be a string present in the ID token');
+        assert.equal(
+          session.user.org_id,
+          organization,
+          `Organization Id (org_id) claim value mismatch in the ID token; ` +
+            `expected "${organization}", found "${session.user.org_id}"`
+        );
+      } else {
+        assert(session.user.org_name, 'Organization Name (org_name) claim must be a string present in the ID token');
+        assert.equal(
+          session.user.org_name.toLowerCase(),
+          organization.toLowerCase(),
+          `Organization Name (org_name) claim value mismatch in the ID token; ` +
+            `expected "${organization}", found "${session.user.org_name}"`
+        );
+      }
     }
     if (afterCallback) {
       return afterCallback(req, res, session, state);

--- a/src/handlers/login.ts
+++ b/src/handlers/login.ts
@@ -115,7 +115,7 @@ export interface AuthorizationParams extends Partial<AuthorizationParameters> {
    * ```
    *
    * Your invite url can then take the format:
-   * `https://example.com/api/invite?invitation=invitation_id&organization=org_id`.
+   * `https://example.com/api/invite?invitation=invitation_id&organization=org_id_or_name`.
    */
   invitation?: string;
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Adds support for the organization name by extending the ID Token validation as follows:

- If organization is set and has the `org_` prefix, we expect an org_id claim
- If organization is set and does not have the `org_` prefix, we expect an org_name claim
