### PR TITLE
chore: Add `.semgrepignore` exclusion manifest

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,7 @@
+.circleci/
+.github/
+cypress/
+docs/
+examples/
+tests/
+*.md

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,3 @@
-.circleci/
-.github/
 cypress/
 docs/
 examples/


### PR DESCRIPTION
This PR adds a `.semgrepignore` manifest file to exclude certain directories and documentation files from being incorrectly flagged by Semgrep.