### PR TITLE
Should not throw when cookie delete fails

### DIFF
--- a/src/http/auth0-next-response-cookies.ts
+++ b/src/http/auth0-next-response-cookies.ts
@@ -4,6 +4,17 @@ import { Auth0ResponseCookies } from '../auth0-session/http';
 
 let warned = false;
 
+const warn = () => {
+  /* c8 ignore next 8 */
+  if (process.env.NODE_ENV === 'development' && !warned) {
+    console.warn(
+      'nextjs-auth0 is attempting to set cookies from a server component,' +
+        'see https://github.com/auth0/nextjs-auth0/tree/beta#important-limitations-of-the-app-directory'
+    );
+    warned = true;
+  }
+};
+
 export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   public constructor() {
     super();
@@ -12,25 +23,18 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   public setCookie(name: string, value: string, options?: CookieSerializeOptions) {
     const cookieSetter = cookies();
     try {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore see: https://github.com/vercel/next.js/pull/50052
       cookieSetter.set({ ...options, name, value });
-    } catch (_) /* c8 ignore next */ {
-      /* c8 ignore next 8 */
-      if (process.env.NODE_ENV === 'development' && !warned) {
-        console.warn(
-          'nextjs-auth0 is attempting to set cookies from a server component,' +
-            'see https://github.com/auth0/nextjs-auth0/tree/beta#important-limitations-of-the-app-directory'
-        );
-        warned = true;
-      }
+    } catch (_) {
+      warn();
     }
   }
 
   public clearCookie(name: string, options?: CookieSerializeOptions) {
     const cookieSetter = cookies();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore see: https://github.com/vercel/next.js/pull/50052
-    cookieSetter.delete({ ...options, name, value: '' });
+    try {
+      cookieSetter.delete({ ...options, name, value: '' });
+    } catch (_) {
+      warn();
+    }
   }
 }

--- a/tests/http/auth0-next-response-cookies.test.ts
+++ b/tests/http/auth0-next-response-cookies.test.ts
@@ -13,11 +13,37 @@ describe('auth0-next-response', () => {
     expect(res.cookies.get('foo')?.value).toEqual('bar');
   });
 
+  it('should not throw when setting a cookie fails', async () => {
+    const cookies = new Auth0NextResponseCookies();
+    jest.mocked(nextCookies).mockImplementation(
+      () =>
+        ({
+          set: () => {
+            throw new Error();
+          }
+        } as any)
+    );
+    expect(() => cookies.setCookie('foo', 'bar')).not.toThrow();
+  });
+
   it('should delete cookies', async () => {
     const cookies = new Auth0NextResponseCookies();
     const res = new NextResponse();
     jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
     cookies.clearCookie('foo');
     expect(res.headers.get('set-cookie')).toEqual('foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
+  });
+
+  it('should not throw when deleting a cookie fails', async () => {
+    const cookies = new Auth0NextResponseCookies();
+    jest.mocked(nextCookies).mockImplementation(
+      () =>
+        ({
+          delete: () => {
+            throw new Error();
+          }
+        } as any)
+    );
+    expect(() => cookies.clearCookie('foo')).not.toThrow();
   });
 });


### PR DESCRIPTION
### 📋 Changes

In addition to setting, clearing cookies should not throw when `cookies.delete` fails (when you're in a Server Component)

### 📎 References

https://github.com/auth0/nextjs-auth0/issues/1235#issuecomment-1632072973


