### PR TITLE
Fix auth handler types when using custom handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "expect-type": "^0.16.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-environment-node-single-context": "^27.3.0",
@@ -6319,6 +6320,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-0.16.0.tgz",
+      "integrity": "sha512-wCpFeVBiAPGiYkQZzaqvGuuBnNCHbtnowMOBpBGY8a27XbG8VAit3lklWph1r8VmgsH61mOZqI3NuGm8bZnUlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expect/node_modules/chalk": {
@@ -19640,6 +19650,12 @@
           }
         }
       }
+    },
+    "expect-type": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-0.16.0.tgz",
+      "integrity": "sha512-wCpFeVBiAPGiYkQZzaqvGuuBnNCHbtnowMOBpBGY8a27XbG8VAit3lklWph1r8VmgsH61mOZqI3NuGm8bZnUlw==",
+      "dev": true
     },
     "extend": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "expect-type": "^0.16.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-environment-node-single-context": "^27.3.0",

--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -5,7 +5,7 @@ import { HandleLogout } from './logout';
 import { HandleCallback } from './callback';
 import { HandleProfile } from './profile';
 import { HandlerError } from '../utils/errors';
-import { AppRouteHandlerFn, AppRouteHandlerFnContext, Handler } from './router-helpers';
+import { AppRouteHandlerFn, AppRouteHandlerFnContext, AppRouterHandler, PageRouterHandler } from './router-helpers';
 import { isRequest } from '../utils/req-helpers';
 
 /**
@@ -66,7 +66,7 @@ export type Handlers = ApiHandlers | ErrorHandlers;
 /**
  * @ignore
  */
-type ApiHandlers = { [key: string]: Handler };
+type ApiHandlers = { [key: string]: PageRouterHandler | AppRouterHandler };
 
 /**
  * @ignore

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -24,5 +24,4 @@ export {
   AfterRefetchAppRoute
 } from './profile';
 export { default as handlerFactory, Handlers, HandleAuth, AppRouterOnError, PageRouterOnError } from './auth';
-export { AppRouteHandlerFn } from './router-helpers';
-export { AppRouteHandlerFnContext } from './router-helpers';
+export { AppRouteHandlerFnContext, PageRouterHandler, AppRouterHandler } from './router-helpers';

--- a/src/handlers/router-helpers.ts
+++ b/src/handlers/router-helpers.ts
@@ -47,6 +47,9 @@ export type AuthHandler<Opts> = Handler<Opts> & {
   (options?: Opts): Handler<Opts>;
 };
 
+export type PageRouterHandler = (req: NextRequest, ctx: AppRouteHandlerFnContext) => Promise<Response> | Response;
+export type AppRouterHandler = (req: NextApiRequest, res: NextApiResponse) => Promise<unknown> | unknown;
+
 export type Handler<Opts = any> = {
   (req: NextRequest, ctx: AppRouteHandlerFnContext, options?: Opts): Promise<Response> | Response;
   (req: NextApiRequest, res: NextApiResponse, options?: Opts): Promise<unknown> | unknown;

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -39,7 +39,7 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
  * @category Server
  */
 export type AppRouterPageRouteOpts = {
-  params?: { slug: string };
+  params?: Record<string, string | string[]>;
   searchParams?: { [key: string]: string | string[] | undefined };
 };
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -107,7 +107,9 @@ export {
   AfterRefetchAppRoute,
   AppRouterOnError,
   PageRouterOnError,
-  AppRouteHandlerFnContext
+  AppRouteHandlerFnContext,
+  AppRouterHandler,
+  PageRouterHandler
 } from './handlers';
 
 export {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -106,7 +106,8 @@ export {
   AfterRefetchPageRoute,
   AfterRefetchAppRoute,
   AppRouterOnError,
-  PageRouterOnError
+  PageRouterOnError,
+  AppRouteHandlerFnContext
 } from './handlers';
 
 export {

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { expectTypeOf } from 'expect-type';
+import { handleAuth, HandlerError, AppRouteHandlerFnContext, withPageAuthRequired } from '../src';
+
+describe('types', () => {
+  test('should allow customisation of page router auth handlers', () => {
+    expectTypeOf(handleAuth).toBeCallableWith({
+      login(_req: NextApiRequest, _res: NextApiResponse) {}
+    });
+  });
+
+  test('should allow customisation of page router error handler', () => {
+    expectTypeOf(handleAuth).toBeCallableWith({
+      onError(_req: NextApiRequest, _res: NextApiResponse, _err: HandlerError) {}
+    });
+  });
+
+  test('should allow customisation of app router auth handlers', () => {
+    expectTypeOf(handleAuth).toBeCallableWith({
+      login(_req: NextRequest) {
+        return new NextResponse();
+      }
+    });
+  });
+
+  test('should allow customisation of app router auth handlers with context', () => {
+    expectTypeOf(handleAuth).toBeCallableWith({
+      login(_req: NextRequest, _ctx: AppRouteHandlerFnContext) {
+        return new NextResponse();
+      }
+    });
+  });
+
+  test('should allow customisation of app router auth handlers with context literal', () => {
+    expectTypeOf(handleAuth).toBeCallableWith({
+      login(_req: NextRequest, _ctx: { params: Record<string, string | string[]> }) {
+        return new NextResponse();
+      }
+    });
+  });
+
+  test('should allow withPageAuthRequired in app router', () => {
+    async function Page() {
+      return <span>Foo</span>;
+    }
+    expectTypeOf(withPageAuthRequired).toBeCallableWith(Page);
+  });
+
+  test('should allow withPageAuthRequired in app router with opts', () => {
+    async function Page() {
+      return <span>Foo</span>;
+    }
+    expectTypeOf(withPageAuthRequired).toBeCallableWith(Page, { returnTo: 'foo' });
+  });
+
+  test('should allow custom params in withPageAuthRequired', () => {
+    async function Page({ params }: { params?: Record<string, string | string[]> }) {
+      return <span>{typeof params}</span>;
+    }
+    expectTypeOf(withPageAuthRequired).toBeCallableWith(Page);
+  });
+});


### PR DESCRIPTION
### 📋 Changes

Fix types for `handleAuth` when customizing the app and page router handlers with functions
Fix types for `withPageAuthRequired` when providing custom param names
Add some types tests using 'expect-type'

### 📎 References

fixes #1321
see https://github.com/auth0/nextjs-auth0/issues/1235#issuecomment-1641250543
