### PR TITLE
Fix broken link in warning

### DIFF
--- a/src/http/auth0-next-response-cookies.ts
+++ b/src/http/auth0-next-response-cookies.ts
@@ -9,7 +9,7 @@ const warn = () => {
   if (process.env.NODE_ENV === 'development' && !warned) {
     console.warn(
       'nextjs-auth0 is attempting to set cookies from a server component,' +
-        'see https://github.com/auth0/nextjs-auth0/tree/beta#important-limitations-of-the-app-directory'
+        'see https://github.com/auth0/nextjs-auth0#important-limitations-of-the-app-directory'
     );
     warned = true;
   }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The library prints a warning when attempting to set cookies from a server component (saw it on CI) and points to a beta link which is now broken. This PR fixes the link.
