### PR TITLE
Fix for edge cookies delete not supporting domain or path

### DIFF
--- a/src/http/auth0-next-response-cookies.ts
+++ b/src/http/auth0-next-response-cookies.ts
@@ -32,7 +32,7 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   public clearCookie(name: string, options?: CookieSerializeOptions) {
     const cookieSetter = cookies();
     try {
-      cookieSetter.delete({ ...options, name, value: '' });
+      cookieSetter.set({ ...options, name, value: '', expires: new Date(0) });
     } catch (_) {
       warn();
     }

--- a/src/http/auth0-next-response.ts
+++ b/src/http/auth0-next-response.ts
@@ -13,7 +13,7 @@ export default class Auth0NextResponse extends Auth0Response<NextResponse> {
   }
 
   public clearCookie(name: string, options?: CookieSerializeOptions) {
-    this.res.cookies.delete({ ...options, name, value: '' });
+    this.setCookie(name, '', { ...options, expires: new Date(0) });
   }
 
   public redirect(location: string, status = 302): void {

--- a/tests/http/auth0-next-response-cookies.test.ts
+++ b/tests/http/auth0-next-response-cookies.test.ts
@@ -34,6 +34,24 @@ describe('auth0-next-response', () => {
     expect(res.headers.get('set-cookie')).toEqual('foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
   });
 
+  it('should delete cookies with a domain', async () => {
+    const cookies = new Auth0NextResponseCookies();
+    const res = new NextResponse();
+    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    cookies.clearCookie('foo', { domain: 'example.com' });
+    expect(res.headers.get('set-cookie')).toEqual(
+      'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com'
+    );
+  });
+
+  it('should delete cookies with a path', async () => {
+    const cookies = new Auth0NextResponseCookies();
+    const res = new NextResponse();
+    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    cookies.clearCookie('foo', { path: '/foo' });
+    expect(res.headers.get('set-cookie')).toEqual('foo=; Path=/foo; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
+  });
+
   it('should not throw when deleting a cookie fails', async () => {
     const cookies = new Auth0NextResponseCookies();
     jest.mocked(nextCookies).mockImplementation(

--- a/tests/http/auth0-next-response.test.ts
+++ b/tests/http/auth0-next-response.test.ts
@@ -34,11 +34,29 @@ describe('auth0-next-response', () => {
     expect(auth0Res.res.headers.get('set-cookie')).toEqual(['foo=bar; Path=/', 'baz=qux; Path=/'].join(', '));
   });
 
-  it('should clear cookies', async () => {
+  it('should delete a cookie', async () => {
     const [, res] = setup();
     const auth0Res = new Auth0NextResponse(res);
     auth0Res.clearCookie('foo');
 
-    expect(auth0Res.res.headers.get('set-cookie')).toMatch(/foo=;.*Expires=.*1970/);
+    expect(auth0Res.res.headers.get('set-cookie')).toBe('foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
+  });
+
+  it('should delete a cookie with domain option', async () => {
+    const [, res] = setup();
+    const auth0Res = new Auth0NextResponse(res);
+    auth0Res.clearCookie('foo', { domain: 'example.com' });
+
+    expect(auth0Res.res.headers.get('set-cookie')).toBe(
+      'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com'
+    );
+  });
+
+  it('should delete a cookie with path option', async () => {
+    const [, res] = setup();
+    const auth0Res = new Auth0NextResponse(res);
+    auth0Res.clearCookie('foo', { path: '/foo' });
+
+    expect(auth0Res.res.headers.get('set-cookie')).toBe('foo=; Path=/foo; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
   });
 });


### PR DESCRIPTION
### 📋 Changes

`NextRespons.cookies.delete` currently doesn't support the `path` or `domain` options. Workaround this by using `NextRespons.cookies.set` (which does)

### 📎 References

See https://github.com/vercel/edge-runtime/pull/507
fixes #1337 
