### PR TITLE
Move state cookies to under a single cookie

### DIFF
--- a/src/auth0-session/index.ts
+++ b/src/auth0-session/index.ts
@@ -1,6 +1,7 @@
 export {
   MissingStateParamError,
   MissingStateCookieError,
+  MalformedStateCookieError,
   IdentityProviderError,
   ApplicationError
 } from './utils/errors';

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -30,7 +30,7 @@ export class MalformedStateCookieError extends Error {
   constructor() {
     /* c8 ignore next */
     super(MalformedStateCookieError.message);
-    Object.setPrototypeOf(this, MissingStateCookieError.prototype);
+    Object.setPrototypeOf(this, MalformedStateCookieError.prototype);
   }
 }
 

--- a/src/auth0-session/utils/errors.ts
+++ b/src/auth0-session/utils/errors.ts
@@ -22,6 +22,18 @@ export class MissingStateParamError extends Error {
   }
 }
 
+export class MalformedStateCookieError extends Error {
+  static message = 'Your state cookie is not valid JSON.';
+  status = 400;
+  statusCode = 400;
+
+  constructor() {
+    /* c8 ignore next */
+    super(MalformedStateCookieError.message);
+    Object.setPrototypeOf(this, MissingStateCookieError.prototype);
+  }
+}
+
 export class MissingStateCookieError extends Error {
   static message = 'Missing state cookie from login request (check login URL, callback URL and cookie config).';
   status = 400;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -137,6 +137,7 @@ export {
 
 export {
   MissingStateCookieError,
+  MalformedStateCookieError,
   MissingStateParamError,
   IdentityProviderError,
   ApplicationError

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -52,6 +52,20 @@ describe('callback', () => {
     );
   });
 
+  it('should error when auth_verification cookie is malformed', async () => {
+    const baseURL = await setup(defaultConfig);
+
+    await expect(
+      post(baseURL, '/callback', {
+        body: {
+          state: '__test_state__',
+          id_token: '__invalid_token__'
+        },
+        cookieJar: await toSignedCookieJar({ auth_verification: 'not json' }, baseURL)
+      })
+    ).rejects.toThrowError('Your state cookie is not valid JSON.');
+  });
+
   it("should error when state doesn't match", async () => {
     const baseURL = await setup(defaultConfig);
 
@@ -167,9 +181,9 @@ describe('callback', () => {
     const baseURL = await setup({ ...defaultConfig, legacySameSiteCookie: false });
 
     const cookieJar = await toSignedCookieJar(
-      authVerificationCookie({
-        _state: '__valid_state__'
-      }),
+      {
+        _auth_verification: JSON.stringify({ state: '__valid_state__' })
+      },
       baseURL
     );
 

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -15,6 +15,8 @@ const privateKey = readFileSync(join(__dirname, '..', 'fixtures', 'private-key.p
 
 const expectedDefaultState = encodeState({ returnTo: 'https://example.org' });
 
+const authVerificationCookie = (cookies: Record<string, string>) => ({ auth_verification: JSON.stringify(cookies) });
+
 describe('callback', () => {
   afterEach(teardown);
 
@@ -22,10 +24,10 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         nonce: '__test_nonce__',
         state: '__test_state__'
-      },
+      }),
       baseURL
     );
 
@@ -54,10 +56,10 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         nonce: '__valid_nonce__',
         state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -76,10 +78,10 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         nonce: '__valid_nonce__',
         state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -98,10 +100,10 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         nonce: '__valid_nonce__',
         state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -122,10 +124,10 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         nonce: '__valid_nonce__',
         state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -144,9 +146,9 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -165,9 +167,9 @@ describe('callback', () => {
     const baseURL = await setup({ ...defaultConfig, legacySameSiteCookie: false });
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         _state: '__valid_state__'
-      },
+      }),
       baseURL
     );
 
@@ -197,11 +199,11 @@ describe('callback', () => {
     };
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
         max_age: '100'
-      },
+      }),
       baseURL
     );
 
@@ -228,10 +230,10 @@ describe('callback', () => {
     };
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -254,11 +256,11 @@ describe('callback', () => {
     const baseURL = await setup({ ...defaultConfig, authorizationParams: { response_type: 'id_token' } });
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
         response_type: 'code id_token'
-      },
+      }),
       baseURL
     );
 
@@ -300,10 +302,10 @@ describe('callback', () => {
       }));
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -360,10 +362,10 @@ describe('callback', () => {
       });
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -411,10 +413,10 @@ describe('callback', () => {
       });
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -441,10 +443,10 @@ describe('callback', () => {
 
     const state = encodeState({ foo: 'bar' });
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: state,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -465,7 +467,7 @@ describe('callback', () => {
     const redirectUri = 'http://messi:3000/api/auth/callback/runtime';
     const baseURL = await setup(defaultConfig, { callbackOptions: { redirectUri } });
     const state = encodeState({ foo: 'bar' });
-    const cookieJar = await toSignedCookieJar({ state, nonce: '__test_nonce__' }, baseURL);
+    const cookieJar = await toSignedCookieJar(authVerificationCookie({ state, nonce: '__test_nonce__' }), baseURL);
     const { res } = await post(baseURL, '/callback', {
       body: {
         state: state,
@@ -491,10 +493,10 @@ describe('callback', () => {
 
     const state = encodeState({ foo: 'bar' });
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: state,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -523,10 +525,10 @@ describe('callback', () => {
 
     const state = encodeState({ foo: 'bar' });
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: state,
         nonce: '__test_nonce__'
-      },
+      }),
       baseURL
     );
 
@@ -547,11 +549,11 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
         response_type: 'code id_token'
-      },
+      }),
       baseURL
     );
 
@@ -572,11 +574,11 @@ describe('callback', () => {
     const baseURL = await setup(defaultConfig);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
         response_type: 'code id_token'
-      },
+      }),
       baseURL
     );
 
@@ -599,11 +601,11 @@ describe('callback', () => {
     nock('https://op2.example.com').get('/.well-known/openid-configuration').reply(500);
 
     const cookieJar = await toSignedCookieJar(
-      {
+      authVerificationCookie({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
         response_type: 'code id_token'
-      },
+      }),
       baseURL
     );
 

--- a/tests/auth0-session/handlers/logout.test.ts
+++ b/tests/auth0-session/handlers/logout.test.ts
@@ -10,7 +10,7 @@ import wellKnown from '../fixtures/well-known.json';
 const login = async (baseURL: string): Promise<CookieJar> => {
   const nonce = '__test_nonce__';
   const state = encodeState({ returnTo: 'https://example.org' });
-  const cookieJar = await toSignedCookieJar({ state, nonce }, baseURL);
+  const cookieJar = await toSignedCookieJar({ auth_verification: JSON.stringify({ state, nonce }) }, baseURL);
   await post(baseURL, '/callback', {
     body: {
       state,
@@ -89,7 +89,7 @@ describe('logout route', () => {
     });
     const nonce = '__test_nonce__';
     const state = encodeState({ returnTo: 'https://example.org' });
-    const cookieJar = await toSignedCookieJar({ state, nonce }, baseURL);
+    const cookieJar = await toSignedCookieJar({ auth_verification: JSON.stringify({ state, nonce }) }, baseURL);
     await post(baseURL, '/callback', {
       body: {
         state,

--- a/tests/auth0-session/session/stateful-session.test.ts
+++ b/tests/auth0-session/session/stateful-session.test.ts
@@ -14,7 +14,10 @@ const epochNow = (Date.now() / 1000) | 0;
 const login = async (baseURL: string, existingSession?: { appSession: string }): Promise<CookieJar> => {
   const nonce = '__test_nonce__';
   const state = encodeState({ returnTo: 'https://example.org' });
-  const cookieJar = await toSignedCookieJar({ state, nonce, ...existingSession }, baseURL);
+  const cookieJar = await toSignedCookieJar(
+    { auth_verification: JSON.stringify({ state, nonce }), ...existingSession },
+    baseURL
+  );
   await post(baseURL, '/callback', {
     body: {
       state,

--- a/tests/fixtures/app-router-helpers.ts
+++ b/tests/fixtures/app-router-helpers.ts
@@ -126,9 +126,10 @@ export const login = async (opts: LoginOpts = {}) => {
     url: `/api/auth/callback?state=${state}&code=code`,
     cookies: {
       ...opts.cookies,
-      state: await signCookie('state', state),
-      nonce: await signCookie('nonce', '__test_nonce__'),
-      code_verifier: await signCookie('code_verifier', '__test_code_verifier__')
+      auth_verification: await signCookie(
+        'auth_verification',
+        JSON.stringify({ state, nonce: '__test_nonce__', code_verifier: '__test_code_verifier__' })
+      )
     }
   });
 };

--- a/tests/fixtures/setup.ts
+++ b/tests/fixtures/setup.ts
@@ -135,7 +135,7 @@ export const teardown = async (): Promise<void> => {
 export const login = async (baseUrl: string): Promise<CookieJar> => {
   const nonce = '__test_nonce__';
   const state = encodeState({ returnTo: '/' });
-  const cookieJar = await toSignedCookieJar({ state, nonce }, baseUrl);
+  const cookieJar = await toSignedCookieJar({ auth_verification: JSON.stringify({ state, nonce }) }, baseUrl);
   await post(baseUrl, '/api/auth/callback', {
     fullResponse: true,
     body: {

--- a/tests/handlers/login.test.ts
+++ b/tests/handlers/login.test.ts
@@ -12,17 +12,7 @@ describe('login handler (app router)', () => {
     const res = await getResponse({
       url: '/api/auth/login'
     });
-    expect(res.cookies.get('nonce')).toMatchObject({
-      value: expect.any(String),
-      path: '/',
-      sameSite: 'lax'
-    });
-    expect(res.cookies.get('state')).toMatchObject({
-      value: expect.any(String),
-      path: '/',
-      sameSite: 'lax'
-    });
-    expect(res.cookies.get('code_verifier')).toMatchObject({
+    expect(res.cookies.get('auth_verification')).toMatchObject({
       value: expect.any(String),
       path: '/',
       sameSite: 'lax'
@@ -34,8 +24,9 @@ describe('login handler (app router)', () => {
       url: '/api/auth/login',
       loginOpts: { returnTo: '/custom-url' }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toEqual('/custom-url');
   });
 
@@ -43,7 +34,8 @@ describe('login handler (app router)', () => {
     const res = await getResponse({
       url: '/api/auth/login'
     });
-    const { value: state } = res.cookies.get('state');
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
     expect(urlParse(res.headers.get('location'), true)).toMatchObject({
       protocol: 'https:',
       host: 'acme.auth0.local',
@@ -54,7 +46,7 @@ describe('login handler (app router)', () => {
         response_type: 'code',
         redirect_uri: 'http://www.acme.com/api/auth/callback',
         nonce: expect.any(String),
-        state: state.split('.')[0],
+        state,
         code_challenge: expect.any(String),
         code_challenge_method: 'S256'
       },
@@ -119,8 +111,9 @@ describe('login handler (app router)', () => {
         }
       }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState).toEqual({
       foo: 'bar',
       returnTo: 'http://www.acme.com/'
@@ -137,8 +130,9 @@ describe('login handler (app router)', () => {
         }
       }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState).toEqual({
       foo: 'bar',
       returnTo: '/profile'
@@ -155,8 +149,9 @@ describe('login handler (app router)', () => {
         }
       }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState).toEqual({
       foo: 'bar',
       returnTo: '/bar'
@@ -167,8 +162,9 @@ describe('login handler (app router)', () => {
     const res = await getResponse({
       url: '/api/auth/login?returnTo=/from-query'
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toEqual('http://www.acme.com/from-query');
   });
 
@@ -176,8 +172,9 @@ describe('login handler (app router)', () => {
     const res = await getResponse({
       url: '/api/auth/login?returnTo=/foo&returnTo=bar'
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toEqual('http://www.acme.com/foo');
   });
 
@@ -185,8 +182,9 @@ describe('login handler (app router)', () => {
     const res = await getResponse({
       url: '/api/auth/login?returnTo=https://evil.com'
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toBeUndefined();
   });
 
@@ -195,8 +193,9 @@ describe('login handler (app router)', () => {
       url: '/api/auth/login',
       loginOpts: { returnTo: 'https://google.com' }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toBe('https://google.com');
   });
 
@@ -210,8 +209,9 @@ describe('login handler (app router)', () => {
       url: '/api/auth/login?returnTo=/bar',
       loginOpts
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toBe('https://other-org.acme.com/bar');
   });
 
@@ -224,8 +224,9 @@ describe('login handler (app router)', () => {
         }
       }
     });
-    const { value: state } = res.cookies.get('state');
-    const decodedState = decodeState(state.split('.')[0]);
+    const { value: authVerification } = res.cookies.get('auth_verification');
+    const { state } = JSON.parse(authVerification.split('.')[0]);
+    const decodedState = decodeState(state);
     expect(decodedState?.returnTo).toBe('/bar');
   });
 


### PR DESCRIPTION
### 📋 Changes

Currently we set up to 5 cookies to verify the authentication response (state, nonce, max_age, code_verifier, response_type)

Am moving these under a single cookie to make it easier to customize the cookie name and settings to implement a solution for #1297

The same change has been done in express-openid-connect https://github.com/auth0/express-openid-connect/pull/168

The change is to 2 files:
- src/auth0-session/handlers/callback.ts
- src/auth0-session/handlers/login.ts
 
(the rest of the changes are tests)