### PR TITLE
Add option to override transaction cookie name and config

### DIFF
--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -188,6 +188,14 @@ export interface Config {
    * You can also use the `AUTH0_CLIENT_ASSERTION_SIGNING_ALG` environment variable.
    */
   clientAssertionSigningAlg?: string;
+
+  /**
+   * By default, the transaction cookie takes the same settings as the
+   * session cookie. But you may want to configure the session cookie to be more
+   * secure in a way that would break the OAuth flow's usage of the transaction
+   * cookie (Setting SameSite=Strict for example).
+   */
+  transactionCookie: CookieConfig & { name: string };
 }
 
 /**

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -195,7 +195,7 @@ export interface Config {
    * secure in a way that would break the OAuth flow's usage of the transaction
    * cookie (Setting SameSite=Strict for example).
    */
-  transactionCookie: CookieConfig & { name: string };
+  transactionCookie: Omit<CookieConfig, 'transient' | 'httpOnly'> & { name: string };
 }
 
 /**

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -166,7 +166,18 @@ const paramsSchema = Joi.object({
     }),
   clientAssertionSigningAlg: Joi.string()
     .optional()
-    .valid('RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512', 'EdDSA')
+    .valid('RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES256K', 'ES384', 'ES512', 'EdDSA'),
+  transactionCookie: Joi.object({
+    name: Joi.string().default('auth_verification'),
+    domain: Joi.string().default(Joi.ref('/session.cookie.domain')),
+    transient: Joi.boolean().default(Joi.ref('/session.cookie.transient')),
+    httpOnly: Joi.boolean().default(Joi.ref('/session.cookie.transient')),
+    secure: Joi.boolean().default(Joi.ref('/session.cookie.secure')),
+    sameSite: Joi.string().valid('lax', 'strict', 'none').default(Joi.ref('/session.cookie.sameSite')),
+    path: Joi.string().uri({ relativeOnly: true }).default(Joi.ref('/session.cookie.transient'))
+  })
+    .default()
+    .unknown(false)
 });
 
 export type DeepPartial<T> = {

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -170,8 +170,6 @@ const paramsSchema = Joi.object({
   transactionCookie: Joi.object({
     name: Joi.string().default('auth_verification'),
     domain: Joi.string().default(Joi.ref('/session.cookie.domain')),
-    transient: Joi.boolean().default(Joi.ref('/session.cookie.transient')),
-    httpOnly: Joi.boolean().default(Joi.ref('/session.cookie.transient')),
     secure: Joi.boolean().default(Joi.ref('/session.cookie.secure')),
     sameSite: Joi.string().valid('lax', 'strict', 'none').default(Joi.ref('/session.cookie.sameSite')),
     path: Joi.string().uri({ relativeOnly: true }).default(Joi.ref('/session.cookie.transient'))

--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -36,7 +36,7 @@ export default function callbackHandlerFactory(
     let tokenResponse;
 
     let authVerification: AuthVerification;
-    const cookie = await transientCookieHandler.read('auth_verification', req, res);
+    const cookie = await transientCookieHandler.read(config.transactionCookie.name, req, res);
 
     if (!cookie) {
       throw new MissingStateCookieError();

--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -86,8 +86,8 @@ export default function loginHandlerFactory(
       authVerification.response_type = responseType;
     }
 
-    await transientHandler.save('auth_verification', req, res, {
-      sameSite: authParams.response_mode === 'form_post' ? 'none' : config.session.cookie.sameSite,
+    await transientHandler.save(config.transactionCookie.name, req, res, {
+      sameSite: authParams.response_mode === 'form_post' ? 'none' : config.transactionCookie.sameSite,
       value: JSON.stringify(authVerification)
     });
 

--- a/src/auth0-session/transient-store.ts
+++ b/src/auth0-session/transient-store.ts
@@ -41,7 +41,7 @@ export default class TransientStore {
     { sameSite = 'none', value }: StoreOptions
   ): Promise<string> {
     const isSameSiteNone = sameSite === 'none';
-    const { domain, path, secure } = this.config.session.cookie;
+    const { domain, path, secure } = this.config.transactionCookie;
     const basicAttr = {
       httpOnly: true,
       secure,
@@ -81,7 +81,7 @@ export default class TransientStore {
   async read(key: string, req: Auth0Request, res: Auth0Response): Promise<string | undefined> {
     const cookies = req.getCookies();
     const cookie = cookies[key];
-    const cookieConfig = this.config.session.cookie;
+    const cookieConfig = this.config.transactionCookie;
 
     const verifyingKeys = await this.getKeys();
     let value = await getCookieValue(key, cookie, verifyingKeys);

--- a/src/config.ts
+++ b/src/config.ts
@@ -203,12 +203,10 @@ export interface BaseConfig {
    * `AUTH0_TRANSACTION_COOKIE_NAME`
    * `AUTH0_TRANSACTION_COOKIE_DOMAIN`
    * `AUTH0_TRANSACTION_COOKIE_PATH`
-   * `AUTH0_TRANSACTION_COOKIE_TRANSIENT`
-   * `AUTH0_TRANSACTION_COOKIE_HTTP_ONLY`
    * `AUTH0_TRANSACTION_COOKIE_SAME_SITE`
    * `AUTH0_TRANSACTION_COOKIE_SECURE`
    */
-  transactionCookie: CookieConfig & { name: string };
+  transactionCookie: Omit<CookieConfig, 'transient' | 'httpOnly'> & { name: string };
 }
 
 /**
@@ -437,8 +435,6 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  * - `AUTH0_TRANSACTION_COOKIE_NAME` See {@link BaseConfig.transactionCookie}
  * - `AUTH0_TRANSACTION_COOKIE_DOMAIN` See {@link BaseConfig.transactionCookie}
  * - `AUTH0_TRANSACTION_COOKIE_PATH` See {@link BaseConfig.transactionCookie}
- * - `AUTH0_TRANSACTION_COOKIE_TRANSIENT` See {@link BaseConfig.transactionCookie}
- * - `AUTH0_TRANSACTION_COOKIE_HTTP_ONLY` See {@link BaseConfig.transactionCookie}
  * - `AUTH0_TRANSACTION_COOKIE_SAME_SITE` See {@link BaseConfig.transactionCookie}
  * - `AUTH0_TRANSACTION_COOKIE_SECURE` See {@link BaseConfig.transactionCookie}
  *
@@ -546,8 +542,6 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   const AUTH0_TRANSACTION_COOKIE_NAME = process.env.AUTH0_TRANSACTION_COOKIE_NAME;
   const AUTH0_TRANSACTION_COOKIE_DOMAIN = process.env.AUTH0_TRANSACTION_COOKIE_DOMAIN;
   const AUTH0_TRANSACTION_COOKIE_PATH = process.env.AUTH0_TRANSACTION_COOKIE_PATH;
-  const AUTH0_TRANSACTION_COOKIE_TRANSIENT = process.env.AUTH0_TRANSACTION_COOKIE_TRANSIENT;
-  const AUTH0_TRANSACTION_COOKIE_HTTP_ONLY = process.env.AUTH0_TRANSACTION_COOKIE_HTTP_ONLY;
   const AUTH0_TRANSACTION_COOKIE_SAME_SITE = process.env.AUTH0_TRANSACTION_COOKIE_SAME_SITE;
   const AUTH0_TRANSACTION_COOKIE_SECURE = process.env.AUTH0_TRANSACTION_COOKIE_SECURE;
 
@@ -611,8 +605,6 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
       name: AUTH0_TRANSACTION_COOKIE_NAME,
       domain: AUTH0_TRANSACTION_COOKIE_DOMAIN,
       path: AUTH0_TRANSACTION_COOKIE_PATH || '/',
-      transient: bool(AUTH0_TRANSACTION_COOKIE_TRANSIENT),
-      httpOnly: bool(AUTH0_TRANSACTION_COOKIE_HTTP_ONLY),
       secure: bool(AUTH0_TRANSACTION_COOKIE_SECURE),
       sameSite: AUTH0_TRANSACTION_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none' | undefined,
       ...baseParams.transactionCookie

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,23 @@ export interface BaseConfig {
    *  You can also use the `AUTH0_CLIENT_ASSERTION_SIGNING_ALG` environment variable.
    */
   clientAssertionSigningAlg?: string;
+
+  /**
+   * By default, the transaction cookie takes the same settings as the
+   * session cookie. But you may want to configure the session cookie to be more
+   * secure in a way that would break the OAuth flow's usage of the transaction
+   * cookie (Setting SameSite=Strict for example).
+   *
+   * You can also use:
+   * `AUTH0_TRANSACTION_COOKIE_NAME`
+   * `AUTH0_TRANSACTION_COOKIE_DOMAIN`
+   * `AUTH0_TRANSACTION_COOKIE_PATH`
+   * `AUTH0_TRANSACTION_COOKIE_TRANSIENT`
+   * `AUTH0_TRANSACTION_COOKIE_HTTP_ONLY`
+   * `AUTH0_TRANSACTION_COOKIE_SAME_SITE`
+   * `AUTH0_TRANSACTION_COOKIE_SECURE`
+   */
+  transactionCookie: CookieConfig & { name: string };
 }
 
 /**
@@ -417,6 +434,13 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  * - `AUTH0_COOKIE_SAME_SITE`: See {@link CookieConfig.sameSite}.
  * - `AUTH0_CLIENT_ASSERTION_SIGNING_KEY`: See {@link BaseConfig.clientAssertionSigningKey}
  * - `AUTH0_CLIENT_ASSERTION_SIGNING_ALG`: See {@link BaseConfig.clientAssertionSigningAlg}
+ * - `AUTH0_TRANSACTION_COOKIE_NAME` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_DOMAIN` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_PATH` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_TRANSIENT` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_HTTP_ONLY` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_SAME_SITE` See {@link BaseConfig.transactionCookie}
+ * - `AUTH0_TRANSACTION_COOKIE_SECURE` See {@link BaseConfig.transactionCookie}
  *
  * ### 2. Create your own instance using {@link InitAuth0}
  *
@@ -519,6 +543,13 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
   const AUTH0_COOKIE_SAME_SITE = process.env.AUTH0_COOKIE_SAME_SITE;
   const AUTH0_CLIENT_ASSERTION_SIGNING_KEY = process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY;
   const AUTH0_CLIENT_ASSERTION_SIGNING_ALG = process.env.AUTH0_CLIENT_ASSERTION_SIGNING_ALG;
+  const AUTH0_TRANSACTION_COOKIE_NAME = process.env.AUTH0_TRANSACTION_COOKIE_NAME;
+  const AUTH0_TRANSACTION_COOKIE_DOMAIN = process.env.AUTH0_TRANSACTION_COOKIE_DOMAIN;
+  const AUTH0_TRANSACTION_COOKIE_PATH = process.env.AUTH0_TRANSACTION_COOKIE_PATH;
+  const AUTH0_TRANSACTION_COOKIE_TRANSIENT = process.env.AUTH0_TRANSACTION_COOKIE_TRANSIENT;
+  const AUTH0_TRANSACTION_COOKIE_HTTP_ONLY = process.env.AUTH0_TRANSACTION_COOKIE_HTTP_ONLY;
+  const AUTH0_TRANSACTION_COOKIE_SAME_SITE = process.env.AUTH0_TRANSACTION_COOKIE_SAME_SITE;
+  const AUTH0_TRANSACTION_COOKIE_SECURE = process.env.AUTH0_TRANSACTION_COOKIE_SECURE;
 
   const baseURL =
     AUTH0_BASE_URL && !/^https?:\/\//.test(AUTH0_BASE_URL as string) ? `https://${AUTH0_BASE_URL}` : AUTH0_BASE_URL;
@@ -575,7 +606,17 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
       postLogoutRedirect: baseParams.routes?.postLogoutRedirect || AUTH0_POST_LOGOUT_REDIRECT
     },
     clientAssertionSigningKey: AUTH0_CLIENT_ASSERTION_SIGNING_KEY,
-    clientAssertionSigningAlg: AUTH0_CLIENT_ASSERTION_SIGNING_ALG
+    clientAssertionSigningAlg: AUTH0_CLIENT_ASSERTION_SIGNING_ALG,
+    transactionCookie: {
+      name: AUTH0_TRANSACTION_COOKIE_NAME,
+      domain: AUTH0_TRANSACTION_COOKIE_DOMAIN,
+      path: AUTH0_TRANSACTION_COOKIE_PATH || '/',
+      transient: bool(AUTH0_TRANSACTION_COOKIE_TRANSIENT),
+      httpOnly: bool(AUTH0_TRANSACTION_COOKIE_HTTP_ONLY),
+      secure: bool(AUTH0_TRANSACTION_COOKIE_SECURE),
+      sameSite: AUTH0_TRANSACTION_COOKIE_SAME_SITE as 'lax' | 'strict' | 'none' | undefined,
+      ...baseParams.transactionCookie
+    }
   });
 
   const nextConfig: NextConfig = {

--- a/tests/auth0-session/handlers/login.test.ts
+++ b/tests/auth0-session/handlers/login.test.ts
@@ -260,4 +260,29 @@ describe('login', () => {
     expect(cookie?.sameSite).toEqual('none');
     expect(cookie?.secure).toBeTruthy();
   });
+
+  it('transient cookie should honor transaction cookie config in code flow', async () => {
+    const baseURL = await setup(
+      {
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        authorizationParams: {
+          response_type: 'code'
+        },
+        transactionCookie: {
+          name: 'foo_bar',
+          sameSite: 'none'
+        }
+      },
+      { https: true }
+    );
+    const cookieJar = new CookieJar();
+
+    const { res } = await get(baseURL, '/login', { fullResponse: true, cookieJar });
+    expect(res.statusCode).toEqual(302);
+
+    const cookie = getCookie('foo_bar', cookieJar, baseURL);
+    expect(cookie?.sameSite).toEqual('none');
+    expect(cookie?.secure).toBeTruthy();
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -84,11 +84,9 @@ describe('config params', () => {
       transactionCookie: {
         name: 'auth_verification',
         domain: undefined,
-        httpOnly: false,
         path: '/',
         sameSite: 'lax',
-        secure: true,
-        transient: false
+        secure: true
       }
     });
     expect(nextConfig).toStrictEqual({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -80,7 +80,16 @@ describe('config params', () => {
         'at_hash',
         'c_hash'
       ],
-      clientAuthMethod: 'client_secret_basic'
+      clientAuthMethod: 'client_secret_basic',
+      transactionCookie: {
+        name: 'auth_verification',
+        domain: undefined,
+        httpOnly: false,
+        path: '/',
+        sameSite: 'lax',
+        secure: true,
+        transient: false
+      }
     });
     expect(nextConfig).toStrictEqual({
       identityClaimFilter: [


### PR DESCRIPTION
### 📋 Changes

Add options to customize the transaction cookie's name and config. This can be useful for a number or reasons:

- You may want to make concurrent logins for different instances, so you would need to customise the cookie name (see #1297 )
- You may want to use `SameSite=Strict` for the session cookie, in which case you would need to set the transaction cookie to `Lax` or `None` to make the code flow work. (see https://github.com/auth0/express-openid-connect/issues/322)
- You may want to limit the session cookie to a specific host (or path), but accept logins from the naked domain (or root path) (see https://github.com/auth0/nextjs-auth0/issues/1337#issuecomment-1662767118)

### 📎 References

fixes #1297
