### PR TITLE
Fix for Next.js < 13

### DIFF
--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -53,5 +53,23 @@ export default handleAuth({
     });
   }
 });
-
 ```
+
+## Using middleware on Next 12 requires custom Webpack config
+
+v3 of this SDK uses modules that are only available to Next 13. When this SDK is bundled to middleware using Next.js 12, Webpack can't resolve these modules - so you need to ignore them from your webpack config like so:
+
+```js
+const webpack = require('webpack');
+
+/** @type {import('next').NextConfig} */
+module.exports = {
+  webpack(config) {
+    config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^next\/(navigation|headers)$/ }))
+    return config;
+  }
+}
+```
+
+It's safe to ignore these modules as you will not hit these code paths using Next.js 12.
+

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -208,7 +208,8 @@ const appRouteHandlerFactory =
     const [session] = await get({ sessionCache });
     if (!session?.user) {
       const returnTo = typeof opts.returnTo === 'function' ? await opts.returnTo(params) : opts.returnTo;
-      const { redirect } = await import('next/navigation');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { redirect } = require('next/navigation');
       redirect(`${loginUrl}${opts.returnTo ? `?returnTo=${returnTo}` : ''}`);
     }
     return handler(params);

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -1,6 +1,5 @@
 import type React from 'react';
 import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import { redirect } from 'next/navigation';
 import { Claims, get, SessionCache } from '../session';
 import { assertCtx } from '../utils/assert';
 import { ParsedUrlQuery } from 'querystring';
@@ -209,6 +208,7 @@ const appRouteHandlerFactory =
     const [session] = await get({ sessionCache });
     if (!session?.user) {
       const returnTo = typeof opts.returnTo === 'function' ? await opts.returnTo(params) : opts.returnTo;
+      const { redirect } = await import('next/navigation');
       redirect(`${loginUrl}${opts.returnTo ? `?returnTo=${returnTo}` : ''}`);
     }
     return handler(params);

--- a/src/http/auth0-next-request-cookies.ts
+++ b/src/http/auth0-next-request-cookies.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers';
 import { Auth0RequestCookies } from '../auth0-session/http';
 
 export default class Auth0NextRequestCookies extends Auth0RequestCookies {
@@ -7,7 +6,14 @@ export default class Auth0NextRequestCookies extends Auth0RequestCookies {
   }
 
   public getCookies(): Record<string, string> {
+    const { cookies } = require('next/headers');
     const cookieStore = cookies();
-    return cookieStore.getAll().reduce((memo, { name, value }) => ({ ...memo, [name]: value }), {});
+    return cookieStore.getAll().reduce(
+      (memo: Record<string, string>, { name, value }: { name: string; value: string }) => ({
+        ...memo,
+        [name]: value
+      }),
+      {}
+    );
   }
 }

--- a/src/http/auth0-next-request-cookies.ts
+++ b/src/http/auth0-next-request-cookies.ts
@@ -6,6 +6,7 @@ export default class Auth0NextRequestCookies extends Auth0RequestCookies {
   }
 
   public getCookies(): Record<string, string> {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { cookies } = require('next/headers');
     const cookieStore = cookies();
     return cookieStore.getAll().reduce(

--- a/src/http/auth0-next-response-cookies.ts
+++ b/src/http/auth0-next-response-cookies.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers';
 import type { CookieSerializeOptions } from 'cookie';
 import { Auth0ResponseCookies } from '../auth0-session/http';
 
@@ -21,6 +20,7 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   }
 
   public setCookie(name: string, value: string, options?: CookieSerializeOptions) {
+    const { cookies } = require('next/headers');
     const cookieSetter = cookies();
     try {
       cookieSetter.set({ ...options, name, value });
@@ -30,6 +30,7 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   }
 
   public clearCookie(name: string, options?: CookieSerializeOptions) {
+    const { cookies } = require('next/headers');
     const cookieSetter = cookies();
     try {
       cookieSetter.set({ ...options, name, value: '', expires: new Date(0) });

--- a/src/http/auth0-next-response-cookies.ts
+++ b/src/http/auth0-next-response-cookies.ts
@@ -20,6 +20,7 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   }
 
   public setCookie(name: string, value: string, options?: CookieSerializeOptions) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { cookies } = require('next/headers');
     const cookieSetter = cookies();
     try {
@@ -30,6 +31,7 @@ export default class Auth0NextResponseCookies extends Auth0ResponseCookies {
   }
 
   public clearCookie(name: string, options?: CookieSerializeOptions) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { cookies } = require('next/headers');
     const cookieSetter = cookies();
     try {

--- a/tests/http/auth0-next-response-cookies.test.ts
+++ b/tests/http/auth0-next-response-cookies.test.ts
@@ -1,35 +1,33 @@
-import { cookies as nextCookies } from 'next/headers';
 import { Auth0NextResponseCookies } from '../../src/http';
 import { NextResponse } from 'next/server';
-
-jest.mock('next/headers');
 
 describe('auth0-next-response', () => {
   it('should set a cookie', async () => {
     const cookies = new Auth0NextResponseCookies();
     const res = new NextResponse();
-    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    jest.doMock('next/headers', () => ({ cookies: () => res.cookies }));
     cookies.setCookie('foo', 'bar');
     expect(res.cookies.get('foo')?.value).toEqual('bar');
   });
 
   it('should not throw when setting a cookie fails', async () => {
     const cookies = new Auth0NextResponseCookies();
-    jest.mocked(nextCookies).mockImplementation(
-      () =>
-        ({
+    jest.doMock('next/headers', () => ({
+      cookies() {
+        return {
           set: () => {
             throw new Error();
           }
-        } as any)
-    );
+        } as any;
+      }
+    }));
     expect(() => cookies.setCookie('foo', 'bar')).not.toThrow();
   });
 
   it('should delete cookies', async () => {
     const cookies = new Auth0NextResponseCookies();
     const res = new NextResponse();
-    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    jest.doMock('next/headers', () => ({ cookies: () => res.cookies }));
     cookies.clearCookie('foo');
     expect(res.headers.get('set-cookie')).toEqual('foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
   });
@@ -37,7 +35,7 @@ describe('auth0-next-response', () => {
   it('should delete cookies with a domain', async () => {
     const cookies = new Auth0NextResponseCookies();
     const res = new NextResponse();
-    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    jest.doMock('next/headers', () => ({ cookies: () => res.cookies }));
     cookies.clearCookie('foo', { domain: 'example.com' });
     expect(res.headers.get('set-cookie')).toEqual(
       'foo=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=example.com'
@@ -47,21 +45,22 @@ describe('auth0-next-response', () => {
   it('should delete cookies with a path', async () => {
     const cookies = new Auth0NextResponseCookies();
     const res = new NextResponse();
-    jest.mocked(nextCookies).mockImplementation(() => res.cookies as any);
+    jest.doMock('next/headers', () => ({ cookies: () => res.cookies }));
     cookies.clearCookie('foo', { path: '/foo' });
     expect(res.headers.get('set-cookie')).toEqual('foo=; Path=/foo; Expires=Thu, 01 Jan 1970 00:00:00 GMT');
   });
 
   it('should not throw when deleting a cookie fails', async () => {
     const cookies = new Auth0NextResponseCookies();
-    jest.mocked(nextCookies).mockImplementation(
-      () =>
-        ({
+    jest.doMock('next/headers', () => ({
+      cookies() {
+        return {
           delete: () => {
             throw new Error();
           }
-        } as any)
-    );
+        } as any;
+      }
+    }));
     expect(() => cookies.clearCookie('foo')).not.toThrow();
   });
 });

--- a/tests/session/get-access-token-app-router-rsc.test.ts
+++ b/tests/session/get-access-token-app-router-rsc.test.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies as nextCookies } from 'next/headers';
 import nock from 'nock';
 import { withApi } from '../fixtures/default-settings';
 import { AccessTokenRequest, initAuth0, Session } from '../../src';
@@ -11,8 +10,6 @@ import {
   login as appRouterLogin,
   mockFetch
 } from '../fixtures/app-router-helpers';
-
-jest.mock('next/headers');
 
 const getAccessTokenResponse = async ({
   authenticated = false,
@@ -30,7 +27,7 @@ const getAccessTokenResponse = async ({
   if (authenticated) {
     const loginRes = await appRouterLogin(loginOpts);
     cookies.appSession = loginRes.cookies.get('appSession').value;
-    jest.mocked(nextCookies).mockImplementation(() => loginRes.cookies);
+    jest.doMock('next/headers', () => ({ cookies: () => loginRes.cookies }));
   }
   await refreshTokenExchange(
     withApi,

--- a/tests/session/update-session.test.ts
+++ b/tests/session/update-session.test.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies as nextCookies } from 'next/headers';
 import { CookieJar } from 'tough-cookie';
 import { login, setup, teardown } from '../fixtures/setup';
 import { withApi, withoutApi } from '../fixtures/default-settings';
 import { get, post } from '../auth0-session/fixtures/helpers';
 import { getResponse, login as appRouterLogin, getSession } from '../fixtures/app-router-helpers';
 import { initAuth0 } from '../../src';
-
-jest.mock('next/headers');
 
 describe('update-user', () => {
   describe('app router', () => {
@@ -34,9 +31,9 @@ describe('update-user', () => {
     test('should update session from a server component', async () => {
       const loginRes = await appRouterLogin();
       // Note: An updated session from a React Server Component will not persist
-      // because you can't write to a cookie from a RSC in the current version of Next.js
+      // because you can't write to a cookie from a RSC in Next.js
       // This test passes because we're mocking the dynamic `cookies` function.
-      jest.mocked(nextCookies).mockImplementation(() => loginRes.cookies);
+      jest.doMock('next/headers', () => ({ cookies: () => loginRes.cookies }));
       const auth0Instance = initAuth0(withApi);
       const res = await getResponse({
         url: '/api/auth/update',


### PR DESCRIPTION
### 📋 Changes

Use dynamic imports for Next 13 APIs so that building the node version of this SDK does not error in Next 12.

This does not work for edge apis as Webpack attempts to resolve the Dynamic requires when it tries to bundle the code for the Edge runtime. Since middleware is available in Next.js 12, I've added a section in the migration guide to workaround this.

### 📎 References

fixes #1393 

### 🎯 Testing

Tested on https://github.com/robertwbradford/next-12-with-nextjs-auth0-3