### PR TITLE
test(security): Add `example-app` to `.semgrepignore`

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,6 @@
 cypress/
 docs/
 examples/
+example-app/
 tests/
 *.md


### PR DESCRIPTION
This pull request updates the `.semgrepignore` manifest to ignore the `example-app` subdirectory to remove false positive warnings about this sample code.