### PR TITLE
Fix customizable handler

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -106,13 +106,15 @@ export default handleAuth({
         custom_param: 'custom'
       },
       returnTo: '/custom-page'
-    });
+    })(req,res);
   },
-  invite: handleLogin({
-    authorizationParams: {
-      invitation: req.query.invitation
-    }
-  }),
+  async invite(req,res) {
+    await handleLogin(req,res, {
+        authorizationParams: {
+        invitation: req.query.invitation
+      }
+    })(req,res)
+  },
   'login-with-google': handleLogin({ authorizationParams: { connection: 'google' } }),
   'refresh-profile': handleProfile({ refetch: true }),
   onError(req, res, error) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A) - It was tested by a human not a written test.
- [x] I have added documentation for all new/changed functionality (or N/A) - It is self explanatory -> there was a missing function call, and incorrectly set up handler

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

I've added an function call to async login function, which would not work without it.
I've refactored the invite route, because it was using an out of scope property "req". It was refactored to a similar handler that "login" handler uses, because it requires an async function with req, and res as a property passed inside of it.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->


### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
To reproduce this issue, simply create a sample Next.js auth0 project with CLI. Run the project with the issued routes, and try to navigate to them in your browser window, the login handler will return an error with stalled request, because the function login isn't called. To reproduce the issue with invite handler, you can simply try to navigate over there in your browser window, and it will return an error because of the out of scope variable, which is basically not defined anywhere. After applying my changes, just navigate to following routes in your browser window, and everything should work as expected.
