### PR TITLE
Add HTTPS_PROXY support for network calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@panva/hkdf": "^1.0.2",
         "cookie": "^0.5.0",
         "debug": "^4.3.4",
+        "https-proxy-agent": "^7.0.2",
         "joi": "^17.6.0",
         "jose": "^4.9.2",
         "oauth4webapi": "^2.3.0",
@@ -4167,6 +4168,19 @@
         "temp-fs": "^0.9.9"
       }
     },
+    "node_modules/browserstack-local/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -7413,16 +7427,26 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -10333,6 +10357,19 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"
@@ -18312,6 +18349,18 @@
         "is-running": "^2.1.0",
         "ps-tree": "=1.2.0",
         "temp-fs": "^0.9.9"
+      },
+      "dependencies": {
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "bs-logger": {
@@ -20797,13 +20846,22 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "requires": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        }
       }
     },
     "human-signals": {
@@ -22997,6 +23055,16 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@panva/hkdf": "^1.0.2",
     "cookie": "^0.5.0",
     "debug": "^4.3.4",
+    "https-proxy-agent": "^7.0.2",
     "joi": "^17.6.0",
     "jose": "^4.9.2",
     "oauth4webapi": "^2.3.0",

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -23,6 +23,7 @@ import urlJoin from 'url-join';
 import createDebug from '../utils/debug';
 import { IncomingMessage } from 'http';
 import { AccessTokenError, AccessTokenErrorCode } from '../../utils/errors';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const debug = createDebug('client');
 
@@ -41,6 +42,9 @@ export class NodeClient extends AbstractClient {
       config,
       telemetry: { name, version }
     } = this;
+
+    const proxy =
+      config.httpsProxy || process.env.AUTH0_HTTPS_PROXY || process.env.HTTPS_PROXY || process.env.https_proxy;
 
     const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
       ...options,
@@ -61,7 +65,8 @@ export class NodeClient extends AbstractClient {
             }
           : undefined)
       },
-      timeout: config.httpTimeout
+      timeout: config.httpTimeout,
+      ...(proxy && { agent: new HttpsProxyAgent(proxy) })
     });
     const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
       entity[custom.http_options] = defaultHttpOptions;

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -101,6 +101,15 @@ export interface Config {
   httpTimeout: number;
 
   /**
+   * String value for an https proxy URL that requests can route through.
+   * You can also use any of the following environment variables:
+   * - `AUTH0_HTTPS_PROXY`
+   * - `HTTPS_PROXY`
+   * - `https_proxy`
+   */
+  httpsProxy?: string;
+
+  /**
    * Boolean value to opt-out of sending the library and Node.js version to your authorization server
    * via the `Auth0-Client` header. Defaults to `true`.
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,15 @@ export interface BaseConfig {
   httpTimeout: number;
 
   /**
+   * String value for an https proxy URL that requests can route through.
+   * You can also use any of the following environment variables:
+   * - `AUTH0_HTTPS_PROXY`
+   * - `HTTPS_PROXY`
+   * - `https_proxy`
+   */
+  httpsProxy?: string;
+
+  /**
    * Boolean value to opt-out of sending the library and node version to your authorization server
    * via the `Auth0-Client` header. Defaults to `true`.
    * You can also use the `AUTH0_ENABLE_TELEMETRY` environment variable.
@@ -408,6 +417,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  *
  * - `AUTH0_CLOCK_TOLERANCE`: See {@link clockTolerance}.
  * - `AUTH0_HTTP_TIMEOUT`: See {@link httpTimeout}.
+ * - `AUTH0_HTTPS_PROXY`: See {@link httpsProxy}.
  * - `AUTH0_ENABLE_TELEMETRY`: See {@link enableTelemetry}.
  * - `AUTH0_IDP_LOGOUT`: See {@link idpLogout}.
  * - `AUTH0_ID_TOKEN_SIGNING_ALG`: See {@link idTokenSigningAlg}.


### PR DESCRIPTION
Resolves #1425

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

- Added support for setting up an HTTPS_PROXY by adding an instance of HttpsProxyAgent to the `defaultHttpOptions` whenever httpsProxy is either configured or in the environment (AUTH0_HTTPS_PROXY, HTTPS_PROXY, https_proxy)

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Okta SDK Node.js library added support in a similar way: https://github.com/okta/okta-sdk-nodejs/pull/307/files
- Golang uses env.HTTPS_PROXY and env.HTTP_PROXY to automatically route requests through proxy, by default.

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
