### PR TITLE
Add support for passing a custom http agent

### DIFF
--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -61,7 +61,8 @@ export class NodeClient extends AbstractClient {
             }
           : undefined)
       },
-      timeout: config.httpTimeout
+      timeout: config.httpTimeout,
+      agent: config.httpAgent
     });
     const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
       entity[custom.http_options] = defaultHttpOptions;

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -2,6 +2,7 @@ import type {
   AuthorizationParameters as OidcAuthorizationParameters,
   ClientAuthMethod
 } from './client/abstract-client';
+import type { Agent } from 'https';
 import { SessionStore } from './session/stateful-session';
 
 /**
@@ -99,6 +100,11 @@ export interface Config {
    * Defaults to `5000` ms.
    */
   httpTimeout: number;
+
+  /**
+   * Instance of an HTTP agent for authentication requests.
+   */
+  httpAgent?: Agent;
 
   /**
    * Boolean value to opt-out of sending the library and Node.js version to your authorization server

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -103,6 +103,7 @@ export interface Config {
 
   /**
    * Instance of an HTTP agent for authentication requests.
+   * (This is for the Node.js runtime only)
    */
   httpAgent?: Agent;
 

--- a/src/auth0-session/get-config.ts
+++ b/src/auth0-session/get-config.ts
@@ -112,6 +112,7 @@ const paramsSchema = Joi.object({
     ),
   clockTolerance: Joi.number().optional().default(60),
   httpTimeout: Joi.number().optional().default(5000),
+  httpAgent: Joi.object().optional(),
   enableTelemetry: Joi.boolean().optional().default(true),
   getLoginState: Joi.function()
     .optional()

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import type { Agent } from 'https';
 import type { LoginOptions, AuthorizationParameters as OidcAuthorizationParameters } from './auth0-session/config';
 import { SessionStore } from './auth0-session/session/stateful-session';
 import Session from './session/session';
@@ -95,6 +96,11 @@ export interface BaseConfig {
    * You can also use the `AUTH0_HTTP_TIMEOUT` environment variable.
    */
   httpTimeout: number;
+
+  /**
+   * Instance of an HTTP agent for authentication requests.
+   */
+  httpAgent?: Agent;
 
   /**
    * Boolean value to opt-out of sending the library and node version to your authorization server

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,7 @@ export interface BaseConfig {
 
   /**
    * Instance of an HTTP agent for authentication requests.
+   * (This is for the Node.js runtime only)
    */
   httpAgent?: Agent;
 


### PR DESCRIPTION
There are times that you'd need to have a custom http agent for making the authentication requests (via openid-client). This can allow a user to provide their own agent so that they can proxy or do other things that they'd like to do.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

- Add a configuration option for `httpAgent` so that users can provide their own http agent for authentication requests (such as an HttpsProxyAgent). This is important for corporate users that require going through a corporate proxy.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->
