### PR TITLE
fix: add missing touchSession for exported function

### DIFF
--- a/src/edge.ts
+++ b/src/edge.ts
@@ -9,6 +9,7 @@ import {
   HandleLogout,
   HandleProfile,
   SessionCache,
+  TouchSession,
   UpdateSession,
   WithApiAuthRequired,
   WithPageAuthRequired,
@@ -65,6 +66,7 @@ const getSessionCache = () => getInstance().sessionCache;
 export const getSession: GetSession = (...args) => getInstance().getSession(...args);
 export const updateSession: UpdateSession = (...args) => getInstance().updateSession(...args);
 export const getAccessToken: GetAccessToken = (...args) => getInstance().getAccessToken(...args);
+export const touchSession: TouchSession = (...args) => getInstance().touchSession(...args);
 export const withApiAuthRequired: WithApiAuthRequired = (...args) =>
   (getInstance().withApiAuthRequired as any)(...args);
 export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSessionCache);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   HandleLogout,
   HandleProfile,
   SessionCache,
+  TouchSession,
   UpdateSession,
   WithApiAuthRequired,
   WithPageAuthRequired,
@@ -61,6 +62,7 @@ const getSessionCache = () => getInstance().sessionCache;
 export const getSession: GetSession = (...args) => getInstance().getSession(...args);
 export const updateSession: UpdateSession = (...args) => getInstance().updateSession(...args);
 export const getAccessToken: GetAccessToken = (...args) => getInstance().getAccessToken(...args);
+export const touchSession: TouchSession = (...args) => getInstance().touchSession(...args);
 export const withApiAuthRequired: WithApiAuthRequired = (...args) =>
   (getInstance().withApiAuthRequired as any)(...args);
 export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSessionCache);


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

when `touchSession` was implemented in https://github.com/auth0/nextjs-auth0/pull/1116 it was missed in exported functions but only added to the instance export.

### 📎 References

https://github.com/auth0/nextjs-auth0/issues/1458#issuecomment-1738069377

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
