### PR TITLE
Bail out of static rendering for pages and routes in app dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "3.2.0-experimental-lazy-conf.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/nextjs-auth0",
-      "version": "3.2.0-experimental-lazy-conf.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@panva/hkdf": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "3.2.0",
+  "version": "3.2.0-experimental-lazy-conf.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/nextjs-auth0",
-      "version": "3.2.0",
+      "version": "3.2.0-experimental-lazy-conf.0",
       "license": "MIT",
       "dependencies": {
         "@panva/hkdf": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "3.2.0",
+  "version": "3.2.0-experimental-lazy-conf.0",
   "description": "Next.js SDK for signing in with Auth0",
   "exports": {
     ".": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "3.2.0-experimental-lazy-conf.0",
+  "version": "3.2.0",
   "description": "Next.js SDK for signing in with Auth0",
   "exports": {
     ".": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
       "!<rootDir>/src/edge.ts",
       "!<rootDir>/src/index.ts",
       "!<rootDir>/src/shared.ts",
+      "!<rootDir>/src/version.ts",
       "!<rootDir>/src/auth0-session/config.ts",
       "!<rootDir>/src/auth0-session/index.ts",
       "!<rootDir>/src/auth0-session/session-cache.ts"

--- a/src/auth0-session/client/abstract-client.ts
+++ b/src/auth0-session/client/abstract-client.ts
@@ -1,4 +1,4 @@
-import { Config } from '../config';
+import { Config, GetConfig } from '../config';
 import { Auth0Request } from '../http';
 
 export type Telemetry = {
@@ -85,7 +85,10 @@ export interface AuthorizationParameters {
 }
 
 export abstract class AbstractClient {
-  constructor(protected config: Config, protected telemetry: Telemetry) {}
+  protected getConfig: () => Config | Promise<Config>;
+  constructor(getConfig: GetConfig, protected telemetry: Telemetry) {
+    this.getConfig = typeof getConfig === 'function' ? getConfig : () => getConfig;
+  }
   abstract authorizationUrl(parameters: Record<string, unknown>): Promise<string>;
   abstract callbackParams(req: Auth0Request, expectedState: string): Promise<URLSearchParams>;
   abstract callback(

--- a/src/auth0-session/client/abstract-client.ts
+++ b/src/auth0-session/client/abstract-client.ts
@@ -1,5 +1,5 @@
-import { Auth0Request } from '../http';
 import { Config } from '../config';
+import { Auth0Request } from '../http';
 
 export type Telemetry = {
   name: string;
@@ -85,6 +85,7 @@ export interface AuthorizationParameters {
 }
 
 export abstract class AbstractClient {
+  constructor(protected config: Config, protected telemetry: Telemetry) {}
   abstract authorizationUrl(parameters: Record<string, unknown>): Promise<string>;
   abstract callbackParams(req: Auth0Request, expectedState: string): Promise<URLSearchParams>;
   abstract callback(

--- a/src/auth0-session/client/abstract-client.ts
+++ b/src/auth0-session/client/abstract-client.ts
@@ -1,5 +1,5 @@
-import { Config, GetConfig } from '../config';
 import { Auth0Request } from '../http';
+import { Config } from '../config';
 
 export type Telemetry = {
   name: string;
@@ -85,10 +85,6 @@ export interface AuthorizationParameters {
 }
 
 export abstract class AbstractClient {
-  protected getConfig: () => Config | Promise<Config>;
-  constructor(getConfig: GetConfig, protected telemetry: Telemetry) {
-    this.getConfig = typeof getConfig === 'function' ? getConfig : () => getConfig;
-  }
   abstract authorizationUrl(parameters: Record<string, unknown>): Promise<string>;
   abstract callbackParams(req: Auth0Request, expectedState: string): Promise<URLSearchParams>;
   abstract callback(
@@ -107,3 +103,5 @@ export abstract class AbstractClient {
   abstract generateRandomNonce(): string;
   abstract calculateCodeChallenge(codeVerifier: string): Promise<string> | string;
 }
+
+export type GetClient = (config: Config) => Promise<AbstractClient>;

--- a/src/auth0-session/client/edge-client.ts
+++ b/src/auth0-session/client/edge-client.ts
@@ -26,17 +26,69 @@ const encodeBase64 = (input: string) => {
 };
 
 export class EdgeClient extends AbstractClient {
-  constructor(
-    private client: oauth.Client,
-    private as: oauth.AuthorizationServer,
-    private config: Config,
-    private httpOptions: oauth.HttpRequestOptions
-  ) {
-    super();
+  private client?: oauth.Client;
+  private as?: oauth.AuthorizationServer;
+  private httpOptions: () => oauth.HttpRequestOptions;
+
+  constructor(protected config: Config, protected telemetry: Telemetry) {
+    super(config, telemetry);
+    if (config.authorizationParams.response_type !== 'code') {
+      throw new Error('This SDK only supports `response_type=code` when used in an Edge runtime.');
+    }
+
+    this.httpOptions = () => {
+      const headers = new Headers();
+      if (config.enableTelemetry) {
+        const { name, version } = telemetry;
+        headers.set('User-Agent', `${name}/${version}`);
+        headers.set(
+          'Auth0-Client',
+          encodeBase64(
+            JSON.stringify({
+              name,
+              version,
+              env: {
+                edge: true
+              }
+            })
+          )
+        );
+      }
+      return {
+        signal: AbortSignal.timeout(this.config.httpTimeout),
+        headers
+      };
+    };
+  }
+
+  private async getClient(): Promise<[oauth.AuthorizationServer, oauth.Client]> {
+    if (this.as) {
+      return [this.as, this.client as oauth.Client];
+    }
+
+    const issuer = new URL(this.config.issuerBaseURL);
+    try {
+      this.as = await oauth
+        .discoveryRequest(issuer, this.httpOptions())
+        .then((response) => oauth.processDiscoveryResponse(issuer, response));
+    } catch (e) {
+      throw new DiscoveryError(e, this.config.issuerBaseURL);
+    }
+
+    this.client = {
+      client_id: this.config.clientID,
+      ...(!this.config.clientAssertionSigningKey && { client_secret: this.config.clientSecret }),
+      token_endpoint_auth_method: this.config.clientAuthMethod,
+      id_token_signed_response_alg: this.config.idTokenSigningAlg,
+      [oauth.clockTolerance]: this.config.clockTolerance
+    };
+
+    return [this.as, this.client];
   }
 
   async authorizationUrl(parameters: Record<string, unknown>): Promise<string> {
-    const authorizationUrl = new URL(this.as.authorization_endpoint as string);
+    const [as] = await this.getClient();
+    const authorizationUrl = new URL(as.authorization_endpoint as string);
     authorizationUrl.searchParams.set('client_id', this.config.clientID);
     Object.entries(parameters).forEach(([key, value]) => {
       if (value === null || value === undefined) {
@@ -48,11 +100,12 @@ export class EdgeClient extends AbstractClient {
   }
 
   async callbackParams(req: Auth0Request, expectedState: string) {
+    const [as, client] = await this.getClient();
     const url =
       req.getMethod().toUpperCase() === 'GET' ? new URL(req.getUrl()) : new URLSearchParams(await req.getBody());
     let result: ReturnType<typeof oauth.validateAuthResponse>;
     try {
-      result = oauth.validateAuthResponse(this.as, this.client, url, expectedState);
+      result = oauth.validateAuthResponse(as, client, url, expectedState);
     } catch (e) {
       throw new ApplicationError(e);
     }
@@ -72,6 +125,8 @@ export class EdgeClient extends AbstractClient {
     checks: OpenIDCallbackChecks,
     extras: CallbackExtras
   ): Promise<TokenEndpointResponse> {
+    const [as, client] = await this.getClient();
+
     const { clientAssertionSigningKey, clientAssertionSigningAlg } = this.config;
 
     let clientPrivateKey = clientAssertionSigningKey as CryptoKey | undefined;
@@ -80,21 +135,21 @@ export class EdgeClient extends AbstractClient {
       clientPrivateKey = await jose.importPKCS8<CryptoKey>(clientPrivateKey, clientAssertionSigningAlg || 'RS256');
     }
     const response = await oauth.authorizationCodeGrantRequest(
-      this.as,
-      this.client,
+      as,
+      client,
       parameters,
       redirectUri,
       checks.code_verifier as string,
       {
         additionalParameters: extras.exchangeBody,
         ...(clientPrivateKey && { clientPrivateKey }),
-        ...this.httpOptions
+        ...this.httpOptions()
       }
     );
 
     const result = await oauth.processAuthorizationCodeOpenIDResponse(
-      this.as,
-      this.client,
+      as,
+      client,
       response,
       checks.nonce,
       checks.max_age
@@ -110,14 +165,15 @@ export class EdgeClient extends AbstractClient {
   }
 
   async endSessionUrl(parameters: EndSessionParameters): Promise<string> {
-    const issuerUrl = new URL(this.as.issuer);
+    const [as] = await this.getClient();
+    const issuerUrl = new URL(as.issuer);
 
     if (
       this.config.idpLogout &&
       (this.config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && this.config.auth0Logout !== false))
     ) {
       const { id_token_hint, post_logout_redirect_uri, ...extraParams } = parameters;
-      const auth0LogoutUrl: URL = new URL(urlJoin(this.as.issuer, '/v2/logout'));
+      const auth0LogoutUrl: URL = new URL(urlJoin(as.issuer, '/v2/logout'));
       post_logout_redirect_uri && auth0LogoutUrl.searchParams.set('returnTo', post_logout_redirect_uri);
       auth0LogoutUrl.searchParams.set('client_id', this.config.clientID);
       Object.entries(extraParams).forEach(([key, value]: [string, string]) => {
@@ -128,10 +184,10 @@ export class EdgeClient extends AbstractClient {
       });
       return auth0LogoutUrl.toString();
     }
-    if (!this.as.end_session_endpoint) {
+    if (!as.end_session_endpoint) {
       throw new Error('RP Initiated Logout is not supported on your Authorization Server.');
     }
-    const oidcLogoutUrl = new URL(this.as.end_session_endpoint);
+    const oidcLogoutUrl = new URL(as.end_session_endpoint);
     Object.entries(parameters).forEach(([key, value]: [string, string]) => {
       if (value === null || value === undefined) {
         return;
@@ -144,21 +200,23 @@ export class EdgeClient extends AbstractClient {
   }
 
   async userinfo(accessToken: string): Promise<Record<string, unknown>> {
-    const response = await oauth.userInfoRequest(this.as, this.client, accessToken, this.httpOptions);
+    const [as, client] = await this.getClient();
+    const response = await oauth.userInfoRequest(as, client, accessToken, this.httpOptions());
 
     try {
-      return await oauth.processUserInfoResponse(this.as, this.client, oauth.skipSubjectCheck, response);
+      return await oauth.processUserInfoResponse(as, client, oauth.skipSubjectCheck, response);
     } catch (e) {
       throw new UserInfoError(e.message);
     }
   }
 
   async refresh(refreshToken: string, extras: { exchangeBody: Record<string, any> }): Promise<TokenEndpointResponse> {
-    const res = await oauth.refreshTokenGrantRequest(this.as, this.client, refreshToken, {
+    const [as, client] = await this.getClient();
+    const res = await oauth.refreshTokenGrantRequest(as, client, refreshToken, {
       additionalParameters: extras.exchangeBody,
-      ...this.httpOptions
+      ...this.httpOptions()
     });
-    const result = await oauth.processRefreshTokenResponse(this.as, this.client, res);
+    const result = await oauth.processRefreshTokenResponse(as, client, res);
     if (oauth.isOAuth2Error(result)) {
       throw new AccessTokenError(
         AccessTokenErrorCode.FAILED_REFRESH_GRANT,
@@ -190,51 +248,7 @@ export const clientGetter = (telemetry: Telemetry): ((config: Config) => Promise
   let client: EdgeClient;
   return async (config) => {
     if (!client) {
-      const headers = new Headers();
-      if (config.enableTelemetry) {
-        const { name, version } = telemetry;
-        headers.set('User-Agent', `${name}/${version}`);
-        headers.set(
-          'Auth0-Client',
-          encodeBase64(
-            JSON.stringify({
-              name,
-              version,
-              env: {
-                edge: true
-              }
-            })
-          )
-        );
-      }
-      const httpOptions: oauth.HttpRequestOptions = {
-        signal: AbortSignal.timeout(config.httpTimeout),
-        headers
-      };
-
-      if (config.authorizationParams.response_type !== 'code') {
-        throw new Error('This SDK only supports `response_type=code` when used in an Edge runtime.');
-      }
-
-      const issuer = new URL(config.issuerBaseURL);
-      let as: oauth.AuthorizationServer;
-      try {
-        as = await oauth
-          .discoveryRequest(issuer, httpOptions)
-          .then((response) => oauth.processDiscoveryResponse(issuer, response));
-      } catch (e) {
-        throw new DiscoveryError(e, config.issuerBaseURL);
-      }
-
-      const oauthClient: oauth.Client = {
-        client_id: config.clientID,
-        ...(!config.clientAssertionSigningKey && { client_secret: config.clientSecret }),
-        token_endpoint_auth_method: config.clientAuthMethod,
-        id_token_signed_response_alg: config.idTokenSigningAlg,
-        [oauth.clockTolerance]: config.clockTolerance
-      };
-
-      client = new EdgeClient(oauthClient, as, config, httpOptions);
+      client = new EdgeClient(config, telemetry);
     }
     return client;
   };

--- a/src/auth0-session/client/edge-client.ts
+++ b/src/auth0-session/client/edge-client.ts
@@ -6,11 +6,13 @@ import {
   OpenIDCallbackChecks,
   TokenEndpointResponse,
   AbstractClient,
-  EndSessionParameters
+  EndSessionParameters,
+  Telemetry
 } from './abstract-client';
 import { ApplicationError, DiscoveryError, IdentityProviderError, UserInfoError } from '../utils/errors';
 import { AccessTokenError, AccessTokenErrorCode } from '../../utils/errors';
 import urlJoin from 'url-join';
+import { Config } from '../config';
 
 const encodeBase64 = (input: string) => {
   const unencoded = new TextEncoder().encode(input);
@@ -24,68 +26,18 @@ const encodeBase64 = (input: string) => {
 };
 
 export class EdgeClient extends AbstractClient {
-  private client?: oauth.Client;
-  private as?: oauth.AuthorizationServer;
-
-  private async httpOptions(): Promise<oauth.HttpRequestOptions> {
-    const headers = new Headers();
-    const config = await this.getConfig();
-    if (config.enableTelemetry) {
-      const { name, version } = this.telemetry;
-      headers.set('User-Agent', `${name}/${version}`);
-      headers.set(
-        'Auth0-Client',
-        encodeBase64(
-          JSON.stringify({
-            name,
-            version,
-            env: {
-              edge: true
-            }
-          })
-        )
-      );
-    }
-    return {
-      signal: AbortSignal.timeout(config.httpTimeout),
-      headers
-    };
-  }
-
-  private async getClient(): Promise<[oauth.AuthorizationServer, oauth.Client]> {
-    if (this.as) {
-      return [this.as, this.client as oauth.Client];
-    }
-    const config = await this.getConfig();
-    if (config.authorizationParams.response_type !== 'code') {
-      throw new Error('This SDK only supports `response_type=code` when used in an Edge runtime.');
-    }
-
-    const issuer = new URL(config.issuerBaseURL);
-    try {
-      this.as = await oauth
-        .discoveryRequest(issuer, await this.httpOptions())
-        .then((response) => oauth.processDiscoveryResponse(issuer, response));
-    } catch (e) {
-      throw new DiscoveryError(e, config.issuerBaseURL);
-    }
-
-    this.client = {
-      client_id: config.clientID,
-      ...(!config.clientAssertionSigningKey && { client_secret: config.clientSecret }),
-      token_endpoint_auth_method: config.clientAuthMethod,
-      id_token_signed_response_alg: config.idTokenSigningAlg,
-      [oauth.clockTolerance]: config.clockTolerance
-    };
-
-    return [this.as, this.client];
+  constructor(
+    private client: oauth.Client,
+    private as: oauth.AuthorizationServer,
+    private config: Config,
+    private httpOptions: oauth.HttpRequestOptions
+  ) {
+    super();
   }
 
   async authorizationUrl(parameters: Record<string, unknown>): Promise<string> {
-    const [as] = await this.getClient();
-    const config = await this.getConfig();
-    const authorizationUrl = new URL(as.authorization_endpoint as string);
-    authorizationUrl.searchParams.set('client_id', config.clientID);
+    const authorizationUrl = new URL(this.as.authorization_endpoint as string);
+    authorizationUrl.searchParams.set('client_id', this.config.clientID);
     Object.entries(parameters).forEach(([key, value]) => {
       if (value === null || value === undefined) {
         return;
@@ -96,12 +48,11 @@ export class EdgeClient extends AbstractClient {
   }
 
   async callbackParams(req: Auth0Request, expectedState: string) {
-    const [as, client] = await this.getClient();
     const url =
       req.getMethod().toUpperCase() === 'GET' ? new URL(req.getUrl()) : new URLSearchParams(await req.getBody());
     let result: ReturnType<typeof oauth.validateAuthResponse>;
     try {
-      result = oauth.validateAuthResponse(as, client, url, expectedState);
+      result = oauth.validateAuthResponse(this.as, this.client, url, expectedState);
     } catch (e) {
       throw new ApplicationError(e);
     }
@@ -121,8 +72,7 @@ export class EdgeClient extends AbstractClient {
     checks: OpenIDCallbackChecks,
     extras: CallbackExtras
   ): Promise<TokenEndpointResponse> {
-    const [as, client] = await this.getClient();
-    const { clientAssertionSigningKey, clientAssertionSigningAlg } = await this.getConfig();
+    const { clientAssertionSigningKey, clientAssertionSigningAlg } = this.config;
 
     let clientPrivateKey = clientAssertionSigningKey as CryptoKey | undefined;
     /* c8 ignore next 3 */
@@ -130,21 +80,21 @@ export class EdgeClient extends AbstractClient {
       clientPrivateKey = await jose.importPKCS8<CryptoKey>(clientPrivateKey, clientAssertionSigningAlg || 'RS256');
     }
     const response = await oauth.authorizationCodeGrantRequest(
-      as,
-      client,
+      this.as,
+      this.client,
       parameters,
       redirectUri,
       checks.code_verifier as string,
       {
         additionalParameters: extras.exchangeBody,
         ...(clientPrivateKey && { clientPrivateKey }),
-        ...this.httpOptions()
+        ...this.httpOptions
       }
     );
 
     const result = await oauth.processAuthorizationCodeOpenIDResponse(
-      as,
-      client,
+      this.as,
+      this.client,
       response,
       checks.nonce,
       checks.max_age
@@ -160,18 +110,16 @@ export class EdgeClient extends AbstractClient {
   }
 
   async endSessionUrl(parameters: EndSessionParameters): Promise<string> {
-    const [as] = await this.getClient();
-    const issuerUrl = new URL(as.issuer);
-    const config = await this.getConfig();
+    const issuerUrl = new URL(this.as.issuer);
 
     if (
-      config.idpLogout &&
-      (config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && config.auth0Logout !== false))
+      this.config.idpLogout &&
+      (this.config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && this.config.auth0Logout !== false))
     ) {
       const { id_token_hint, post_logout_redirect_uri, ...extraParams } = parameters;
-      const auth0LogoutUrl: URL = new URL(urlJoin(as.issuer, '/v2/logout'));
+      const auth0LogoutUrl: URL = new URL(urlJoin(this.as.issuer, '/v2/logout'));
       post_logout_redirect_uri && auth0LogoutUrl.searchParams.set('returnTo', post_logout_redirect_uri);
-      auth0LogoutUrl.searchParams.set('client_id', config.clientID);
+      auth0LogoutUrl.searchParams.set('client_id', this.config.clientID);
       Object.entries(extraParams).forEach(([key, value]: [string, string]) => {
         if (value === null || value === undefined) {
           return;
@@ -180,10 +128,10 @@ export class EdgeClient extends AbstractClient {
       });
       return auth0LogoutUrl.toString();
     }
-    if (!as.end_session_endpoint) {
+    if (!this.as.end_session_endpoint) {
       throw new Error('RP Initiated Logout is not supported on your Authorization Server.');
     }
-    const oidcLogoutUrl = new URL(as.end_session_endpoint);
+    const oidcLogoutUrl = new URL(this.as.end_session_endpoint);
     Object.entries(parameters).forEach(([key, value]: [string, string]) => {
       if (value === null || value === undefined) {
         return;
@@ -191,28 +139,26 @@ export class EdgeClient extends AbstractClient {
       oidcLogoutUrl.searchParams.set(key, value);
     });
 
-    oidcLogoutUrl.searchParams.set('client_id', config.clientID);
+    oidcLogoutUrl.searchParams.set('client_id', this.config.clientID);
     return oidcLogoutUrl.toString();
   }
 
   async userinfo(accessToken: string): Promise<Record<string, unknown>> {
-    const [as, client] = await this.getClient();
-    const response = await oauth.userInfoRequest(as, client, accessToken, await this.httpOptions());
+    const response = await oauth.userInfoRequest(this.as, this.client, accessToken, this.httpOptions);
 
     try {
-      return await oauth.processUserInfoResponse(as, client, oauth.skipSubjectCheck, response);
+      return await oauth.processUserInfoResponse(this.as, this.client, oauth.skipSubjectCheck, response);
     } catch (e) {
       throw new UserInfoError(e.message);
     }
   }
 
   async refresh(refreshToken: string, extras: { exchangeBody: Record<string, any> }): Promise<TokenEndpointResponse> {
-    const [as, client] = await this.getClient();
-    const res = await oauth.refreshTokenGrantRequest(as, client, refreshToken, {
+    const res = await oauth.refreshTokenGrantRequest(this.as, this.client, refreshToken, {
       additionalParameters: extras.exchangeBody,
-      ...this.httpOptions()
+      ...this.httpOptions
     });
-    const result = await oauth.processRefreshTokenResponse(as, client, res);
+    const result = await oauth.processRefreshTokenResponse(this.as, this.client, res);
     if (oauth.isOAuth2Error(result)) {
       throw new AccessTokenError(
         AccessTokenErrorCode.FAILED_REFRESH_GRANT,
@@ -239,3 +185,57 @@ export class EdgeClient extends AbstractClient {
     return oauth.calculatePKCECodeChallenge(codeVerifier);
   }
 }
+
+export const clientGetter = (telemetry: Telemetry): ((config: Config) => Promise<EdgeClient>) => {
+  let client: EdgeClient;
+  return async (config) => {
+    if (!client) {
+      const headers = new Headers();
+      if (config.enableTelemetry) {
+        const { name, version } = telemetry;
+        headers.set('User-Agent', `${name}/${version}`);
+        headers.set(
+          'Auth0-Client',
+          encodeBase64(
+            JSON.stringify({
+              name,
+              version,
+              env: {
+                edge: true
+              }
+            })
+          )
+        );
+      }
+      const httpOptions: oauth.HttpRequestOptions = {
+        signal: AbortSignal.timeout(config.httpTimeout),
+        headers
+      };
+
+      if (config.authorizationParams.response_type !== 'code') {
+        throw new Error('This SDK only supports `response_type=code` when used in an Edge runtime.');
+      }
+
+      const issuer = new URL(config.issuerBaseURL);
+      let as: oauth.AuthorizationServer;
+      try {
+        as = await oauth
+          .discoveryRequest(issuer, httpOptions)
+          .then((response) => oauth.processDiscoveryResponse(issuer, response));
+      } catch (e) {
+        throw new DiscoveryError(e, config.issuerBaseURL);
+      }
+
+      const oauthClient: oauth.Client = {
+        client_id: config.clientID,
+        ...(!config.clientAssertionSigningKey && { client_secret: config.clientSecret }),
+        token_endpoint_auth_method: config.clientAuthMethod,
+        id_token_signed_response_alg: config.idTokenSigningAlg,
+        [oauth.clockTolerance]: config.clockTolerance
+      };
+
+      client = new EdgeClient(oauthClient, as, config, httpOptions);
+    }
+    return client;
+  };
+};

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -33,16 +33,142 @@ function sortSpaceDelimitedString(str: string): string {
 }
 
 export class NodeClient extends AbstractClient {
-  constructor(private client: Client) {
-    super();
+  private client?: Client;
+
+  private async getClient(): Promise<Client> {
+    if (this.client) {
+      return this.client;
+    }
+    const {
+      config,
+      telemetry: { name, version }
+    } = this;
+
+    const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
+      ...options,
+      headers: {
+        ...options.headers,
+        'User-Agent': `${name}/${version}`,
+        ...(config.enableTelemetry
+          ? {
+              'Auth0-Client': Buffer.from(
+                JSON.stringify({
+                  name,
+                  version,
+                  env: {
+                    node: process.version
+                  }
+                })
+              ).toString('base64')
+            }
+          : undefined)
+      },
+      timeout: config.httpTimeout,
+      agent: config.httpAgent
+    });
+    const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
+      entity[custom.http_options] = defaultHttpOptions;
+    };
+
+    applyHttpOptionsCustom(Issuer);
+    let issuer: Issuer<Client>;
+    try {
+      issuer = await Issuer.discover(config.issuerBaseURL);
+    } catch (e) {
+      throw new DiscoveryError(e, config.issuerBaseURL);
+    }
+    applyHttpOptionsCustom(issuer);
+
+    const issuerTokenAlgs = Array.isArray(issuer.id_token_signing_alg_values_supported)
+      ? issuer.id_token_signing_alg_values_supported
+      : [];
+    if (!issuerTokenAlgs.includes(config.idTokenSigningAlg)) {
+      debug(
+        'ID token algorithm %o is not supported by the issuer. Supported ID token algorithms are: %o.',
+        config.idTokenSigningAlg,
+        issuerTokenAlgs
+      );
+    }
+
+    const configRespType = sortSpaceDelimitedString(config.authorizationParams.response_type);
+    const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
+    issuerRespTypes.map(sortSpaceDelimitedString);
+    if (!issuerRespTypes.includes(configRespType)) {
+      debug(
+        'Response type %o is not supported by the issuer. Supported response types are: %o.',
+        configRespType,
+        issuerRespTypes
+      );
+    }
+
+    const configRespMode = config.authorizationParams.response_mode;
+    const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
+    if (configRespMode && !issuerRespModes.includes(configRespMode)) {
+      debug(
+        'Response mode %o is not supported by the issuer. Supported response modes are %o.',
+        configRespMode,
+        issuerRespModes
+      );
+    }
+
+    let jwks;
+    if (config.clientAssertionSigningKey) {
+      const privateKey = createPrivateKey({ key: config.clientAssertionSigningKey as string });
+      const jwk = await exportJWK(privateKey);
+      jwks = { keys: [jwk] };
+    }
+
+    this.client = new issuer.Client(
+      {
+        client_id: config.clientID,
+        client_secret: config.clientSecret,
+        id_token_signed_response_alg: config.idTokenSigningAlg,
+        token_endpoint_auth_method: config.clientAuthMethod as ClientAuthMethod,
+        token_endpoint_auth_signing_alg: config.clientAssertionSigningAlg
+      },
+      jwks
+    );
+    applyHttpOptionsCustom(this.client);
+
+    this.client[custom.clock_tolerance] = config.clockTolerance;
+    const issuerUrl = new URL(issuer.metadata.issuer);
+
+    if (config.idpLogout) {
+      if (
+        this.config.idpLogout &&
+        (this.config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && this.config.auth0Logout !== false))
+      ) {
+        Object.defineProperty(this.client, 'endSessionUrl', {
+          value(params: EndSessionParameters) {
+            const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
+            const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
+            parsedUrl.searchParams.set('client_id', config.clientID);
+            post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);
+            Object.entries(extraParams).forEach(([key, value]) => {
+              if (value === null || value === undefined) {
+                return;
+              }
+              parsedUrl.searchParams.set(key, value as string);
+            });
+            return parsedUrl.toString();
+          }
+        });
+      } else if (!issuer.end_session_endpoint) {
+        debug('the issuer does not support RP-Initiated Logout');
+      }
+    }
+
+    return this.client;
   }
 
   async authorizationUrl(parameters: Record<string, unknown>): Promise<string> {
-    return this.client.authorizationUrl(parameters);
+    const client = await this.getClient();
+    return client.authorizationUrl(parameters);
   }
 
   async callbackParams(req: Auth0Request) {
-    const obj: CallbackParamsType = this.client.callbackParams({
+    const client = await this.getClient();
+    const obj: CallbackParamsType = client.callbackParams({
       method: req.getMethod(),
       url: req.getUrl(),
       body: await req.getBody()
@@ -57,8 +183,9 @@ export class NodeClient extends AbstractClient {
     extras: CallbackExtras
   ): Promise<TokenEndpointResponse> {
     const params = Object.fromEntries(parameters.entries());
+    const client = await this.getClient();
     try {
-      return await this.client.callback(redirectUri, params, checks, extras);
+      return await client.callback(redirectUri, params, checks, extras);
     } catch (err) {
       if (err instanceof errors.OPError) {
         throw new IdentityProviderError(err);
@@ -72,20 +199,23 @@ export class NodeClient extends AbstractClient {
   }
 
   async endSessionUrl(parameters: EndSessionParameters): Promise<string> {
-    return this.client.endSessionUrl(parameters);
+    const client = await this.getClient();
+    return client.endSessionUrl(parameters);
   }
 
   async userinfo(accessToken: string): Promise<Record<string, unknown>> {
+    const client = await this.getClient();
     try {
-      return await this.client.userinfo(accessToken);
+      return await client.userinfo(accessToken);
     } catch (e) {
       throw new UserInfoError(e.message);
     }
   }
 
   async refresh(refreshToken: string, extras: { exchangeBody: Record<string, any> }): Promise<TokenEndpointResponse> {
+    const client = await this.getClient();
     try {
-      return await this.client.refresh(refreshToken, extras);
+      return await client.refresh(refreshToken, extras);
     } catch (e) {
       throw new AccessTokenError(
         AccessTokenErrorCode.FAILED_REFRESH_GRANT,
@@ -112,120 +242,7 @@ export const clientGetter = (telemetry: Telemetry): ((config: Config) => Promise
   let client: NodeClient;
   return async (config) => {
     if (!client) {
-      const { name, version } = telemetry;
-
-      const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
-        ...options,
-        headers: {
-          ...options.headers,
-          'User-Agent': `${name}/${version}`,
-          ...(config.enableTelemetry
-            ? {
-                'Auth0-Client': Buffer.from(
-                  JSON.stringify({
-                    name,
-                    version,
-                    env: {
-                      node: process.version
-                    }
-                  })
-                ).toString('base64')
-              }
-            : undefined)
-        },
-        timeout: config.httpTimeout,
-        agent: config.httpAgent
-      });
-      const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
-        entity[custom.http_options] = defaultHttpOptions;
-      };
-
-      applyHttpOptionsCustom(Issuer);
-      let issuer: Issuer<Client>;
-      try {
-        issuer = await Issuer.discover(config.issuerBaseURL);
-      } catch (e) {
-        throw new DiscoveryError(e, config.issuerBaseURL);
-      }
-      applyHttpOptionsCustom(issuer);
-
-      const issuerTokenAlgs = Array.isArray(issuer.id_token_signing_alg_values_supported)
-        ? issuer.id_token_signing_alg_values_supported
-        : [];
-      if (!issuerTokenAlgs.includes(config.idTokenSigningAlg)) {
-        debug(
-          'ID token algorithm %o is not supported by the issuer. Supported ID token algorithms are: %o.',
-          config.idTokenSigningAlg,
-          issuerTokenAlgs
-        );
-      }
-
-      const configRespType = sortSpaceDelimitedString(config.authorizationParams.response_type);
-      const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
-      issuerRespTypes.map(sortSpaceDelimitedString);
-      if (!issuerRespTypes.includes(configRespType)) {
-        debug(
-          'Response type %o is not supported by the issuer. Supported response types are: %o.',
-          configRespType,
-          issuerRespTypes
-        );
-      }
-
-      const configRespMode = config.authorizationParams.response_mode;
-      const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
-      if (configRespMode && !issuerRespModes.includes(configRespMode)) {
-        debug(
-          'Response mode %o is not supported by the issuer. Supported response modes are %o.',
-          configRespMode,
-          issuerRespModes
-        );
-      }
-
-      let jwks;
-      if (config.clientAssertionSigningKey) {
-        const privateKey = createPrivateKey({ key: config.clientAssertionSigningKey as string });
-        const jwk = await exportJWK(privateKey);
-        jwks = { keys: [jwk] };
-      }
-
-      const oidcClient = new issuer.Client(
-        {
-          client_id: config.clientID,
-          client_secret: config.clientSecret,
-          id_token_signed_response_alg: config.idTokenSigningAlg,
-          token_endpoint_auth_method: config.clientAuthMethod as ClientAuthMethod,
-          token_endpoint_auth_signing_alg: config.clientAssertionSigningAlg
-        },
-        jwks
-      );
-      applyHttpOptionsCustom(oidcClient);
-
-      oidcClient[custom.clock_tolerance] = config.clockTolerance;
-      const issuerUrl = new URL(issuer.metadata.issuer);
-
-      if (config.idpLogout) {
-        if (config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && config.auth0Logout !== false)) {
-          Object.defineProperty(oidcClient, 'endSessionUrl', {
-            value(params: EndSessionParameters) {
-              const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
-              const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
-              parsedUrl.searchParams.set('client_id', config.clientID);
-              post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);
-              Object.entries(extraParams).forEach(([key, value]) => {
-                if (value === null || value === undefined) {
-                  return;
-                }
-                parsedUrl.searchParams.set(key, value as string);
-              });
-              return parsedUrl.toString();
-            }
-          });
-        } else if (!issuer.end_session_endpoint) {
-          debug('the issuer does not support RP-Initiated Logout');
-        }
-      }
-
-      client = new NodeClient(oidcClient);
+      client = new NodeClient(config, telemetry);
     }
     return client;
   };

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -4,7 +4,8 @@ import {
   CallbackParamsType,
   OpenIDCallbackChecks,
   TokenEndpointResponse,
-  AbstractClient
+  AbstractClient,
+  Telemetry
 } from './abstract-client';
 import {
   Client,
@@ -23,6 +24,7 @@ import urlJoin from 'url-join';
 import createDebug from '../utils/debug';
 import { IncomingMessage } from 'http';
 import { AccessTokenError, AccessTokenErrorCode } from '../../utils/errors';
+import { Config } from '../config';
 
 const debug = createDebug('client');
 
@@ -31,140 +33,16 @@ function sortSpaceDelimitedString(str: string): string {
 }
 
 export class NodeClient extends AbstractClient {
-  private client?: Client;
-
-  private async getClient(): Promise<Client> {
-    if (this.client) {
-      return this.client;
-    }
-    const {
-      getConfig,
-      telemetry: { name, version }
-    } = this;
-    const config = await getConfig();
-
-    const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
-      ...options,
-      headers: {
-        ...options.headers,
-        'User-Agent': `${name}/${version}`,
-        ...(config.enableTelemetry
-          ? {
-              'Auth0-Client': Buffer.from(
-                JSON.stringify({
-                  name,
-                  version,
-                  env: {
-                    node: process.version
-                  }
-                })
-              ).toString('base64')
-            }
-          : undefined)
-      },
-      timeout: config.httpTimeout,
-      agent: config.httpAgent
-    });
-    const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
-      entity[custom.http_options] = defaultHttpOptions;
-    };
-
-    applyHttpOptionsCustom(Issuer);
-    let issuer: Issuer<Client>;
-    try {
-      issuer = await Issuer.discover(config.issuerBaseURL);
-    } catch (e) {
-      throw new DiscoveryError(e, config.issuerBaseURL);
-    }
-    applyHttpOptionsCustom(issuer);
-
-    const issuerTokenAlgs = Array.isArray(issuer.id_token_signing_alg_values_supported)
-      ? issuer.id_token_signing_alg_values_supported
-      : [];
-    if (!issuerTokenAlgs.includes(config.idTokenSigningAlg)) {
-      debug(
-        'ID token algorithm %o is not supported by the issuer. Supported ID token algorithms are: %o.',
-        config.idTokenSigningAlg,
-        issuerTokenAlgs
-      );
-    }
-
-    const configRespType = sortSpaceDelimitedString(config.authorizationParams.response_type);
-    const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
-    issuerRespTypes.map(sortSpaceDelimitedString);
-    if (!issuerRespTypes.includes(configRespType)) {
-      debug(
-        'Response type %o is not supported by the issuer. Supported response types are: %o.',
-        configRespType,
-        issuerRespTypes
-      );
-    }
-
-    const configRespMode = config.authorizationParams.response_mode;
-    const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
-    if (configRespMode && !issuerRespModes.includes(configRespMode)) {
-      debug(
-        'Response mode %o is not supported by the issuer. Supported response modes are %o.',
-        configRespMode,
-        issuerRespModes
-      );
-    }
-
-    let jwks;
-    if (config.clientAssertionSigningKey) {
-      const privateKey = createPrivateKey({ key: config.clientAssertionSigningKey as string });
-      const jwk = await exportJWK(privateKey);
-      jwks = { keys: [jwk] };
-    }
-
-    this.client = new issuer.Client(
-      {
-        client_id: config.clientID,
-        client_secret: config.clientSecret,
-        id_token_signed_response_alg: config.idTokenSigningAlg,
-        token_endpoint_auth_method: config.clientAuthMethod as ClientAuthMethod,
-        token_endpoint_auth_signing_alg: config.clientAssertionSigningAlg
-      },
-      jwks
-    );
-    applyHttpOptionsCustom(this.client);
-
-    this.client[custom.clock_tolerance] = config.clockTolerance;
-    const issuerUrl = new URL(issuer.metadata.issuer);
-
-    if (config.idpLogout) {
-      if (config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && config.auth0Logout !== false)) {
-        Object.defineProperty(this.client, 'endSessionUrl', {
-          value(params: EndSessionParameters) {
-            const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
-            const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
-            parsedUrl.searchParams.set('client_id', config.clientID);
-            post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);
-            Object.entries(extraParams).forEach(([key, value]) => {
-              if (value === null || value === undefined) {
-                return;
-              }
-              parsedUrl.searchParams.set(key, value as string);
-            });
-            return parsedUrl.toString();
-          }
-        });
-      } else if (!issuer.end_session_endpoint) {
-        debug('the issuer does not support RP-Initiated Logout');
-      }
-    }
-
-    return this.client;
+  constructor(private client: Client) {
+    super();
   }
 
   async authorizationUrl(parameters: Record<string, unknown>): Promise<string> {
-    const client = await this.getClient();
-    return client.authorizationUrl(parameters);
+    return this.client.authorizationUrl(parameters);
   }
 
   async callbackParams(req: Auth0Request) {
-    const client = await this.getClient();
-    const obj: CallbackParamsType = client.callbackParams({
+    const obj: CallbackParamsType = this.client.callbackParams({
       method: req.getMethod(),
       url: req.getUrl(),
       body: await req.getBody()
@@ -179,9 +57,8 @@ export class NodeClient extends AbstractClient {
     extras: CallbackExtras
   ): Promise<TokenEndpointResponse> {
     const params = Object.fromEntries(parameters.entries());
-    const client = await this.getClient();
     try {
-      return await client.callback(redirectUri, params, checks, extras);
+      return await this.client.callback(redirectUri, params, checks, extras);
     } catch (err) {
       if (err instanceof errors.OPError) {
         throw new IdentityProviderError(err);
@@ -195,23 +72,20 @@ export class NodeClient extends AbstractClient {
   }
 
   async endSessionUrl(parameters: EndSessionParameters): Promise<string> {
-    const client = await this.getClient();
-    return client.endSessionUrl(parameters);
+    return this.client.endSessionUrl(parameters);
   }
 
   async userinfo(accessToken: string): Promise<Record<string, unknown>> {
-    const client = await this.getClient();
     try {
-      return await client.userinfo(accessToken);
+      return await this.client.userinfo(accessToken);
     } catch (e) {
       throw new UserInfoError(e.message);
     }
   }
 
   async refresh(refreshToken: string, extras: { exchangeBody: Record<string, any> }): Promise<TokenEndpointResponse> {
-    const client = await this.getClient();
     try {
-      return await client.refresh(refreshToken, extras);
+      return await this.client.refresh(refreshToken, extras);
     } catch (e) {
       throw new AccessTokenError(
         AccessTokenErrorCode.FAILED_REFRESH_GRANT,
@@ -233,3 +107,126 @@ export class NodeClient extends AbstractClient {
     return generators.codeChallenge(codeVerifier);
   }
 }
+
+export const clientGetter = (telemetry: Telemetry): ((config: Config) => Promise<NodeClient>) => {
+  let client: NodeClient;
+  return async (config) => {
+    if (!client) {
+      const { name, version } = telemetry;
+
+      const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
+        ...options,
+        headers: {
+          ...options.headers,
+          'User-Agent': `${name}/${version}`,
+          ...(config.enableTelemetry
+            ? {
+                'Auth0-Client': Buffer.from(
+                  JSON.stringify({
+                    name,
+                    version,
+                    env: {
+                      node: process.version
+                    }
+                  })
+                ).toString('base64')
+              }
+            : undefined)
+        },
+        timeout: config.httpTimeout,
+        agent: config.httpAgent
+      });
+      const applyHttpOptionsCustom = (entity: Issuer<Client> | typeof Issuer | Client) => {
+        entity[custom.http_options] = defaultHttpOptions;
+      };
+
+      applyHttpOptionsCustom(Issuer);
+      let issuer: Issuer<Client>;
+      try {
+        issuer = await Issuer.discover(config.issuerBaseURL);
+      } catch (e) {
+        throw new DiscoveryError(e, config.issuerBaseURL);
+      }
+      applyHttpOptionsCustom(issuer);
+
+      const issuerTokenAlgs = Array.isArray(issuer.id_token_signing_alg_values_supported)
+        ? issuer.id_token_signing_alg_values_supported
+        : [];
+      if (!issuerTokenAlgs.includes(config.idTokenSigningAlg)) {
+        debug(
+          'ID token algorithm %o is not supported by the issuer. Supported ID token algorithms are: %o.',
+          config.idTokenSigningAlg,
+          issuerTokenAlgs
+        );
+      }
+
+      const configRespType = sortSpaceDelimitedString(config.authorizationParams.response_type);
+      const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
+      issuerRespTypes.map(sortSpaceDelimitedString);
+      if (!issuerRespTypes.includes(configRespType)) {
+        debug(
+          'Response type %o is not supported by the issuer. Supported response types are: %o.',
+          configRespType,
+          issuerRespTypes
+        );
+      }
+
+      const configRespMode = config.authorizationParams.response_mode;
+      const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
+      if (configRespMode && !issuerRespModes.includes(configRespMode)) {
+        debug(
+          'Response mode %o is not supported by the issuer. Supported response modes are %o.',
+          configRespMode,
+          issuerRespModes
+        );
+      }
+
+      let jwks;
+      if (config.clientAssertionSigningKey) {
+        const privateKey = createPrivateKey({ key: config.clientAssertionSigningKey as string });
+        const jwk = await exportJWK(privateKey);
+        jwks = { keys: [jwk] };
+      }
+
+      const oidcClient = new issuer.Client(
+        {
+          client_id: config.clientID,
+          client_secret: config.clientSecret,
+          id_token_signed_response_alg: config.idTokenSigningAlg,
+          token_endpoint_auth_method: config.clientAuthMethod as ClientAuthMethod,
+          token_endpoint_auth_signing_alg: config.clientAssertionSigningAlg
+        },
+        jwks
+      );
+      applyHttpOptionsCustom(oidcClient);
+
+      oidcClient[custom.clock_tolerance] = config.clockTolerance;
+      const issuerUrl = new URL(issuer.metadata.issuer);
+
+      if (config.idpLogout) {
+        if (config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && config.auth0Logout !== false)) {
+          Object.defineProperty(oidcClient, 'endSessionUrl', {
+            value(params: EndSessionParameters) {
+              const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
+              const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
+              parsedUrl.searchParams.set('client_id', config.clientID);
+              post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);
+              Object.entries(extraParams).forEach(([key, value]) => {
+                if (value === null || value === undefined) {
+                  return;
+                }
+                parsedUrl.searchParams.set(key, value as string);
+              });
+              return parsedUrl.toString();
+            }
+          });
+        } else if (!issuer.end_session_endpoint) {
+          debug('the issuer does not support RP-Initiated Logout');
+        }
+      }
+
+      client = new NodeClient(oidcClient);
+    }
+    return client;
+  };
+};

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -38,9 +38,10 @@ export class NodeClient extends AbstractClient {
       return this.client;
     }
     const {
-      config,
+      getConfig,
       telemetry: { name, version }
     } = this;
+    const config = await getConfig();
 
     const defaultHttpOptions: CustomHttpOptionsProvider = (_url, options) => ({
       ...options,
@@ -132,10 +133,7 @@ export class NodeClient extends AbstractClient {
     const issuerUrl = new URL(issuer.metadata.issuer);
 
     if (config.idpLogout) {
-      if (
-        this.config.idpLogout &&
-        (this.config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && this.config.auth0Logout !== false))
-      ) {
+      if (config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && config.auth0Logout !== false)) {
         Object.defineProperty(this.client, 'endSessionUrl', {
           value(params: EndSessionParameters) {
             const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -364,3 +364,5 @@ export interface LogoutOptions {
    */
   logoutParams?: { [key: string]: any };
 }
+
+export type GetConfig = Config | (() => Config | Promise<Config>);

--- a/src/auth0-session/config.ts
+++ b/src/auth0-session/config.ts
@@ -4,6 +4,7 @@ import type {
 } from './client/abstract-client';
 import type { Agent } from 'https';
 import { SessionStore } from './session/stateful-session';
+import { Auth0RequestCookies } from './http';
 
 /**
  * Configuration properties.
@@ -365,4 +366,4 @@ export interface LogoutOptions {
   logoutParams?: { [key: string]: any };
 }
 
-export type GetConfig = Config | (() => Config | Promise<Config>);
+export type GetConfig = Config | ((req: Auth0RequestCookies) => Config | Promise<Config>);

--- a/src/auth0-session/handlers/callback.ts
+++ b/src/auth0-session/handlers/callback.ts
@@ -1,5 +1,5 @@
 import urlJoin from 'url-join';
-import { AuthorizationParameters, Config } from '../config';
+import { AuthorizationParameters, GetConfig, Config } from '../config';
 import TransientStore from '../transient-store';
 import { decodeState } from '../utils/encoding';
 import { SessionCache } from '../session-cache';
@@ -25,12 +25,14 @@ export type CallbackOptions = {
 export type HandleCallback = (req: Auth0Request, res: Auth0Response, options?: CallbackOptions) => Promise<void>;
 
 export default function callbackHandlerFactory(
-  config: Config,
+  getConfig: GetConfig,
   client: AbstractClient,
   sessionCache: SessionCache,
   transientCookieHandler: TransientStore
 ): HandleCallback {
+  const getConfigFn = typeof getConfig === 'function' ? getConfig : () => getConfig;
   return async (req, res, options) => {
+    const config = await getConfigFn();
     const redirectUri = options?.redirectUri || getRedirectUri(config);
 
     let tokenResponse;

--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -1,5 +1,5 @@
 import urlJoin from 'url-join';
-import { Config, LoginOptions } from '../config';
+import { Config, GetConfig, LoginOptions } from '../config';
 import TransientStore from '../transient-store';
 import { encodeState } from '../utils/encoding';
 import createDebug from '../utils/debug';
@@ -23,11 +23,13 @@ export type AuthVerification = {
 };
 
 export default function loginHandlerFactory(
-  config: Config,
+  getConfig: GetConfig,
   client: AbstractClient,
   transientHandler: TransientStore
 ): HandleLogin {
+  const getConfigFn = typeof getConfig === 'function' ? getConfig : () => getConfig;
   return async (req, res, options = {}) => {
+    const config = await getConfigFn();
     const returnTo = options.returnTo || config.baseURL;
 
     const opts = {

--- a/src/auth0-session/handlers/login.ts
+++ b/src/auth0-session/handlers/login.ts
@@ -4,7 +4,7 @@ import TransientStore from '../transient-store';
 import { encodeState } from '../utils/encoding';
 import createDebug from '../utils/debug';
 import { Auth0Request, Auth0Response } from '../http';
-import { AbstractClient } from '../client/abstract-client';
+import { GetClient } from '../client/abstract-client';
 
 const debug = createDebug('handlers');
 
@@ -24,12 +24,13 @@ export type AuthVerification = {
 
 export default function loginHandlerFactory(
   getConfig: GetConfig,
-  client: AbstractClient,
+  getClient: GetClient,
   transientHandler: TransientStore
 ): HandleLogin {
   const getConfigFn = typeof getConfig === 'function' ? getConfig : () => getConfig;
   return async (req, res, options = {}) => {
-    const config = await getConfigFn();
+    const config = await getConfigFn(req);
+    const client = await getClient(config);
     const returnTo = options.returnTo || config.baseURL;
 
     const opts = {

--- a/src/auth0-session/handlers/logout.ts
+++ b/src/auth0-session/handlers/logout.ts
@@ -3,7 +3,7 @@ import createDebug from '../utils/debug';
 import { GetConfig, LogoutOptions } from '../config';
 import { SessionCache } from '../session-cache';
 import { Auth0Request, Auth0Response } from '../http';
-import { AbstractClient } from '../client/abstract-client';
+import { GetClient } from '../client/abstract-client';
 
 const debug = createDebug('logout');
 
@@ -11,12 +11,13 @@ export type HandleLogout = (req: Auth0Request, res: Auth0Response, options?: Log
 
 export default function logoutHandlerFactory(
   getConfig: GetConfig,
-  client: AbstractClient,
+  getClient: GetClient,
   sessionCache: SessionCache
 ): HandleLogout {
   const getConfigFn = typeof getConfig === 'function' ? getConfig : () => getConfig;
   return async (req, res, options = {}) => {
-    const config = await getConfigFn();
+    const config = await getConfigFn(req);
+    const client = await getClient(config);
     let returnURL = options.returnTo || config.routes.postLogoutRedirect;
     debug('logout() with return url: %s', returnURL);
 

--- a/src/auth0-session/handlers/logout.ts
+++ b/src/auth0-session/handlers/logout.ts
@@ -1,6 +1,6 @@
 import urlJoin from 'url-join';
 import createDebug from '../utils/debug';
-import { Config, LogoutOptions } from '../config';
+import { GetConfig, LogoutOptions } from '../config';
 import { SessionCache } from '../session-cache';
 import { Auth0Request, Auth0Response } from '../http';
 import { AbstractClient } from '../client/abstract-client';
@@ -10,11 +10,13 @@ const debug = createDebug('logout');
 export type HandleLogout = (req: Auth0Request, res: Auth0Response, options?: LogoutOptions) => Promise<void>;
 
 export default function logoutHandlerFactory(
-  config: Config,
+  getConfig: GetConfig,
   client: AbstractClient,
   sessionCache: SessionCache
 ): HandleLogout {
+  const getConfigFn = typeof getConfig === 'function' ? getConfig : () => getConfig;
   return async (req, res, options = {}) => {
+    const config = await getConfigFn();
     let returnURL = options.returnTo || config.routes.postLogoutRedirect;
     debug('logout() with return url: %s', returnURL);
 

--- a/src/auth0-session/index.ts
+++ b/src/auth0-session/index.ts
@@ -9,10 +9,18 @@ export { StatelessSession } from './session/stateless-session';
 export { AbstractSession, SessionPayload } from './session/abstract-session';
 export { StatefulSession, SessionStore } from './session/stateful-session';
 export { default as TransientStore } from './transient-store';
-export { Config, SessionConfig, CookieConfig, LoginOptions, LogoutOptions, AuthorizationParameters } from './config';
+export {
+  Config,
+  GetConfig,
+  SessionConfig,
+  CookieConfig,
+  LoginOptions,
+  LogoutOptions,
+  AuthorizationParameters
+} from './config';
 export { get as getConfig, ConfigParameters, DeepPartial } from './get-config';
 export { default as loginHandler, HandleLogin } from './handlers/login';
 export { default as logoutHandler, HandleLogout } from './handlers/logout';
 export { default as callbackHandler, CallbackOptions, AfterCallback, HandleCallback } from './handlers/callback';
-export { TokenEndpointResponse, AbstractClient } from './client/abstract-client';
+export { TokenEndpointResponse, AbstractClient, Telemetry } from './client/abstract-client';
 export { SessionCache } from './session-cache';

--- a/src/auth0-session/session-cache.ts
+++ b/src/auth0-session/session-cache.ts
@@ -5,5 +5,5 @@ export interface SessionCache<Req = any, Res = any, Session = { [key: string]: a
   delete(req: Req, res: Res): Promise<void>;
   isAuthenticated(req: Req, res: Res): Promise<boolean>;
   getIdToken(req: Req, res: Res): Promise<string | undefined>;
-  fromTokenEndpointResponse(tokenSet: TokenEndpointResponse): Session;
+  fromTokenEndpointResponse(req: Req, res: Res, tokenSet: TokenEndpointResponse): Promise<Session>;
 }

--- a/src/auth0-session/session/abstract-session.ts
+++ b/src/auth0-session/session/abstract-session.ts
@@ -1,6 +1,6 @@
 import createDebug from '../utils/debug';
 import { CookieSerializeOptions } from 'cookie';
-import { Config } from '../config';
+import { Config, GetConfig } from '../config';
 import { Auth0RequestCookies, Auth0ResponseCookies } from '../http';
 
 const debug = createDebug('session');
@@ -36,7 +36,11 @@ const assert = (bool: boolean, msg: string) => {
 };
 
 export abstract class AbstractSession<Session> {
-  constructor(protected config: Config) {}
+  protected getConfig: () => Config | Promise<Config>;
+
+  constructor(getConfig: GetConfig) {
+    this.getConfig = typeof getConfig === 'function' ? getConfig : () => getConfig;
+  }
 
   abstract getSession(req: Auth0RequestCookies): Promise<SessionPayload<Session> | undefined | null>;
 
@@ -58,7 +62,8 @@ export abstract class AbstractSession<Session> {
   ): Promise<void>;
 
   public async read(req: Auth0RequestCookies): Promise<[Session?, number?]> {
-    const { rollingDuration, absoluteDuration } = this.config.session;
+    const config = await this.getConfig();
+    const { rollingDuration, absoluteDuration } = config.session;
 
     try {
       const existingSessionValue = await this.getSession(req);
@@ -95,9 +100,10 @@ export abstract class AbstractSession<Session> {
     session: Session | null | undefined,
     createdAt?: number
   ): Promise<void> {
+    const config = await this.getConfig();
     const {
       cookie: { transient, ...cookieConfig }
-    } = this.config.session;
+    } = config.session;
 
     if (!session) {
       await this.deleteSession(req, res, cookieConfig);
@@ -107,7 +113,7 @@ export abstract class AbstractSession<Session> {
     const isNewSession = typeof createdAt === 'undefined';
     const uat = epoch();
     const iat = typeof createdAt === 'number' ? createdAt : uat;
-    const exp = this.calculateExp(iat, uat);
+    const exp = this.calculateExp(iat, uat, config);
 
     const cookieOptions: CookieSerializeOptions = {
       ...cookieConfig
@@ -119,9 +125,9 @@ export abstract class AbstractSession<Session> {
     await this.setSession(req, res, session, uat, iat, exp, cookieOptions, isNewSession);
   }
 
-  private calculateExp(iat: number, uat: number): number {
-    const { absoluteDuration } = this.config.session;
-    const { rolling, rollingDuration } = this.config.session;
+  private calculateExp(iat: number, uat: number, config: Config): number {
+    const { absoluteDuration } = config.session;
+    const { rolling, rollingDuration } = config.session;
 
     if (typeof absoluteDuration !== 'number') {
       return uat + (rollingDuration as number);

--- a/src/auth0-session/session/abstract-session.ts
+++ b/src/auth0-session/session/abstract-session.ts
@@ -36,7 +36,7 @@ const assert = (bool: boolean, msg: string) => {
 };
 
 export abstract class AbstractSession<Session> {
-  protected getConfig: () => Config | Promise<Config>;
+  protected getConfig: (req: Auth0RequestCookies) => Config | Promise<Config>;
 
   constructor(getConfig: GetConfig) {
     this.getConfig = typeof getConfig === 'function' ? getConfig : () => getConfig;
@@ -62,7 +62,7 @@ export abstract class AbstractSession<Session> {
   ): Promise<void>;
 
   public async read(req: Auth0RequestCookies): Promise<[Session?, number?]> {
-    const config = await this.getConfig();
+    const config = await this.getConfig(req);
     const { rollingDuration, absoluteDuration } = config.session;
 
     try {
@@ -100,7 +100,7 @@ export abstract class AbstractSession<Session> {
     session: Session | null | undefined,
     createdAt?: number
   ): Promise<void> {
-    const config = await this.getConfig();
+    const config = await this.getConfig(req);
     const {
       cookie: { transient, ...cookieConfig }
     } = config.session;

--- a/src/auth0-session/session/stateless-session.ts
+++ b/src/auth0-session/session/stateless-session.ts
@@ -24,9 +24,8 @@ export class StatelessSession<
     super(config);
   }
 
-  private async getChunkSize(): Promise<number> {
+  private async getChunkSize(config: Config): Promise<number> {
     if (this.chunkSize === undefined) {
-      const config = await this.getConfig();
       const {
         cookie: { transient, ...cookieConfig },
         name: sessionName
@@ -44,9 +43,8 @@ export class StatelessSession<
     return this.chunkSize;
   }
 
-  private async getKeys(): Promise<Uint8Array[]> {
+  public async getKeys(config: Config): Promise<Uint8Array[]> {
     if (!this.keys) {
-      const config = await this.getConfig();
       const secret = config.secret;
       const secrets = Array.isArray(secret) ? secret : [secret];
       this.keys = await Promise.all(secrets.map(encryption));
@@ -54,13 +52,11 @@ export class StatelessSession<
     return this.keys;
   }
 
-  public async encrypt(payload: jose.JWTPayload, { iat, uat, exp }: Header): Promise<string> {
-    const [key] = await this.getKeys();
+  public async encrypt(payload: jose.JWTPayload, { iat, uat, exp }: Header, key: Uint8Array): Promise<string> {
     return await new jose.EncryptJWT({ ...payload }).setProtectedHeader({ alg, enc, uat, iat, exp }).encrypt(key);
   }
 
-  private async decrypt(jwe: string): Promise<jose.JWTDecryptResult> {
-    const keys = await this.getKeys();
+  private async decrypt(jwe: string, keys: Uint8Array[]): Promise<jose.JWTDecryptResult> {
     let err;
     for (const key of keys) {
       try {
@@ -73,7 +69,7 @@ export class StatelessSession<
   }
 
   async getSession(req: Auth0RequestCookies): Promise<SessionPayload<Session> | undefined | null> {
-    const config = await this.getConfig();
+    const config = await this.getConfig(req);
     const { name: sessionName } = config.session;
     const cookies = req.getCookies();
     let existingSessionValue: string | undefined;
@@ -106,7 +102,8 @@ export class StatelessSession<
         .join('');
     }
     if (existingSessionValue) {
-      const { protectedHeader, payload } = await this.decrypt(existingSessionValue);
+      const keys = await this.getKeys(config);
+      const { protectedHeader, payload } = await this.decrypt(existingSessionValue, keys);
       return { header: protectedHeader as unknown as Header, data: payload as Session };
     }
     return;
@@ -121,14 +118,15 @@ export class StatelessSession<
     exp: number,
     cookieOptions: CookieSerializeOptions
   ): Promise<void> {
-    const config = await this.getConfig();
+    const config = await this.getConfig(req);
     const { name: sessionName } = config.session;
     const cookies = req.getCookies();
 
     debug('found session, creating signed session cookie(s) with name %o(.i)', sessionName);
-    const value = await this.encrypt(session, { iat, uat, exp });
+    const [key] = await this.getKeys(config);
+    const value = await this.encrypt(session, { iat, uat, exp }, key);
 
-    const chunkSize = await this.getChunkSize();
+    const chunkSize = await this.getChunkSize(config);
     const chunkCount = Math.ceil(value.length / chunkSize);
 
     const existingCookies = new Set(
@@ -158,7 +156,7 @@ export class StatelessSession<
     res: Auth0ResponseCookies,
     cookieOptions: CookieSerializeOptions
   ): Promise<void> {
-    const config = await this.getConfig();
+    const config = await this.getConfig(req);
     const { name: sessionName } = config.session;
     const cookies = req.getCookies();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -263,8 +263,16 @@ export type GetConfig = (req: Auth0Request | Auth0RequestCookies) => Promise<Nex
 
 export const configSingletonGetter = (params: ConfigParameters = {}, genId: () => string): GetConfig => {
   let config: NextConfig;
-  return () => {
+  return (req) => {
     if (!config) {
+      // Bails out of static rendering for Server Components
+      // Need to query cookies because Server Components don't have access to URL
+      req.getCookies();
+      if ('getUrl' in req) {
+        // Bail out of static rendering for API Routes
+        // Reading cookies is not always enough https://github.com/vercel/next.js/issues/49006
+        req.getUrl();
+      }
       config = getConfig({ ...params, session: { genId, ...params.session } });
     }
     return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,371 +1,11 @@
-import type { Agent } from 'https';
-import type { LoginOptions, AuthorizationParameters as OidcAuthorizationParameters } from './auth0-session/config';
-import { SessionStore } from './auth0-session/session/stateful-session';
-import Session from './session/session';
+import type { Config as BaseConfig } from './auth0-session/config';
 import { DeepPartial, get as getBaseConfig } from './auth0-session/get-config';
+import type { Auth0Request, Auth0RequestCookies } from './auth0-session/http';
 
 /**
  * @category server
  */
-export interface BaseConfig {
-  /**
-   * The secret(s) used to derive an encryption key for the user identity in a session cookie and
-   * to sign the transient cookies used by the login callback.
-   * Provide a single string secret, but if you want to rotate the secret you can provide an array putting
-   * the new secret first.
-   * You can also use the `AUTH0_SECRET` environment variable.
-   */
-  secret: string | Array<string>;
-
-  /**
-   * Object defining application session cookie attributes.
-   */
-  session: SessionConfig;
-
-  /**
-   * Boolean value to enable Auth0's proprietary logout feature.
-   * Since this SDK is for Auth0, it's set to `true` by default.
-   * Set it to `false` if you don't want to use https://auth0.com/docs/api/authentication#logout.
-   * You can also use the `AUTH0_LOGOUT` environment variable.
-   */
-  auth0Logout?: boolean;
-
-  /**
-   *  URL parameters used when redirecting users to the authorization server to log in.
-   *
-   *  If this property is not provided by your application, its default values will be:
-   *
-   * ```js
-   * {
-   *   response_type: 'code',
-   *   scope: 'openid profile email'
-   * }
-   * ```
-   *
-   * New values can be passed in to change what is returned from the authorization server
-   * depending on your specific scenario. Additional custom parameters can be added as well.
-   *
-   * **Note:** You must provide the required parameters if this object is set.
-   *
-   * ```js
-   * {
-   *   response_type: 'code',
-   *   scope: 'openid profile email',
-   *
-   *   // Additional parameters
-   *   acr_value: 'tenant:test-tenant',
-   *   custom_param: 'custom-value'
-   * };
-   * ```
-   */
-  authorizationParams: AuthorizationParameters;
-
-  /**
-   * The root URL for the application router, for example `https://localhost`.
-   * You can also use the `AUTH0_BASE_URL` environment variable.
-   * If you provide a domain, we will prefix it with `https://`. This can be useful when assigning it to
-   * `VERCEL_URL` for Vercel deploys.
-   *
-   * `NEXT_PUBLIC_AUTH0_BASE_URL` will also be checked if `AUTH0_BASE_URL` is not defined.
-   */
-  baseURL: string;
-
-  /**
-   * The Client ID for your application.
-   * You can also use the `AUTH0_CLIENT_ID` environment variable.
-   */
-  clientID: string;
-
-  /**
-   * The Client Secret for your application.
-   * Required when requesting access tokens.
-   * You can also use the `AUTH0_CLIENT_SECRET` environment variable.
-   */
-  clientSecret?: string;
-
-  /**
-   * Integer value for the system clock's tolerance (leeway) in seconds for ID token verification.`
-   * Defaults to `60` seconds.
-   * You can also use the `AUTH0_CLOCK_TOLERANCE` environment variable.
-   */
-  clockTolerance: number;
-
-  /**
-   * Integer value for the HTTP timeout in milliseconds for authentication requests.
-   * Defaults to `5000` ms.
-   * You can also use the `AUTH0_HTTP_TIMEOUT` environment variable.
-   */
-  httpTimeout: number;
-
-  /**
-   * Instance of an HTTP agent for authentication requests.
-   * (This is for the Node.js runtime only)
-   */
-  httpAgent?: Agent;
-
-  /**
-   * Boolean value to opt-out of sending the library and node version to your authorization server
-   * via the `Auth0-Client` header. Defaults to `true`.
-   * You can also use the `AUTH0_ENABLE_TELEMETRY` environment variable.
-   */
-  enableTelemetry: boolean;
-
-  /**
-   * Function that returns an object with URL-safe state values for login.
-   * Used for passing custom state parameters to your authorization server.
-   * Can also be passed in to {@link HandleLogin}.
-   *
-   * ```js
-   * {
-   *   ...
-   *   getLoginState(options) {
-   *     return {
-   *       returnTo: options.returnTo || req.originalUrl,
-   *       customState: 'foo'
-   *     };
-   *   }
-   * }
-   * ```
-   */
-  getLoginState: (options: LoginOptions) => Record<string, any>;
-
-  /**
-   * Array value of claims to remove from the ID token before storing the cookie session.
-   * Defaults to `['aud', 'iss', 'iat', 'exp', 'nbf', 'nonce', 'azp', 'auth_time', 's_hash', 'at_hash', 'c_hash']`.
-   * You can also use the `AUTH0_IDENTITY_CLAIM_FILTER` environment variable.
-   */
-  identityClaimFilter: string[];
-
-  /**
-   * Boolean value to log the user out from the identity provider on application logout. Defaults to `true`.
-   * You can also use the `AUTH0_IDP_LOGOUT` environment variable.
-   */
-  idpLogout: boolean;
-
-  /**
-   * String value for the expected ID token algorithm. Defaults to 'RS256'.
-   * You can also use the `AUTH0_ID_TOKEN_SIGNING_ALG` environment variable.
-   */
-  idTokenSigningAlg: string;
-
-  /**
-   * **REQUIRED** The root URL for the token issuer with no trailing slash.
-   * This is `https://` plus your Auth0 domain.
-   * You can also use the `AUTH0_ISSUER_BASE_URL` environment variable.
-   */
-  issuerBaseURL: string;
-
-  /**
-   * Set a fallback cookie with no `SameSite` attribute when `response_mode` is `form_post`.
-   * The default `response_mode` for this SDK is `query` so this defaults to `false`
-   * You can also use the `AUTH0_LEGACY_SAME_SITE_COOKIE` environment variable.
-   */
-  legacySameSiteCookie: boolean;
-
-  /**
-   * Boolean value to automatically install the login and logout routes.
-   */
-  routes: {
-    /**
-     * Either a relative path to the application or a valid URI to an external domain.
-     * This value must be registered on the authorization server.
-     * The user will be redirected to this after a logout has been performed.
-     * You can also use the `AUTH0_POST_LOGOUT_REDIRECT` environment variable.
-     */
-    postLogoutRedirect: string;
-
-    /**
-     * Relative path to the application callback to process the response from the authorization server.
-     * Defaults to `/api/auth/callback`.
-     * You can also use the `AUTH0_CALLBACK` environment variable.
-     */
-    callback: string;
-  };
-
-  /**
-   * Private key for use with `private_key_jwt` clients.
-   * This should be a string that is the contents of a PEM file.
-   * You can also use the `AUTH0_CLIENT_ASSERTION_SIGNING_KEY` environment variable.
-   *
-   * For Edge runtime, you can also provide an instance of `CryptoKey`.
-   */
-  clientAssertionSigningKey?: string | CryptoKey;
-
-  /**
-   * The algorithm to sign the client assertion JWT.
-   * Uses one of `token_endpoint_auth_signing_alg_values_supported` if not specified.
-   * If the Authorization Server discovery document does not list `token_endpoint_auth_signing_alg_values_supported`
-   * this property will be required.
-   *  You can also use the `AUTH0_CLIENT_ASSERTION_SIGNING_ALG` environment variable.
-   */
-  clientAssertionSigningAlg?: string;
-
-  /**
-   * By default, the transaction cookie takes the same settings as the
-   * session cookie. But you may want to configure the session cookie to be more
-   * secure in a way that would break the OAuth flow's usage of the transaction
-   * cookie (Setting SameSite=Strict for example).
-   *
-   * You can also use:
-   * `AUTH0_TRANSACTION_COOKIE_NAME`
-   * `AUTH0_TRANSACTION_COOKIE_DOMAIN`
-   * `AUTH0_TRANSACTION_COOKIE_PATH`
-   * `AUTH0_TRANSACTION_COOKIE_SAME_SITE`
-   * `AUTH0_TRANSACTION_COOKIE_SECURE`
-   */
-  transactionCookie: Omit<CookieConfig, 'transient' | 'httpOnly'> & { name: string };
-}
-
-/**
- * Configuration parameters used for the application session.
- *
- * @category Server
- */
-export interface SessionConfig {
-  /**
-   * String value for the cookie name used for the internal session.
-   * This value must only include letters, numbers, and underscores.
-   * Defaults to `appSession`.
-   * You can also use the `AUTH0_SESSION_NAME` environment variable.
-   */
-  name: string;
-
-  /**
-   * By default, the session is stateless and stored in an encrypted cookie. But if you want a stateful session
-   * you can provide a store with `get`, `set` and `destroy` methods to store the session on the server.
-   */
-  store?: SessionStore<Session>;
-
-  /**
-   * A Function for generating a session id when using a custom session store.
-   *
-   * **IMPORTANT** If you override this, you must use a suitable value from your platform to
-   * prevent collisions. For example, for Node: `require('crypto').randomBytes(16).toString('hex')`.
-   */
-  genId?: <Req = any, SessionType extends { [key: string]: any } = { [key: string]: any }>(
-    req: Req,
-    session: SessionType
-  ) => string | Promise<string>;
-
-  /**
-   * If you want your session duration to be rolling, resetting everytime the
-   * user is active on your site, set this to `true`. If you want the session
-   * duration to be absolute, where the user gets logged out a fixed time after login
-   * regardless of activity, set this to `false`.
-   * Defaults to `true`.
-   * You can also use the `AUTH0_SESSION_ROLLING` environment variable.
-   */
-  rolling: boolean;
-
-  /**
-   * Integer value, in seconds, for application session rolling duration.
-   * The amount of time for which the user must be idle for then to be logged out.
-   * Should be `false` when rolling is `false`.
-   * Defaults to `86400` seconds (1 day).
-   * You can also use the AUTH0_SESSION_ROLLING_DURATION environment variable.
-   */
-  rollingDuration: number | false;
-
-  /**
-   * Integer value, in seconds, for application absolute rolling duration.
-   * The amount of time after the user has logged in that they will be logged out.
-   * Set this to `false` if you don't want an absolute duration on your session.
-   * Defaults to `604800` seconds (7 days).
-   * You can also use the `AUTH0_SESSION_ABSOLUTE_DURATION` environment variable.
-   */
-  absoluteDuration: boolean | number;
-
-  /**
-   * Boolean value to enable automatic session saving when using rolling sessions.
-   * If this is `false`, you must call `touchSession(req, res)` to update the session.
-   * Defaults to `true`.
-   * You can also use the `AUTH0_SESSION_AUTO_SAVE` environment variable.
-   */
-  autoSave?: boolean;
-
-  /**
-   * Boolean value to store the ID token in the session. Storing it can make the session cookie too
-   * large.
-   * Defaults to `true`.
-   * You can also use the `AUTH0_SESSION_STORE_ID_TOKEN` environment variable.
-   */
-  storeIDToken: boolean;
-
-  cookie: CookieConfig;
-}
-
-/**
- * Configure how the session cookie and transient cookies are stored.
- *
- * @category Server
- */
-export interface CookieConfig {
-  /**
-   * Domain name for the cookie.
-   * You can also use the `AUTH0_COOKIE_DOMAIN` environment variable.
-   */
-  domain?: string;
-
-  /**
-   * Path for the cookie.
-   * Defaults to `/`.
-   * You should change this to be more restrictive if you application shares a domain with other apps.
-   * You can also use the `AUTH0_COOKIE_PATH` environment variable.
-   */
-  path?: string;
-
-  /**
-   * Set to `true` to use a transient cookie (cookie without an explicit expiration).
-   * Defaults to `false`.
-   * You can also use the `AUTH0_COOKIE_TRANSIENT` environment variable.
-   */
-  transient: boolean;
-
-  /**
-   * Flags the cookie to be accessible only by the web server.
-   * Defaults to `true`.
-   * You can also use the `AUTH0_COOKIE_HTTP_ONLY` environment variable.
-   */
-  httpOnly: boolean;
-
-  /**
-   * Marks the cookie to be used over secure channels only.
-   * Defaults to the protocol of {@link BaseConfig.baseURL}.
-   * You can also use the `AUTH0_COOKIE_SECURE` environment variable.
-   */
-  secure?: boolean;
-
-  /**
-   * Value of the SameSite `Set-Cookie` attribute.
-   * Defaults to `lax` but will be adjusted based on {@link AuthorizationParameters.response_type}.
-   * You can also use the `AUTH0_COOKIE_SAME_SITE` environment variable.
-   */
-  sameSite: 'lax' | 'strict' | 'none';
-}
-
-/**
- * Authorization parameters that will be passed to the identity provider on login.
- *
- * The library uses `response_mode: 'query'` and `response_type: 'code'` (with PKCE) by default.
- *
- * @category Server
- */
-export interface AuthorizationParameters extends OidcAuthorizationParameters {
-  /**
-   * A space-separated list of scopes that will be requested during authentication. For example,
-   * `openid profile email offline_access`.
-   * Defaults to `openid profile email`.
-   */
-  scope: string;
-
-  response_mode: 'query' | 'form_post';
-  response_type: 'id_token' | 'code id_token' | 'code';
-}
-
-/**
- * @category server
- */
-export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
+export interface NextConfig extends BaseConfig {
   /**
    * Log users in to a specific organization.
    *
@@ -375,11 +15,9 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
    * If your app supports multiple organizations, you should take a look at {@link AuthorizationParams.organization}.
    */
   organization?: string;
-  routes: {
-    callback: string;
+  routes: BaseConfig['routes'] & {
     login: string;
   };
-  session: Pick<SessionConfig, 'storeIDToken'>;
 }
 
 /**
@@ -405,21 +43,21 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  *
  * ### Required
  *
- * - `AUTH0_SECRET`: See {@link secret}.
- * - `AUTH0_ISSUER_BASE_URL`: See {@link issuerBaseURL}.
- * - `AUTH0_BASE_URL`: See {@link baseURL}.
- * - `AUTH0_CLIENT_ID`: See {@link clientID}.
- * - `AUTH0_CLIENT_SECRET`: See {@link clientSecret}.
+ * - `AUTH0_SECRET`: See {@link BaseConfig.secret}.
+ * - `AUTH0_ISSUER_BASE_URL`: See {@link BaseConfig.issuerBaseURL}.
+ * - `AUTH0_BASE_URL`: See {@link BaseConfig.baseURL}.
+ * - `AUTH0_CLIENT_ID`: See {@link BaseConfig.clientID}.
+ * - `AUTH0_CLIENT_SECRET`: See {@link BaseConfig.clientSecret}.
  *
  * ### Optional
  *
- * - `AUTH0_CLOCK_TOLERANCE`: See {@link clockTolerance}.
- * - `AUTH0_HTTP_TIMEOUT`: See {@link httpTimeout}.
- * - `AUTH0_ENABLE_TELEMETRY`: See {@link enableTelemetry}.
- * - `AUTH0_IDP_LOGOUT`: See {@link idpLogout}.
- * - `AUTH0_ID_TOKEN_SIGNING_ALG`: See {@link idTokenSigningAlg}.
- * - `AUTH0_LEGACY_SAME_SITE_COOKIE`: See {@link legacySameSiteCookie}.
- * - `AUTH0_IDENTITY_CLAIM_FILTER`: See {@link identityClaimFilter}.
+ * - `AUTH0_CLOCK_TOLERANCE`: See {@link BaseConfig.clockTolerance}.
+ * - `AUTH0_HTTP_TIMEOUT`: See {@link BaseConfig.httpTimeout}.
+ * - `AUTH0_ENABLE_TELEMETRY`: See {@link BaseConfig.enableTelemetry}.
+ * - `AUTH0_IDP_LOGOUT`: See {@link BaseConfig.idpLogout}.
+ * - `AUTH0_ID_TOKEN_SIGNING_ALG`: See {@link BaseConfig.idTokenSigningAlg}.
+ * - `AUTH0_LEGACY_SAME_SITE_COOKIE`: See {@link BaseConfig.legacySameSiteCookie}.
+ * - `AUTH0_IDENTITY_CLAIM_FILTER`: See {@link BaseConfig.identityClaimFilter}.
  * - `NEXT_PUBLIC_AUTH0_LOGIN`: See {@link NextConfig.routes}.
  * - `AUTH0_CALLBACK`: See {@link BaseConfig.routes}.
  * - `AUTH0_POST_LOGOUT_REDIRECT`: See {@link BaseConfig.routes}.
@@ -475,7 +113,7 @@ export interface NextConfig extends Pick<BaseConfig, 'identityClaimFilter'> {
  *
  * @category Server
  */
-export type ConfigParameters = DeepPartial<BaseConfig & NextConfig>;
+export type ConfigParameters = DeepPartial<NextConfig>;
 
 /**
  * @ignore
@@ -505,14 +143,7 @@ const array = (param?: string): string[] | undefined =>
 /**
  * @ignore
  */
-export const getLoginUrl = (): string => {
-  return process.env.NEXT_PUBLIC_AUTH0_LOGIN || '/api/auth/login';
-};
-
-/**
- * @ignore
- */
-export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConfig; nextConfig: NextConfig } => {
+export const getConfig = (params: ConfigParameters = {}): NextConfig => {
   // Don't use destructuring here so that the `DefinePlugin` can replace any env vars specified in `next.config.js`
   const AUTH0_SECRET = process.env.AUTH0_SECRET;
   const AUTH0_ISSUER_BASE_URL = process.env.AUTH0_ISSUER_BASE_URL;
@@ -618,15 +249,24 @@ export const getConfig = (params: ConfigParameters = {}): { baseConfig: BaseConf
     }
   });
 
-  const nextConfig: NextConfig = {
+  return {
+    ...baseConfig,
+    organization: organization || AUTH0_ORGANIZATION,
     routes: {
       ...baseConfig.routes,
-      login: baseParams.routes?.login || getLoginUrl()
-    },
-    identityClaimFilter: baseConfig.identityClaimFilter,
-    organization: organization || AUTH0_ORGANIZATION,
-    session: { storeIDToken: baseConfig.session.storeIDToken }
+      login: baseParams.routes?.login || process.env.NEXT_PUBLIC_AUTH0_LOGIN || '/api/auth/login'
+    }
   };
+};
 
-  return { baseConfig, nextConfig };
+export type GetConfig = (req: Auth0Request | Auth0RequestCookies) => Promise<NextConfig> | NextConfig;
+
+export const configSingletonGetter = (params: ConfigParameters = {}, genId: () => string): GetConfig => {
+  let config: NextConfig;
+  return () => {
+    if (!config) {
+      config = getConfig({ ...params, session: { genId, ...params.session } });
+    }
+    return config;
+  };
 };

--- a/src/handlers/logout.ts
+++ b/src/handlers/logout.ts
@@ -4,7 +4,6 @@ import { HandleLogin as BaseHandleLogin, HandleLogout as BaseHandleLogout } from
 import { assertReqRes } from '../utils/assert';
 import { HandlerErrorCause, LogoutHandlerError } from '../utils/errors';
 import { Auth0NextApiRequest, Auth0NextApiResponse, Auth0NextRequest, Auth0NextResponse } from '../http';
-import { BaseConfig } from '../config';
 import { AppRouteHandlerFnContext, AuthHandler, Handler, getHandler, OptionsProvider } from './router-helpers';
 
 /**

--- a/src/helpers/testing.ts
+++ b/src/helpers/testing.ts
@@ -26,8 +26,9 @@ export const generateSessionCookie = async (
 ): Promise<string> => {
   const weekInSeconds = 7 * 24 * 60 * 60;
   const { secret, duration: absoluteDuration = weekInSeconds, ...cookie } = config;
-  const cookieStoreConfig = { secret, session: { absoluteDuration, cookie } };
-  const cookieStore = new StatelessSession(cookieStoreConfig as BaseConfig);
+  const cookieStoreConfig = { secret, session: { absoluteDuration, cookie } } as BaseConfig;
+  const cookieStore = new StatelessSession(cookieStoreConfig);
   const epoch = (Date.now() / 1000) | 0;
-  return cookieStore.encrypt(session, { iat: epoch, uat: epoch, exp: epoch + absoluteDuration });
+  const [key] = await cookieStore.getKeys(cookieStoreConfig);
+  return cookieStore.encrypt(session, { iat: epoch, uat: epoch, exp: epoch + absoluteDuration }, key);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,24 +9,20 @@ import {
   HandleLogin,
   HandleLogout,
   HandleProfile,
-  SessionCache,
   TouchSession,
   UpdateSession,
   WithApiAuthRequired,
-  WithPageAuthRequired,
-  telemetry
+  WithPageAuthRequired
 } from './shared';
 import { _initAuth } from './init';
 import { setIsUsingNamedExports, setIsUsingOwnInstance } from './utils/instance-check';
-import { getConfig, getLoginUrl } from './config';
-import { withPageAuthRequiredFactory } from './helpers';
-import { NodeClient } from './auth0-session/client/node-client';
+import { clientGetter } from './auth0-session/client/node-client';
 
 const genId = () => crypto.randomBytes(16).toString('hex');
 
 export type Auth0Server = Omit<Auth0ServerShared, 'withMiddlewareAuthRequired'>;
 
-let instance: Auth0ServerShared & { sessionCache: SessionCache };
+let instance: Auth0ServerShared;
 
 /**
  * Initialise your own instance of the SDK.
@@ -38,34 +34,34 @@ let instance: Auth0ServerShared & { sessionCache: SessionCache };
 export type InitAuth0 = (params?: ConfigParameters) => Omit<Auth0Server, 'withMiddlewareAuthRequired'>;
 
 // For using managed instance with named exports.
-function getInstance(): Auth0ServerShared & { sessionCache: SessionCache } {
+function getInstance(): Auth0ServerShared {
   setIsUsingNamedExports();
   if (instance) {
     return instance;
   }
-  const { baseConfig, nextConfig } = getConfig({ session: { genId } });
-  const client = new NodeClient(baseConfig, telemetry);
-  instance = _initAuth({ baseConfig, nextConfig, client });
+  instance = _initAuth({ genId, clientGetter });
   return instance;
 }
 
 // For creating own instance.
 export const initAuth0: InitAuth0 = (params) => {
   setIsUsingOwnInstance();
-  const { baseConfig, nextConfig } = getConfig({ ...params, session: { genId, ...params?.session } });
-  const client = new NodeClient(baseConfig, telemetry);
-  const { sessionCache, withMiddlewareAuthRequired, ...publicApi } = _initAuth({ baseConfig, nextConfig, client });
+  const { withMiddlewareAuthRequired, ...publicApi } = _initAuth({
+    genId,
+    params,
+    clientGetter
+  });
   return publicApi;
 };
 
-const getSessionCache = () => getInstance().sessionCache;
 export const getSession: GetSession = (...args) => getInstance().getSession(...args);
 export const updateSession: UpdateSession = (...args) => getInstance().updateSession(...args);
 export const getAccessToken: GetAccessToken = (...args) => getInstance().getAccessToken(...args);
 export const touchSession: TouchSession = (...args) => getInstance().touchSession(...args);
 export const withApiAuthRequired: WithApiAuthRequired = (...args) =>
   (getInstance().withApiAuthRequired as any)(...args);
-export const withPageAuthRequired: WithPageAuthRequired = withPageAuthRequiredFactory(getLoginUrl(), getSessionCache);
+export const withPageAuthRequired: WithPageAuthRequired = ((...args: Parameters<WithPageAuthRequired>) =>
+  getInstance().withPageAuthRequired(...args)) as WithPageAuthRequired;
 export const handleLogin: HandleLogin = ((...args: Parameters<HandleLogin>) =>
   getInstance().handleLogin(...args)) as HandleLogin;
 export const handleLogout: HandleLogout = ((...args: Parameters<HandleLogout>) =>

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,25 +1,23 @@
 import {
-  StatelessSession,
-  StatefulSession,
   TransientStore,
   loginHandler as baseLoginHandler,
   logoutHandler as baseLogoutHandler,
   callbackHandler as baseCallbackHandler,
-  AbstractClient
+  Telemetry
 } from './auth0-session';
 import { handlerFactory, callbackHandler, loginHandler, logoutHandler, profileHandler } from './handlers';
 import {
   sessionFactory,
   accessTokenFactory,
   SessionCache,
-  Session,
   touchSessionFactory,
   updateSessionFactory
 } from './session/';
 import { withPageAuthRequiredFactory, withApiAuthRequiredFactory } from './helpers';
-import { ConfigParameters, BaseConfig, NextConfig } from './config';
-import { Auth0Server } from './shared';
+import { configSingletonGetter, ConfigParameters } from './config';
+import { Auth0Server, telemetry } from './shared';
 import withMiddlewareAuthRequiredFactory from './helpers/with-middleware-auth-required';
+import { GetClient } from './auth0-session/client/abstract-client';
 
 /**
  * Initialise your own instance of the SDK.
@@ -31,43 +29,40 @@ import withMiddlewareAuthRequiredFactory from './helpers/with-middleware-auth-re
 export type InitAuth0 = (params?: ConfigParameters) => Auth0Server;
 
 export const _initAuth = ({
-  baseConfig,
-  nextConfig,
-  client
+  params,
+  genId,
+  clientGetter
 }: {
-  baseConfig: BaseConfig;
-  nextConfig: NextConfig;
-  client: AbstractClient;
-}): Auth0Server & {
-  sessionCache: SessionCache;
-} => {
-  // Init base layer (with base config)
-  const transientStore = new TransientStore(baseConfig);
+  params?: ConfigParameters;
+  genId: () => string;
+  clientGetter: (telemetry: Telemetry) => GetClient;
+}): Auth0Server => {
+  const getConfig = configSingletonGetter(params, genId);
+  const getClient = clientGetter(telemetry);
 
-  const sessionStore = baseConfig.session.store
-    ? new StatefulSession<Session>(baseConfig)
-    : new StatelessSession<Session>(baseConfig);
-  const sessionCache = new SessionCache(baseConfig, sessionStore);
-  const baseHandleLogin = baseLoginHandler(baseConfig, client, transientStore);
-  const baseHandleLogout = baseLogoutHandler(baseConfig, client, sessionCache);
-  const baseHandleCallback = baseCallbackHandler(baseConfig, client, sessionCache, transientStore);
+  // Init base layer (with base config)
+  const transientStore = new TransientStore(getConfig);
+
+  const sessionCache = new SessionCache(getConfig);
+  const baseHandleLogin = baseLoginHandler(getConfig, getClient, transientStore);
+  const baseHandleLogout = baseLogoutHandler(getConfig, getClient, sessionCache);
+  const baseHandleCallback = baseCallbackHandler(getConfig, getClient, sessionCache, transientStore);
 
   // Init Next layer (with next config)
   const getSession = sessionFactory(sessionCache);
   const touchSession = touchSessionFactory(sessionCache);
   const updateSession = updateSessionFactory(sessionCache);
-  const getAccessToken = accessTokenFactory(nextConfig, client, sessionCache);
+  const getAccessToken = accessTokenFactory(getConfig, getClient, sessionCache);
   const withApiAuthRequired = withApiAuthRequiredFactory(sessionCache);
-  const withPageAuthRequired = withPageAuthRequiredFactory(nextConfig.routes.login, () => sessionCache);
-  const handleLogin = loginHandler(baseHandleLogin, nextConfig, baseConfig);
+  const withPageAuthRequired = withPageAuthRequiredFactory(getConfig, sessionCache);
+  const handleLogin = loginHandler(baseHandleLogin, getConfig);
   const handleLogout = logoutHandler(baseHandleLogout);
-  const handleCallback = callbackHandler(baseHandleCallback, nextConfig);
-  const handleProfile = profileHandler(client, getAccessToken, sessionCache);
+  const handleCallback = callbackHandler(baseHandleCallback, getConfig);
+  const handleProfile = profileHandler(getConfig, getClient, getAccessToken, sessionCache);
   const handleAuth = handlerFactory({ handleLogin, handleLogout, handleCallback, handleProfile });
-  const withMiddlewareAuthRequired = withMiddlewareAuthRequiredFactory(nextConfig.routes, () => sessionCache);
+  const withMiddlewareAuthRequired = withMiddlewareAuthRequiredFactory(getConfig, sessionCache);
 
   return {
-    sessionCache,
     getSession,
     touchSession,
     updateSession,

--- a/src/session/get-access-token.ts
+++ b/src/session/get-access-token.ts
@@ -236,7 +236,6 @@ export default function accessTokenFactory(
   return async (reqOrOpts?, res?, accessTokenRequest?): Promise<GetAccessTokenResult> => {
     const options = (res ? accessTokenRequest : reqOrOpts) as AccessTokenRequest | undefined;
     const req = (res ? reqOrOpts : undefined) as IncomingMessage | NextApiRequest | undefined;
-    // TODO: clean up
     const config = await getConfig(req ? getAuth0ReqRes(req, res as any)[0] : new Auth0NextRequestCookies());
     const client = await getClient(config);
 

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -1,6 +1,5 @@
 import * as jose from 'jose';
 import type { TokenEndpointResponse } from '../auth0-session/client/abstract-client';
-import { Config } from '../auth0-session';
 import { NextConfig } from '../config';
 
 /**
@@ -61,10 +60,7 @@ export default class Session {
 /**
  * @ignore
  */
-export function fromTokenEndpointResponse(
-  tokenEndpointResponse: TokenEndpointResponse,
-  config: Config | NextConfig
-): Session {
+export function fromTokenEndpointResponse(tokenEndpointResponse: TokenEndpointResponse, config: NextConfig): Session {
   // Get the claims without any OIDC-specific claim.
   const claims = jose.decodeJwt(tokenEndpointResponse.id_token as string);
   config.identityClaimFilter.forEach((claim) => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.2.0-experimental-lazy-conf.0';
+export default '3.2.0';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '3.2.0';
+export default '3.2.0-experimental-lazy-conf.0';

--- a/tests/auth0-session/client/edge-client.test.ts
+++ b/tests/auth0-session/client/edge-client.test.ts
@@ -293,7 +293,8 @@ describe('edge client', function () {
   });
 
   it('should only support code flow', async () => {
-    await expect(getClient({ authorizationParams: { response_type: 'id_token' } })).rejects.toThrow(
+    const client = await getClient({ authorizationParams: { response_type: 'id_token' } });
+    await expect(client.authorizationUrl({})).rejects.toThrow(
       'This SDK only supports `response_type=code` when used in an Edge runtime.'
     );
   });

--- a/tests/auth0-session/client/node-client.test.ts
+++ b/tests/auth0-session/client/node-client.test.ts
@@ -69,6 +69,21 @@ describe('node client', function () {
     expect(headerProps).not.toContain('auth0-client');
   });
 
+  it('should accept lazy config', async function () {
+    expect(
+      () =>
+        new NodeClient(
+          () => {
+            throw new Error();
+          },
+          {
+            name: 'nextjs-auth0',
+            version
+          }
+        )
+    ).not.toThrow();
+  });
+
   it('should not strip new headers', async function () {
     const client = await getClient();
     const response = await client.userinfo('__test_token__');

--- a/tests/auth0-session/fixtures/server.ts
+++ b/tests/auth0-session/fixtures/server.ts
@@ -25,7 +25,7 @@ import { cert, key } from './https';
 import { Claims } from '../../../src/session';
 import version from '../../../src/version';
 import { NodeRequest, NodeResponse } from '../../../src/auth0-session/http';
-import { NodeClient } from '../../../src/auth0-session/client/node-client';
+import { clientGetter } from '../../../src/auth0-session/client/node-client';
 
 export type SessionResponse = TokenSetParameters & { claims: Claims };
 
@@ -54,7 +54,11 @@ class TestSessionCache implements SessionCache<IncomingMessage, ServerResponse> 
     const [session] = await this.cookieStore.read(new NodeRequest(req));
     return session?.id_token;
   }
-  fromTokenEndpointResponse(tokenSet: TokenSet): { [p: string]: any } {
+  async fromTokenEndpointResponse(
+    _req: IncomingMessage,
+    _res: ServerResponse,
+    tokenSet: TokenSet
+  ): Promise<{ [p: string]: any }> {
     return tokenSet;
   }
 }
@@ -68,15 +72,15 @@ type Handlers = {
 
 const createHandlers = (params: ConfigParameters): Handlers => {
   const config = getConfig(params);
-  const client = new NodeClient(config, { name: 'nextjs-auth0', version });
+  const getClient = clientGetter({ name: 'nextjs-auth0', version });
   const transientStore = new TransientStore(config);
   const cookieStore = params.session?.store ? new StatefulSession<any>(config) : new StatelessSession<any>(config);
   const sessionCache = new TestSessionCache(cookieStore);
 
   return {
-    handleLogin: loginHandler(config, client, transientStore),
-    handleLogout: logoutHandler(config, client, sessionCache),
-    handleCallback: callbackHandler(config, client, sessionCache, transientStore),
+    handleLogin: loginHandler(config, getClient, transientStore),
+    handleLogout: logoutHandler(config, getClient, sessionCache),
+    handleCallback: callbackHandler(config, getClient, sessionCache, transientStore),
     handleSession: async (req: IncomingMessage, res: ServerResponse) => {
       const nodeReq = new NodeRequest(req);
       const [json, iat] = await cookieStore.read(nodeReq);

--- a/tests/auth0-session/handlers/callback.test.ts
+++ b/tests/auth0-session/handlers/callback.test.ts
@@ -10,6 +10,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import * as qs from 'querystring';
+import callbackHandlerFactory from '../../../src/auth0-session/handlers/callback';
 
 const privateKey = readFileSync(join(__dirname, '..', 'fixtures', 'private-key.pem'), 'utf-8');
 
@@ -19,6 +20,13 @@ const authVerificationCookie = (cookies: Record<string, string>) => ({ auth_veri
 
 describe('callback', () => {
   afterEach(teardown);
+
+  it('should accept lazy config', () => {
+    const getConfig = () => {
+      throw new Error();
+    };
+    expect(() => (callbackHandlerFactory as any)(getConfig)).not.toThrow();
+  });
 
   it('should error when the body is empty', async () => {
     const baseURL = await setup(defaultConfig);

--- a/tests/auth0-session/handlers/login.test.ts
+++ b/tests/auth0-session/handlers/login.test.ts
@@ -4,11 +4,19 @@ import { setup, teardown } from '../fixtures/server';
 import { defaultConfig, fromCookieJar, get, getCookie } from '../fixtures/helpers';
 import { decodeState, encodeState } from '../../../src/auth0-session/utils/encoding';
 import { LoginOptions } from '../../../src/auth0-session';
+import loginHandlerFactory from '../../../src/auth0-session/handlers/login';
 
 const authVerificationCookie = (cookie: string) => JSON.parse(decodeURIComponent(cookie));
 
 describe('login', () => {
   afterEach(teardown);
+
+  it('should accept lazy config', () => {
+    const getConfig = () => {
+      throw new Error();
+    };
+    expect(() => (loginHandlerFactory as any)(getConfig)).not.toThrow();
+  });
 
   it('should redirect to the authorize url for /login', async () => {
     const baseURL = await setup(defaultConfig);

--- a/tests/auth0-session/handlers/logout.test.ts
+++ b/tests/auth0-session/handlers/logout.test.ts
@@ -6,6 +6,7 @@ import { toSignedCookieJar, defaultConfig, get, post, fromCookieJar } from '../f
 import { makeIdToken } from '../fixtures/cert';
 import { encodeState } from '../../../src/auth0-session/utils/encoding';
 import wellKnown from '../fixtures/well-known.json';
+import logoutHandlerFactory from '../../../src/auth0-session/handlers/logout';
 
 const login = async (baseURL: string): Promise<CookieJar> => {
   const nonce = '__test_nonce__';
@@ -23,6 +24,13 @@ const login = async (baseURL: string): Promise<CookieJar> => {
 
 describe('logout route', () => {
   afterEach(teardown);
+
+  it('should accept lazy config', () => {
+    const getConfig = () => {
+      throw new Error();
+    };
+    expect(() => (logoutHandlerFactory as any)(getConfig)).not.toThrow();
+  });
 
   it('should perform a local logout', async () => {
     const baseURL = await setup({ ...defaultConfig, idpLogout: false });

--- a/tests/auth0-session/session/stateless-session.test.ts
+++ b/tests/auth0-session/session/stateless-session.test.ts
@@ -9,6 +9,7 @@ import { setup, teardown } from '../fixtures/server';
 import { defaultConfig, fromCookieJar, get, toCookieJar } from '../fixtures/helpers';
 import { encryption } from '../../../src/auth0-session/utils/hkdf';
 import { makeIdToken } from '../fixtures/cert';
+import { StatelessSession } from '../../../src/auth0-session';
 
 const hr = 60 * 60 * 1000;
 const day = 24 * hr;
@@ -37,6 +38,15 @@ const encrypted = async (claims: Partial<IdTokenClaims> = { sub: '__test_sub__' 
 
 describe('StatelessSession', () => {
   afterEach(teardown);
+
+  it('should accept lazy config', () => {
+    expect(
+      () =>
+        new StatelessSession((() => {
+          throw new Error();
+        }) as any)
+    ).not.toThrow();
+  });
 
   it('should not create a session when there are no cookies', async () => {
     const baseURL = await setup(defaultConfig);

--- a/tests/auth0-session/transient-store.test.ts
+++ b/tests/auth0-session/transient-store.test.ts
@@ -30,6 +30,15 @@ const setup = async (
 describe('TransientStore', () => {
   afterEach(teardown);
 
+  it('should accept lazy config', () => {
+    expect(
+      () =>
+        new TransientStore(() => {
+          throw new Error();
+        })
+    ).not.toThrow();
+  });
+
   it('should use the passed-in key to set the cookies', async () => {
     const baseURL: string = await setup(defaultConfig, async (req: NodeRequest, res: NodeResponse) =>
       transientStore.save('test_key', req, res, { value: 'foo' })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { BaseConfig, NextConfig, getConfig } from '../src/config';
+import { NextConfig, getConfig } from '../src/config';
 
 const getConfigWithEnv = (
   env: any = {},
@@ -10,7 +10,7 @@ const getConfigWithEnv = (
     AUTH0_CLIENT_ID: '__test_client_id__',
     AUTH0_CLIENT_SECRET: '__test_client_secret__'
   }
-): { baseConfig: BaseConfig; nextConfig: NextConfig } => {
+): NextConfig => {
   const bkp = process.env;
   process.env = {
     ...process.env,
@@ -28,8 +28,8 @@ const getConfigWithEnv = (
 
 describe('config params', () => {
   test('should return an object from empty defaults', () => {
-    const { baseConfig, nextConfig } = getConfigWithEnv();
-    expect(baseConfig).toStrictEqual({
+    const nextConfig = getConfigWithEnv();
+    expect(nextConfig).toStrictEqual({
       secret: '__long_super_secret_secret__',
       issuerBaseURL: 'https://example.auth0.com',
       baseURL: 'https://example.com',
@@ -65,7 +65,7 @@ describe('config params', () => {
           sameSite: 'lax'
         }
       },
-      routes: { callback: '/api/auth/callback', postLogoutRedirect: '' },
+      routes: { callback: '/api/auth/callback', postLogoutRedirect: '', login: '/api/auth/login' },
       getLoginState: expect.any(Function),
       identityClaimFilter: [
         'aud',
@@ -87,31 +87,8 @@ describe('config params', () => {
         path: '/',
         sameSite: 'lax',
         secure: true
-      }
-    });
-    expect(nextConfig).toStrictEqual({
-      identityClaimFilter: [
-        'aud',
-        'iss',
-        'iat',
-        'exp',
-        'nbf',
-        'nonce',
-        'azp',
-        'auth_time',
-        's_hash',
-        'at_hash',
-        'c_hash'
-      ],
-      routes: {
-        login: '/api/auth/login',
-        callback: '/api/auth/callback',
-        postLogoutRedirect: ''
       },
-      organization: undefined,
-      session: {
-        storeIDToken: true
-      }
+      organization: undefined
     });
   });
 
@@ -128,7 +105,7 @@ describe('config params', () => {
         AUTH0_COOKIE_SECURE: 'ok',
         AUTH0_SESSION_ABSOLUTE_DURATION: 'no',
         AUTH0_SESSION_STORE_ID_TOKEN: '0'
-      }).baseConfig
+      })
     ).toMatchObject({
       auth0Logout: false,
       enableTelemetry: false,
@@ -149,7 +126,7 @@ describe('config params', () => {
       getConfigWithEnv({
         AUTH0_SESSION_ROLLING_DURATION: 'no',
         AUTH0_SESSION_ROLLING: 'no'
-      }).baseConfig
+      })
     ).toMatchObject({
       session: {
         rolling: false,
@@ -165,7 +142,7 @@ describe('config params', () => {
         AUTH0_HTTP_TIMEOUT: '9999',
         AUTH0_SESSION_ROLLING_DURATION: '0',
         AUTH0_SESSION_ABSOLUTE_DURATION: '1'
-      }).baseConfig
+      })
     ).toMatchObject({
       clockTolerance: 100,
       httpTimeout: 9999,
@@ -181,14 +158,14 @@ describe('config params', () => {
     expect(
       getConfigWithEnv({
         AUTH0_IDENTITY_CLAIM_FILTER: 'claim1,claim2,claim3'
-      }).baseConfig
+      })
     ).toMatchObject({
       identityClaimFilter: ['claim1', 'claim2', 'claim3']
     });
   });
 
   test('passed in arguments should take precedence', () => {
-    const { baseConfig, nextConfig } = getConfigWithEnv(
+    const nextConfig = getConfigWithEnv(
       {
         AUTH0_ORGANIZATION: 'foo'
       },
@@ -212,7 +189,7 @@ describe('config params', () => {
         organization: 'bar'
       }
     );
-    expect(baseConfig).toMatchObject({
+    expect(nextConfig).toMatchObject({
       authorizationParams: {
         audience: 'foo',
         scope: 'openid bar'
@@ -228,9 +205,7 @@ describe('config params', () => {
           transient: false
         },
         name: 'quuuux'
-      }
-    });
-    expect(nextConfig).toMatchObject({
+      },
       organization: 'bar'
     });
   });
@@ -239,7 +214,7 @@ describe('config params', () => {
     expect(
       getConfigWithEnv({
         AUTH0_BASE_URL: 'foo.auth0.com'
-      }).baseConfig
+      })
     ).toMatchObject({
       baseURL: 'https://foo.auth0.com'
     });
@@ -259,7 +234,7 @@ describe('config params', () => {
           AUTH0_CLIENT_ID: '__test_client_id__',
           AUTH0_CLIENT_SECRET: '__test_client_secret__'
         }
-      ).baseConfig
+      )
     ).toMatchObject({
       baseURL: 'https://public-foo.auth0.com'
     });
@@ -270,18 +245,15 @@ describe('config params', () => {
       getConfigWithEnv({
         AUTH0_BASE_URL: 'foo.auth0.com',
         NEXT_PUBLIC_AUTH0_BASE_URL: 'bar.auth0.com'
-      }).baseConfig
+      })
     ).toMatchObject({
       baseURL: 'https://foo.auth0.com'
     });
   });
 
   test('should accept optional callback path', () => {
-    const { baseConfig, nextConfig } = getConfigWithEnv({
+    const nextConfig = getConfigWithEnv({
       AUTH0_CALLBACK: '/api/custom-callback'
-    });
-    expect(baseConfig).toMatchObject({
-      routes: expect.objectContaining({ callback: '/api/custom-callback' })
     });
     expect(nextConfig).toMatchObject({
       routes: expect.objectContaining({ callback: '/api/custom-callback' })

--- a/tests/fixtures/app-router-helpers.ts
+++ b/tests/fixtures/app-router-helpers.ts
@@ -114,7 +114,7 @@ export const getSession = async (config: any, res: NextResponse) => {
     .getAll()
     .forEach(({ name, value }: { name: string; value: string }) => value && req.cookies.set(name, value));
 
-  const store = new StatelessSession(getConfig(config).baseConfig);
+  const store = new StatelessSession(getConfig(config));
   const [session] = await store.read(new Auth0NextRequest(req));
   return session;
 };

--- a/tests/helpers/testing.test.ts
+++ b/tests/helpers/testing.test.ts
@@ -4,6 +4,7 @@ import { generateSessionCookie } from '../../src/helpers/testing';
 jest.mock('../../src/auth0-session/session/stateless-session');
 
 const encryptMock = jest.spyOn(CookieStore.prototype, 'encrypt');
+jest.spyOn(CookieStore.prototype, 'getKeys').mockReturnValue(Promise.resolve([]));
 const weekInSeconds = 7 * 24 * 60 * 60;
 
 describe('generate-session-cookie', () => {
@@ -54,7 +55,7 @@ describe('generate-session-cookie', () => {
 
   test('use the provided session', async () => {
     await generateSessionCookie({ user: { foo: 'bar' } }, { secret: '' });
-    expect(encryptMock).toHaveBeenCalledWith({ user: { foo: 'bar' } }, expect.anything());
+    expect(encryptMock).toHaveBeenCalledWith({ user: { foo: 'bar' } }, expect.anything(), undefined);
   });
 
   test('use the current time for the header values', async () => {
@@ -63,11 +64,15 @@ describe('generate-session-cookie', () => {
     const clock = jest.useFakeTimers();
     clock.setSystemTime(now);
     await generateSessionCookie({}, { secret: '' });
-    expect(encryptMock).toHaveBeenCalledWith(expect.anything(), {
-      iat: current,
-      uat: current,
-      exp: current + weekInSeconds
-    });
+    expect(encryptMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        iat: current,
+        uat: current,
+        exp: current + weekInSeconds
+      },
+      undefined
+    );
     clock.restoreAllMocks();
     jest.useRealTimers();
   });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,15 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
 import { withoutApi } from './fixtures/default-settings';
-import { WithApiAuthRequired, WithPageAuthRequired, InitAuth0, GetSession, ConfigParameters } from '../src';
+import {
+  WithApiAuthRequired,
+  WithPageAuthRequired,
+  InitAuth0,
+  GetSession,
+  ConfigParameters,
+  AppRouteHandlerFn
+} from '../src';
+import { NextRequest } from 'next/server';
 
 describe('index', () => {
   let withPageAuthRequired: WithPageAuthRequired,
@@ -31,9 +39,14 @@ describe('index', () => {
     jest.resetModules();
   });
 
-  test('withPageAuthRequired should not create an SDK instance at build time', () => {
+  test('withPageAuthRequired should not create an SDK instance at build time', async () => {
     process.env = { ...env, AUTH0_SECRET: undefined };
-    expect(() => withApiAuthRequired(jest.fn())).toThrow('"secret" is required');
+    await expect(() =>
+      withApiAuthRequired(jest.fn() as AppRouteHandlerFn)(new NextRequest(new URL('http://example.com')), {
+        params: {}
+      })
+    ).rejects.toThrow('"secret" is required');
+    expect(() => withApiAuthRequired(jest.fn())).not.toThrow();
     expect(() => withPageAuthRequired()).not.toThrow();
   });
 

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
-import { StatelessSession, getConfig } from '../../src/auth0-session';
+import { StatelessSession } from '../../src/auth0-session';
+import { getConfig } from '../../src/config';
 import { get, set } from '../../src/session/cache';
 import { ConfigParameters, Session, SessionCache } from '../../src';
 import { withoutApi } from '../fixtures/default-settings';
@@ -18,7 +19,8 @@ describe('SessionCache', () => {
     sessionStore.save = jest.fn();
     session = new Session({ sub: '__test_user__' });
     session.idToken = '__test_id_token__';
-    cache = new SessionCache(config, sessionStore);
+    cache = new SessionCache(() => config);
+    cache.getSessionStore = () => sessionStore;
     req = jest.mocked(new IncomingMessage(new Socket()));
     res = jest.mocked(new ServerResponse(req));
   };

--- a/tests/session/session.test.ts
+++ b/tests/session/session.test.ts
@@ -2,6 +2,8 @@ import { TokenSet } from 'openid-client';
 import { fromJson, fromTokenEndpointResponse } from '../../src/session';
 import { makeIdToken } from '../auth0-session/fixtures/cert';
 import { Session } from '../../src';
+import { getConfig } from '../../src/config';
+import { withoutApi } from '../fixtures/default-settings';
 
 const routes = { login: '', callback: '', postLogoutRedirect: '' };
 
@@ -15,12 +17,15 @@ describe('session', () => {
   describe('from tokenSet', () => {
     test('should construct a session from a tokenSet', async () => {
       expect(
-        fromTokenEndpointResponse(new TokenSet({ id_token: await makeIdToken({ foo: 'bar', bax: 'qux' }) }), {
-          identityClaimFilter: ['baz'],
-          routes,
-          getLoginState,
-          session: { storeIDToken: true }
-        }).user
+        fromTokenEndpointResponse(
+          new TokenSet({ id_token: await makeIdToken({ foo: 'bar', bax: 'qux' }) }),
+          getConfig({
+            ...withoutApi,
+            identityClaimFilter: ['baz'],
+            getLoginState,
+            session: { storeIDToken: true }
+          })
+        ).user
       ).toEqual({
         aud: '__test_client_id__',
         bax: 'qux',
@@ -36,30 +41,38 @@ describe('session', () => {
 
     test('should store the ID Token by default', async () => {
       expect(
-        fromTokenEndpointResponse(new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }), {
-          identityClaimFilter: ['baz'],
-          routes,
-          getLoginState,
-          session: { storeIDToken: true }
-        }).idToken
+        fromTokenEndpointResponse(
+          new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }),
+          getConfig({
+            ...withoutApi,
+            identityClaimFilter: ['baz'],
+            routes,
+            getLoginState,
+            session: { storeIDToken: true }
+          })
+        ).idToken
       ).toBeDefined();
     });
 
     test('should not store the ID Token', async () => {
       expect(
-        fromTokenEndpointResponse(new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }), {
-          session: {
-            storeIDToken: false,
-            name: '',
-            rolling: false,
-            rollingDuration: 0,
-            absoluteDuration: 0,
-            cookie: { transient: false, httpOnly: false, sameSite: 'lax' }
-          },
-          getLoginState,
-          identityClaimFilter: ['baz'],
-          routes
-        }).idToken
+        fromTokenEndpointResponse(
+          new TokenSet({ id_token: await makeIdToken({ foo: 'bar' }) }),
+          getConfig({
+            ...withoutApi,
+            session: {
+              storeIDToken: false,
+              name: 'foo',
+              rolling: false,
+              rollingDuration: false,
+              absoluteDuration: 0,
+              cookie: { transient: false, httpOnly: false, sameSite: 'lax' }
+            },
+            getLoginState,
+            identityClaimFilter: ['baz'],
+            routes
+          })
+        ).idToken
       ).toBeUndefined();
     });
   });


### PR DESCRIPTION
### 📋 Changes


Ensure `getConfig` doesn't run when the Next.js app is being statically rendered (because static rendering happens at build time and users don't necessarily want to supply the config at build time)

The 2 large commits are for making sure the config can be lazily evaluated at request time (`config` -> `getConfig(req)`):

- 30c100e3fdaa00be4d627f84351e3421d9829243 allow lazy config in auth0-session 
- d79ff8f59accdf0535d616ae80dc57de343317e9 allow lazy config in Next.js layer

The 3rd small commit is using this to bail out of static rendering before getting the config.

bec7d6c5998ba06ae87cb906235d7568bab2418f - Bail out of static rendering for pages and routes in app dir

You can bail out of static rendering by using the `cookies()` helper for Server Components and inspecting the request's `url` for API routes

### 📎 References

fixes #1356 
https://github.com/vercel/next.js/issues/49006

### 🎯 Testing

- Make sure you have no environment variables
- Run "npm run build:example"
- You should see no errors