### PR TITLE
Should get instance of Session in RSCs

### DIFF
--- a/src/session/cache.ts
+++ b/src/session/cache.ts
@@ -128,7 +128,8 @@ export const get = async ({
   const {
     session: { rolling, autoSave }
   } = config;
-  const [session, iat] = await sessionStore.read(auth0Req);
+  const [json, iat] = await sessionStore.read(auth0Req);
+  const session = fromJson(json);
   if (rolling && autoSave) {
     await set({ session, sessionCache, iat });
   }

--- a/tests/session/cache.test.ts
+++ b/tests/session/cache.test.ts
@@ -109,4 +109,10 @@ describe('SessionCache', () => {
     expect(sessionStore.read).toHaveBeenCalledTimes(2);
     expect(sessionStore.save).toHaveBeenCalledTimes(1);
   });
+
+  test('should get an instance of Session from an RSC', async () => {
+    sessionStore.read = jest.fn().mockResolvedValue([{ user: { sub: '__test_user__' } }, 500]);
+    const [session] = await get({ sessionCache: cache });
+    expect(session).toBeInstanceOf(Session);
+  });
 });


### PR DESCRIPTION
### 📋 Changes

`getSession` should return an instance of `Session` in a React Server Component.

### 📎 References

fixes #1509 
