### PR TITLE
fix: comment

### DIFF
--- a/src/client/use-user.tsx
+++ b/src/client/use-user.tsx
@@ -170,8 +170,8 @@ export type UseUser = () => UserContext;
  *
  *   if (isLoading) return <div>Loading...</div>;
  *   if (error) return <div>{error.message}</div>;
- *   if (!user) return <Link href="/api/auth/login"><a>Login</a></Link>;
- *   return <div>Hello {user.name}, <Link href="/api/auth/logout"><a>Logout</a></Link></div>;
+ *   if (!user) return <Link href="/api/auth/login">Login</Link>;
+ *   return <div>Hello {user.name}, <Link href="/api/auth/logout">Logout</Link></div>;
  * }
  * ```
  *


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

I just fixed the outdated comment.
> Starting with Next.js 13, `<Link>` renders as `<a>`, so attempting to use `<a>` as a child is invalid.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
N/A