### PR TITLE
App router: Allow types for page params/searchParams for pages wrapped by withPageAuthRequired

### DIFF
--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -36,7 +36,7 @@ export type PageRoute<P, Q extends ParsedUrlQuery = ParsedUrlQuery> = (
 ) => Promise<GetServerSidePropsResultWithSession<P>>;
 
 /**
- * Objects containing the route parameters and search parameters of th page.
+ * Objects containing the route parameters and search parameters of the page.
  *
  * @category Server
  */
@@ -50,7 +50,7 @@ export type AppRouterPageRouteOpts = {
  *
  * @category Server
  */
-export type AppRouterPageRoute = (obj: AppRouterPageRouteOpts) => Promise<React.JSX.Element>;
+export type AppRouterPageRoute<PageProps> = (obj: PageProps) => Promise<React.JSX.Element>;
 
 /**
  * If you have a custom returnTo url you should specify it in `returnTo`.
@@ -124,8 +124,8 @@ export type WithPageAuthRequiredPageRouter = <
  *
  * @category Server
  */
-export type WithPageAuthRequiredAppRouterOptions = {
-  returnTo?: string | ((obj: AppRouterPageRouteOpts) => Promise<string> | string);
+export type WithPageAuthRequiredAppRouterOptions<PageProps> = {
+  returnTo?: string | ((obj: PageProps) => Promise<string> | string);
 };
 
 /**
@@ -166,10 +166,17 @@ export type WithPageAuthRequiredAppRouterOptions = {
  *
  * @category Server
  */
-export type WithPageAuthRequiredAppRouter = (
-  fn: AppRouterPageRoute,
-  opts?: WithPageAuthRequiredAppRouterOptions
-) => AppRouterPageRoute;
+export type WithPageAuthRequiredAppRouter = <
+  T extends {
+    params: T['params'] extends undefined ? undefined : { [K in keyof T['params']]: string };
+    searchParams: T['searchParams'] extends undefined
+      ? undefined
+      : { [K in keyof T['searchParams']]: string | undefined };
+  }
+>(
+  fn: (obj: T) => Promise<React.JSX.Element>,
+  opts?: WithPageAuthRequiredAppRouterOptions<T>
+) => AppRouterPageRoute<T>;
 
 /**
  * Protects Page router pages {@link WithPageAuthRequiredPageRouter} or
@@ -190,8 +197,8 @@ export default function withPageAuthRequiredFactory(
   const pageRouteHandler = pageRouteHandlerFactory(getConfig, sessionCache);
 
   return ((
-    fnOrOpts?: WithPageAuthRequiredPageRouterOptions | AppRouterPageRoute,
-    opts?: WithPageAuthRequiredAppRouterOptions
+    fnOrOpts?: WithPageAuthRequiredPageRouterOptions | AppRouterPageRoute<unknown>,
+    opts?: WithPageAuthRequiredAppRouterOptions<unknown>
   ) => {
     if (typeof fnOrOpts === 'function') {
       return appRouteHandler(fnOrOpts, opts);

--- a/src/helpers/with-page-auth-required.ts
+++ b/src/helpers/with-page-auth-required.ts
@@ -136,7 +136,7 @@ export type WithPageAuthRequiredAppRouterOptions<PageProps> = {
  * // app/protected-page/page.js
  * import { withPageAuthRequired } from '@auth0/nextjs-auth0';
  *
- * export default function withPageAuthRequired(ProtectedPage() {
+ * export default withPageAuthRequired(function ProtectedPage() {
  *   return <div>Protected content</div>;
  * }, { returnTo: '/protected-page' });
  * ```
@@ -155,7 +155,7 @@ export type WithPageAuthRequiredAppRouterOptions<PageProps> = {
  * // app/protected-page/[slug]/page.js
  * import { withPageAuthRequired } from '@auth0/nextjs-auth0';
  *
- * export default function withPageAuthRequired(ProtectedPage() {
+ * export default withPageAuthRequired(function ProtectedPage({ params }: { params: { slug: string } ) {
  *   return <div>Protected content</div>;
  * }, {
  *   returnTo({ params }) {


### PR DESCRIPTION

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR contains only changes to types.

Using NextJs 14, you may now type your Pages wrapped by `withPageAuthRequired`

```typescript
export default withPageAuthRequired(
  async function Home({
    params,
    searchParams: { limit },
  }: {
    searchParams: { limit: string };
    params: { lang: string; slug: string };
  }) {
    console.log(params, limit);
    return <div />;
  },
  {
    returnTo: ({ params, searchParams }) =>
      `/${params.lang}?limit=${searchParams.limit}`,
  }
)
```

previously, this would generate type errors: (@auth0/nextjs-auth0 3.5.0)
![image](https://github.com/user-attachments/assets/59157460-d46c-4b71-bc4f-4cb7332eff98)



### 📎 References

This should close https://github.com/auth0/nextjs-auth0/pull/1750/files

### 🎯 Testing

- [x] added tests for types
