### PR TITLE
set id_token_hint in search params when logging out if available

### DIFF
--- a/src/auth0-session/client/edge-client.ts
+++ b/src/auth0-session/client/edge-client.ts
@@ -196,6 +196,7 @@ export class EdgeClient extends AbstractClient {
       const { id_token_hint, post_logout_redirect_uri, ...extraParams } = parameters;
       const auth0LogoutUrl: URL = new URL(urlJoin(as.issuer, '/v2/logout'));
       post_logout_redirect_uri && auth0LogoutUrl.searchParams.set('returnTo', post_logout_redirect_uri);
+      id_token_hint && auth0LogoutUrl.searchParams.set('id_token_hint', id_token_hint);
       auth0LogoutUrl.searchParams.set('client_id', this.config.clientID);
       Object.entries(extraParams).forEach(([key, value]: [string, string]) => {
         if (value === null || value === undefined) {

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -151,6 +151,7 @@ export class NodeClient extends AbstractClient {
             const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
             parsedUrl.searchParams.set('client_id', config.clientID);
             post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);
+            id_token_hint && parsedUrl.searchParams.set('id_token_hint', id_token_hint);
             Object.entries(extraParams).forEach(([key, value]) => {
               if (value === null || value === undefined) {
                 return;


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes
- setting id_token_hint if available when logging out.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References
https://github.com/auth0/nextjs-auth0/issues/1771
https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0#call-the-oidc-logout-endpoint
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
