### PR TITLE
Update auth.ts to await `params` in NextJS 15

### DIFF
--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -207,7 +207,7 @@ export default function handlerFactory({
 const appRouteHandlerFactory: (customHandlers: ApiHandlers, onError?: AppRouterOnError) => AppRouteHandlerFn =
   (customHandlers, onError) => async (req: NextRequest, ctx) => {
     const { params } = ctx;
-    let route = params.auth0;
+    let route = (await params).auth0;
 
     if (Array.isArray(route)) {
       let otherRoutes;


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [N/A] All new/changed/fixed functionality is covered by tests (or N/A)
- [N/A] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

In NextJS 15, `params` from routes is now a Promise which must be awaited. Direct access is deprecated and will be removed in future versions.

This change is backwards compatible because awaiting on a non-promise returns back the value itself.

Without this change we get the following warning:
```
In route /api/auth/[auth0] a param property was accessed directly with `params.auth0`. `params` is now a Promise and should be awaited before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to await `params`. If this use is inside an async function await it. If this use is inside a synchronous function then convert the function to async or await it from outside this function and pass the result in.
```


### 📎 References

See more details in https://github.com/vercel/next.js/pull/68812

### 🎯 Testing

Add the SDK in NextJS 15 stable and see that the warning is getting generated whenever the auth0 endpoints are hit.