### PR TITLE
build(deps): bump jshttp/cookie from 0.6.0 to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.1",
         "debug": "^4.3.4",
         "joi": "^17.6.0",
         "jose": "^4.9.2",
@@ -4787,9 +4787,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -18852,9 +18853,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
     },
     "cookies": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@panva/hkdf": "^1.0.2",
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.1",
     "debug": "^4.3.4",
     "joi": "^17.6.0",
     "jose": "^4.9.2",


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This bumps [jshttp/cookie](https://github.com/jshttp/cookie) from [0.6.0 -> 0.7.1](https://github.com/jshttp/cookie/compare/v0.6.0...v0.7.1) due to low severity security issue

### 📎 References

- https://github.com/jshttp/cookie/security/advisories/GHSA-pxg6-pf52-xh8x
- https://github.com/jshttp/cookie/pull/167

### 🎯 Testing

Ran unit tests with `npm test` , and all passed