### PR TITLE
1771 - Set id_token_hint when logging out

### DIFF
--- a/src/auth0-session/client/edge-client.ts
+++ b/src/auth0-session/client/edge-client.ts
@@ -193,7 +193,7 @@ export class EdgeClient extends AbstractClient {
       this.config.idpLogout &&
       (this.config.auth0Logout || (issuerUrl.hostname.match('\\.auth0\\.com$') && this.config.auth0Logout !== false))
     ) {
-      const { id_token_hint, post_logout_redirect_uri, ...extraParams } = parameters;
+      const { post_logout_redirect_uri, ...extraParams } = parameters;
       const auth0LogoutUrl: URL = new URL(urlJoin(as.issuer, '/v2/logout'));
       post_logout_redirect_uri && auth0LogoutUrl.searchParams.set('returnTo', post_logout_redirect_uri);
       auth0LogoutUrl.searchParams.set('client_id', this.config.clientID);

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -52,16 +52,16 @@ export class NodeClient extends AbstractClient {
         'User-Agent': `${name}/${version}`,
         ...(config.enableTelemetry
           ? {
-              'Auth0-Client': Buffer.from(
-                JSON.stringify({
-                  name,
-                  version,
-                  env: {
-                    node: process.version
-                  }
-                })
-              ).toString('base64')
-            }
+            'Auth0-Client': Buffer.from(
+              JSON.stringify({
+                name,
+                version,
+                env: {
+                  node: process.version
+                }
+              })
+            ).toString('base64')
+          }
           : undefined)
       },
       timeout: config.httpTimeout,
@@ -147,7 +147,7 @@ export class NodeClient extends AbstractClient {
       ) {
         Object.defineProperty(this.client, 'endSessionUrl', {
           value(params: EndSessionParameters) {
-            const { id_token_hint, post_logout_redirect_uri, ...extraParams } = params;
+            const { post_logout_redirect_uri, ...extraParams } = params;
             const parsedUrl = new URL(urlJoin(issuer.metadata.issuer, '/v2/logout'));
             parsedUrl.searchParams.set('client_id', config.clientID);
             post_logout_redirect_uri && parsedUrl.searchParams.set('returnTo', post_logout_redirect_uri);

--- a/src/auth0-session/client/node-client.ts
+++ b/src/auth0-session/client/node-client.ts
@@ -52,16 +52,16 @@ export class NodeClient extends AbstractClient {
         'User-Agent': `${name}/${version}`,
         ...(config.enableTelemetry
           ? {
-            'Auth0-Client': Buffer.from(
-              JSON.stringify({
-                name,
-                version,
-                env: {
-                  node: process.version
-                }
-              })
-            ).toString('base64')
-          }
+              'Auth0-Client': Buffer.from(
+                JSON.stringify({
+                  name,
+                  version,
+                  env: {
+                    node: process.version
+                  }
+                })
+              ).toString('base64')
+            }
           : undefined)
       },
       timeout: config.httpTimeout,

--- a/tests/auth0-session/client/node-client.test.ts
+++ b/tests/auth0-session/client/node-client.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { getConfig, ConfigParameters } from '../../../src/auth0-session';
-import { jwks } from '../fixtures/cert';
+import { jwks, makeIdToken } from '../fixtures/cert';
 import pkg from '../../../package.json';
 import wellKnown from '../fixtures/well-known.json';
 import version from '../../../src/version';
@@ -179,6 +179,25 @@ describe('node client', function () {
       'https://test.eu.auth0.com/v2/logout?client_id=__test_client_id__&returnTo=foo'
     );
   });
+
+  it('should create custom logout for auth0 with id_token_hint', async function () {
+    nock('https://test.eu.auth0.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, { ...wellKnown, issuer: 'https://test.eu.auth0.com/', end_session_endpoint: undefined });
+    nock('https://test.eu.auth0.com').get('/.well-known/jwks.json').reply(200, jwks);
+
+    const client = await getClient({
+      issuerBaseURL: 'https://test.eu.auth0.com',
+      idpLogout: true,
+    });
+
+    const idToken = await makeIdToken()
+
+    await expect(client.endSessionUrl({ post_logout_redirect_uri: 'foo', id_token_hint: idToken })).resolves.toEqual(
+      `https://test.eu.auth0.com/v2/logout?client_id=__test_client_id__&returnTo=foo&id_token_hint=${idToken}`
+    );
+  });
+
 
   it('should handle limited openid-configuration', async function () {
     nock('https://op2.example.com')

--- a/tests/auth0-session/client/node-client.test.ts
+++ b/tests/auth0-session/client/node-client.test.ts
@@ -198,7 +198,6 @@ describe('node client', function () {
     );
   });
 
-
   it('should handle limited openid-configuration', async function () {
     nock('https://op2.example.com')
       .get('/.well-known/openid-configuration')


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

- Include id_token_hint in searchParams for endSessionUrl
- Ran `npm run pretty`
- This is a fix in behaviour and doesn't change any public or private api

### 📎 References

- Issue: #1771
- Duplicate PR without tests: https://github.com/auth0/nextjs-auth0/pull/1773

### 🎯 Testing

When triggering the logout handler you can verify if the `id_token_hint` search param is set during the redirect.
Before this change the `id_token_hint` was missing. it should be present now.
