### PR TITLE
Bumping up the version | Resolving NPM package issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@auth0/nextjs-auth0",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "Auth0 Next.js SDK",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### 📋 Changes

-  The release `4.0.0-beta.1` did not contain the `build` files. So we had to re-publish it.
-  Bumping up the version in this PR.

