### PR TITLE
fix: use startsWith() instead of exact match comparison

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -235,6 +235,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
       authClient.handleLogin = vi.fn()
       await authClient.handler(request)
       expect(authClient.handleLogin).toHaveBeenCalled()
+
+      // Also checks if the path is /auth/login/ (with trailing slash)
+      const request2 = new NextRequest("https://example.com/auth/login/", {
+        method: "GET",
+      })
+      await authClient.handler(request2)
+      expect(authClient.handleLogin).toHaveBeenCalled()
     })
 
     it("should call the callback handler if the path is /auth/callback", async () => {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -198,19 +198,19 @@ export class AuthClient {
     const { pathname } = req.nextUrl
     const method = req.method
 
-    if (method === "GET" && pathname === this.routes.login) {
+    if (method === "GET" && pathname.startsWith(this.routes.login)) {
       return this.handleLogin(req)
-    } else if (method === "GET" && pathname === this.routes.logout) {
+    } else if (method === "GET" && pathname.startsWith(this.routes.logout)) {
       return this.handleLogout(req)
-    } else if (method === "GET" && pathname === this.routes.callback) {
+    } else if (method === "GET" && pathname.startsWith(this.routes.callback)) {
       return this.handleCallback(req)
-    } else if (method === "GET" && pathname === this.routes.profile) {
+    } else if (method === "GET" && pathname.startsWith(this.routes.profile)) {
       return this.handleProfile(req)
-    } else if (method === "GET" && pathname === this.routes.accessToken) {
+    } else if (method === "GET" && pathname.startsWith(this.routes.accessToken)) {
       return this.handleAccessToken(req)
     } else if (
       method === "POST" &&
-      pathname === this.routes.backChannelLogout
+      pathname.startsWith(this.routes.backChannelLogout)
     ) {
       return this.handleBackChannelLogout(req)
     } else {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Updates the checks from a strict equals condition to a `startsWith()`, since the URL could have trailing slash

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

On the base `v4` branch, boot up a test app and go to `/auth/login`, that should succeed. Then, on `next.config.ts`, set the config:
```ts
const config = {
  // ..more values
  trailingSlash: true
}
```

It won't work because an exact comparison won't be matched. It'll check `/auth/login/` (the pathname on the middleware request) vs `/auth/login` (what's currently used as the hardcoded route on the mapping object).
