### PR TITLE
4.0.0-beta.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,3 +821,29 @@ NEXT_PUBLIC_ACCESS_TOKEN_ROUTE=/api/auth/token
 
 > [!IMPORTANT]  
 > Updating the route paths will also require updating the **Allowed Callback URLs** and **Allowed Logout URLs** configured in the [Auth0 Dashboard](https://manage.auth0.com) for your client.
+
+## Testing helpers
+
+### `generateSessionCookie`
+
+The `generateSessionCookie` helper can be used to generate a session cookie value for use during tests:
+
+```ts
+import { generateSessionCookie } from "@auth0/nextjs-auth0/testing"
+
+const sessionCookieValue = await generateSessionCookie(
+  {
+    user: {
+      sub: "user_123",
+    },
+    tokenSet: {
+      accessToken: "at_123",
+      refreshToken: "rt_123",
+      expiresAt: 123456789,
+    },
+  },
+  {
+    secret: process.env.AUTH0_SECRET!,
+  }
+)
+```

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ export default function Profile() {
 
 ### On the server (App Router)
 
-On the server, the `getSession()` helper can be used in Server Components, Server Routes, Server Actions, and middleware to get the session of the currently authenticated user and to protect resources, like so:
+On the server, the `getSession()` helper can be used in Server Components, Server Routes, and Server Actions to get the session of the currently authenticated user and to protect resources, like so:
 
 ```tsx
 import { auth0 } from "@/lib/auth0"
@@ -215,7 +215,7 @@ export default async function Home() {
 
 ### On the server (Pages Router)
 
-On the server, the `getSession(req)` helper can be used in `getServerSideProps`, API routes, and middleware to get the session of the currently authenticated user and to protect resources, like so:
+On the server, the `getSession(req)` helper can be used in `getServerSideProps` and API routes to get the session of the currently authenticated user and to protect resources, like so:
 
 ```tsx
 import type { GetServerSideProps, InferGetServerSidePropsType } from "next"
@@ -249,16 +249,47 @@ export default function Page({
 }
 ```
 
+### Middleware
+
+In middleware, the `getSession(req)` helper can be used to get the session of the currently authenticated user and to protect resources, like so:
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+
+import { auth0 } from "@/lib/auth0"
+
+export async function middleware(request: NextRequest) {
+  const authRes = await auth0.middleware(request)
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authRes
+  }
+
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // user is not authenticated, redirect to login page
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+  }
+
+  // the headers from the auth middleware should always be returned
+  return authRes
+}
+```
+
+> [!IMPORTANT]  
+> The `request` object must be passed as a parameter to the `getSession(request)` method when called from a middleware to ensure that any updates to the session can be read within the same request.
+
 ## Updating the session
 
-The `updateSession` method could be used to update the session of the currently authenticated user in both the App Router and Pages Router. If the user does not have a session, an error will be thrown.
+The `updateSession` method could be used to update the session of the currently authenticated user in the App Router, Pages Router, and middleware. If the user does not have a session, an error will be thrown.
 
 > [!NOTE]
 > Any updates to the session will be overwritten when the user re-authenticates and obtains a new session.
 
 ### On the server (App Router)
 
-On the server, the `updateSession()` helper can be used in Server Routes, Server Actions, and middleware to update the session of the currently authenticated user, like so:
+On the server, the `updateSession()` helper can be used in Server Routes and Server Actions to update the session of the currently authenticated user, like so:
 
 ```tsx
 import { NextResponse } from "next/server"
@@ -286,7 +317,7 @@ export async function GET() {
 
 ### On the server (Pages Router)
 
-On the server, the `updateSession(req, res, session)` helper can be used in `getServerSideProps`, API routes, and middleware to update the session of the currently authenticated user, like so:
+On the server, the `updateSession(req, res, session)` helper can be used in `getServerSideProps` and API routes to update the session of the currently authenticated user, like so:
 
 ```tsx
 import type { NextApiRequest, NextApiResponse } from "next"
@@ -315,6 +346,93 @@ export default async function handler(
   })
 
   res.status(200).json({})
+}
+```
+
+### Middleware
+
+In middleware, the `updateSession(req, res, session)` helper can be used to update the session of the currently authenticated user, like so:
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+
+import { auth0 } from "@/lib/auth0"
+
+export async function middleware(request: NextRequest) {
+  const authRes = await auth0.middleware(request)
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authRes
+  }
+
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // user is not authenticated, redirect to login page
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+  }
+
+  await auth0.updateSession(request, authRes, {
+    ...session,
+    user: {
+      ...session.user,
+      // add custom user data
+      updatedAt: Date.now(),
+    },
+  })
+
+  // the headers from the auth middleware should always be returned
+  return authRes
+}
+```
+
+> [!IMPORTANT]  
+> The `request` and `response` objects must be passed as a parameters to the `updateSession(request, response, session)` method when called from a middleware to ensure that any updates to the session can be read within the same request.
+
+If you are using the Pages Router and need to read updates to the session made in the middleware within the same request, you will need to ensure that any updates to the session are propagated on the request object, like so:
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+
+import { auth0 } from "@/lib/auth0"
+
+export async function middleware(request: NextRequest) {
+  const authRes = await auth0.middleware(request)
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authRes
+  }
+
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // user is not authenticated, redirect to login page
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+  }
+
+  await auth0.updateSession(request, authRes, {
+    ...session,
+    user: {
+      ...session.user,
+      // add custom user data
+      updatedAt: Date.now(),
+    },
+  })
+
+  // create a new response with the updated request headers
+  const resWithCombinedHeaders = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  })
+
+  // set the response headers (set-cookie) from the auth response
+  authRes.headers.forEach((value, key) => {
+    resWithCombinedHeaders.headers.set(key, value)
+  })
+
+  // the headers from the auth middleware should always be returned
+  return resWithCombinedHeaders
 }
 ```
 
@@ -351,14 +469,16 @@ export default function Component() {
 
 ### On the server (App Router)
 
-On the server, the `getAccessToken()` helper can be used in Server Routes, Server Actions, Server Components, and middleware to get an access token to call external APIs.
+On the server, the `getAccessToken()` helper can be used in Server Routes, Server Actions and Server Components to get an access token to call external APIs.
 
 > [!IMPORTANT]  
 > Server Components cannot set cookies. Calling `getAccessToken()` in a Server Component will cause the access token to be refreshed, if it is expired, and the updated token set will not to be persisted.
+>
+> It is recommended to call `getAccessToken(req, res)` in the middleware if you need to use the refresh token in a Server Component as this will ensure the token is refreshed and correctly persisted.
 
 For example:
 
-```tsx
+```ts
 import { NextResponse } from "next/server"
 
 import { auth0 } from "@/lib/auth0"
@@ -379,9 +499,9 @@ export async function GET() {
 
 ### On the server (Pages Router)
 
-On the server, the `getAccessToken(req, res)` helper can be used in `getServerSideProps`, API routes, and middleware to get an access token to call external APIs, like so:
+On the server, the `getAccessToken(req, res)` helper can be used in `getServerSideProps` and API routes to get an access token to call external APIs, like so:
 
-```tsx
+```ts
 import type { NextApiRequest, NextApiResponse } from "next"
 
 import { auth0 } from "@/lib/auth0"
@@ -398,6 +518,79 @@ export default async function handler(
   }
 
   res.status(200).json({ message: "Success!" })
+}
+```
+
+### Middleware
+
+In middleware, the `getAccessToken(req, res)` helper can be used to get an access token to call external APIs, like so:
+
+```tsx
+import { NextRequest, NextResponse } from "next/server"
+
+import { auth0 } from "@/lib/auth0"
+
+export async function middleware(request: NextRequest) {
+  const authRes = await auth0.middleware(request)
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authRes
+  }
+
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // user is not authenticated, redirect to login page
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+  }
+
+  const accessToken = await auth0.getAccessToken(request, authRes)
+
+  // the headers from the auth middleware should always be returned
+  return authRes
+}
+```
+
+> [!IMPORTANT]  
+> The `request` and `response` objects must be passed as a parameters to the `getAccessToken(request, response)` method when called from a middleware to ensure that the refreshed access token can be accessed within the same request.
+
+If you are using the Pages Router and are calling the `getAccessToken` method in both the middleware and an API Route or `getServerSideProps`, it's recommended to propagate the headers from the middleware, as shown below. This will ensure that calling `getAccessToken` in the API Route or `getServerSideProps` will not result in the access token being refreshed again.
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+
+import { auth0 } from "@/lib/auth0"
+
+export async function middleware(request: NextRequest) {
+  const authRes = await auth0.middleware(request)
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authRes
+  }
+
+  const session = await auth0.getSession(request)
+
+  if (!session) {
+    // user is not authenticated, redirect to login page
+    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+  }
+
+  const accessToken = await auth0.getAccessToken(request, authRes)
+
+  // create a new response with the updated request headers
+  const resWithCombinedHeaders = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  })
+
+  // set the response headers (set-cookie) from the auth response
+  authRes.headers.forEach((value, key) => {
+    resWithCombinedHeaders.headers.set(key, value)
+  })
+
+  // the headers from the auth middleware should always be returned
+  return resWithCombinedHeaders
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/nextjs-auth0",
-  "version": "4.0.0-beta.13",
+  "version": "4.0.0-beta.14",
   "description": "Auth0 Next.js SDK",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     },
     "./types": {
       "import": "./dist/types/index.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing/index.js"
     }
   },
   "dependencies": {
@@ -71,6 +74,9 @@
   },
   "typesVersions": {
     "*": {
+      "testing": [
+        "./dist/testing/index.d.ts"
+      ],
       "types": [
         "./dist/types/index.d.ts"
       ],

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -14,11 +14,8 @@ import {
   OAuth2Error,
   SdkError,
 } from "../errors"
-import { SessionData, TokenSet } from "../types"
-import {
-  AbstractSessionStore,
-  LogoutToken,
-} from "./session/abstract-session-store"
+import { LogoutToken, SessionData, TokenSet } from "../types"
+import { AbstractSessionStore } from "./session/abstract-session-store"
 import { TransactionState, TransactionStore } from "./transaction-store"
 import { filterClaims } from "./user"
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -215,61 +215,81 @@ export class Auth0Client {
   /**
    * getSession returns the session data for the current request.
    *
-   * This method can be used in Server Components, Server Actions, Route Handlers, and middleware in the **App Router**.
+   * This method can be used in Server Components, Server Actions, and Route Handlers in the **App Router**.
    */
   async getSession(): Promise<SessionData | null>
 
   /**
    * getSession returns the session data for the current request.
    *
-   * This method can be used in `getServerSideProps`, API routes, and middleware in the **Pages Router**.
+   * This method can be used in middleware and `getServerSideProps`, API routes in the **Pages Router**.
    */
-  async getSession(req: PagesRouterRequest): Promise<SessionData | null>
+  async getSession(
+    req: PagesRouterRequest | NextRequest
+  ): Promise<SessionData | null>
 
   /**
    * getSession returns the session data for the current request.
    */
-  async getSession(req?: PagesRouterRequest): Promise<SessionData | null> {
+  async getSession(
+    req?: PagesRouterRequest | NextRequest
+  ): Promise<SessionData | null> {
     if (req) {
+      // middleware usage
+      if (req instanceof NextRequest) {
+        return this.sessionStore.get(req.cookies)
+      }
+
+      // pages router usage
       return this.sessionStore.get(this.createRequestCookies(req))
     }
 
+    // app router usage: Server Components, Server Actions, Route Handlers
     return this.sessionStore.get(await cookies())
   }
 
   /**
    * getAccessToken returns the access token.
    *
-   * This method can be used in Server Components, Server Actions, Route Handlers, and middleware in the **App Router**.
+   * This method can be used in Server Components, Server Actions, and Route Handlers in the **App Router**.
    *
    * NOTE: Server Components cannot set cookies. Calling `getAccessToken()` in a Server Component will cause the access token to be refreshed, if it is expired, and the updated token set will not to be persisted.
+   * It is recommended to call `getAccessToken(req, res)` in the middleware if you need to retrieve the access token in a Server Component to ensure the updated token set is persisted.
    */
   async getAccessToken(): Promise<{ token: string; expiresAt: number }>
 
   /**
    * getAccessToken returns the access token.
    *
-   * This method can be used in `getServerSideProps`, API routes, and middleware in the **Pages Router**.
+   * This method can be used in middleware and `getServerSideProps`, API routes in the **Pages Router**.
    */
   async getAccessToken(
-    req: PagesRouterRequest,
-    res: PagesRouterResponse
+    req: PagesRouterRequest | NextRequest,
+    res: PagesRouterResponse | NextResponse
   ): Promise<{ token: string; expiresAt: number }>
 
   /**
    * getAccessToken returns the access token.
    *
    * NOTE: Server Components cannot set cookies. Calling `getAccessToken()` in a Server Component will cause the access token to be refreshed, if it is expired, and the updated token set will not to be persisted.
+   * It is recommended to call `getAccessToken(req, res)` in the middleware if you need to retrieve the access token in a Server Component to ensure the updated token set is persisted.
    */
   async getAccessToken(
-    req?: PagesRouterRequest,
-    res?: PagesRouterResponse
+    req?: PagesRouterRequest | NextRequest,
+    res?: PagesRouterResponse | NextResponse
   ): Promise<{ token: string; expiresAt: number }> {
     let session: SessionData | null = null
 
     if (req) {
-      session = await this.sessionStore.get(this.createRequestCookies(req))
+      if (req instanceof NextRequest) {
+        // middleware usage
+        session = await this.sessionStore.get(req.cookies)
+      } else {
+        // pages router usage
+        session = await this.sessionStore.get(this.createRequestCookies(req))
+      }
     } else {
+      // app router usage: Server Components, Server Actions, Route Handlers
       session = await this.sessionStore.get(await cookies())
     }
 
@@ -294,22 +314,33 @@ export class Auth0Client {
       tokenSet.refreshToken !== session.tokenSet.refreshToken
     ) {
       if (req && res) {
-        const resHeaders = new Headers()
-        const resCookies = new ResponseCookies(resHeaders)
-
-        await this.sessionStore.set(
-          this.createRequestCookies(req),
-          resCookies,
-          {
+        if (req instanceof NextRequest && res instanceof NextResponse) {
+          // middleware usage
+          await this.sessionStore.set(req.cookies, res.cookies, {
             ...session,
             tokenSet,
-          }
-        )
+          })
+        } else {
+          // pages router usage
+          const resHeaders = new Headers()
+          const resCookies = new ResponseCookies(resHeaders)
+          const pagesRouterRes = res as PagesRouterResponse
 
-        for (const [key, value] of resHeaders.entries()) {
-          res.setHeader(key, value)
+          await this.sessionStore.set(
+            this.createRequestCookies(req as PagesRouterRequest),
+            resCookies,
+            {
+              ...session,
+              tokenSet,
+            }
+          )
+
+          for (const [key, value] of resHeaders.entries()) {
+            pagesRouterRes.setHeader(key, value)
+          }
         }
       } else {
+        // app router usage: Server Components, Server Actions, Route Handlers
         try {
           await this.sessionStore.set(await cookies(), await cookies(), {
             ...session,
@@ -334,18 +365,18 @@ export class Auth0Client {
   /**
    * updateSession updates the session of the currently authenticated user. If the user does not have a session, an error is thrown.
    *
-   * This method can be used in `getServerSideProps`, API routes, and middleware in the **Pages Router**.
+   * This method can be used in middleware and `getServerSideProps`, API routes, and middleware in the **Pages Router**.
    */
   async updateSession(
-    req: PagesRouterRequest,
-    res: PagesRouterResponse,
+    req: PagesRouterRequest | NextRequest,
+    res: PagesRouterResponse | NextResponse,
     session: SessionData
   ): Promise<void>
 
   /**
    * updateSession updates the session of the currently authenticated user. If the user does not have a session, an error is thrown.
    *
-   * This method can be used in Server Actions, Route Handlers, and middleware in the **App Router**.
+   * This method can be used in Server Actions and Route Handlers in the **App Router**.
    */
   async updateSession(session: SessionData): Promise<void>
 
@@ -353,12 +384,12 @@ export class Auth0Client {
    * updateSession updates the session of the currently authenticated user. If the user does not have a session, an error is thrown.
    */
   async updateSession(
-    reqOrSession: PagesRouterRequest | SessionData,
-    res?: PagesRouterResponse,
+    reqOrSession: PagesRouterRequest | NextRequest | SessionData,
+    res?: PagesRouterResponse | NextResponse,
     sessionData?: SessionData
   ) {
     if (!res) {
-      // app router
+      // app router: Server Actions, Route Handlers
       const existingSession = await this.getSession()
 
       if (!existingSession) {
@@ -366,6 +397,10 @@ export class Auth0Client {
       }
 
       const updatedSession = reqOrSession as SessionData
+      if (!updatedSession) {
+        throw new Error("The session data is missing.")
+      }
+
       await this.sessionStore.set(await cookies(), await cookies(), {
         ...updatedSession,
         internal: {
@@ -373,27 +408,50 @@ export class Auth0Client {
         },
       })
     } else {
-      // pages router
-      const req = reqOrSession as NextApiRequest
-      const existingSession = await this.getSession(req)
+      const req = reqOrSession as PagesRouterRequest | NextRequest
 
-      if (!existingSession) {
-        throw new Error("The user is not authenticated.")
+      if (!sessionData) {
+        throw new Error("The session data is missing.")
       }
 
-      const resHeaders = new Headers()
-      const resCookies = new ResponseCookies(resHeaders)
-      const updatedSession = sessionData as SessionData
+      if (req instanceof NextRequest && res instanceof NextResponse) {
+        // middleware usage
+        const existingSession = await this.getSession(req)
 
-      await this.sessionStore.set(this.createRequestCookies(req), resCookies, {
-        ...updatedSession,
-        internal: {
-          ...existingSession.internal,
-        },
-      })
+        if (!existingSession) {
+          throw new Error("The user is not authenticated.")
+        }
 
-      for (const [key, value] of resHeaders.entries()) {
-        res.setHeader(key, value)
+        await this.sessionStore.set(req.cookies, res.cookies, {
+          ...sessionData,
+          internal: {
+            ...existingSession.internal,
+          },
+        })
+      } else {
+        // pages router usage
+        const existingSession = await this.getSession(req as PagesRouterRequest)
+
+        if (!existingSession) {
+          throw new Error("The user is not authenticated.")
+        }
+
+        const resHeaders = new Headers()
+        const resCookies = new ResponseCookies(resHeaders)
+        const updatedSession = sessionData as SessionData
+        const reqCookies = this.createRequestCookies(req as PagesRouterRequest)
+        const pagesRouterRes = res as PagesRouterResponse
+
+        await this.sessionStore.set(reqCookies, resCookies, {
+          ...updatedSession,
+          internal: {
+            ...existingSession.internal,
+          },
+        })
+
+        for (const [key, value] of resHeaders.entries()) {
+          pagesRouterRes.setHeader(key, value)
+        }
       }
     }
   }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { NextApiRequest, NextApiResponse } from "next/types"
 
 import { AccessTokenError, AccessTokenErrorCode } from "../errors"
-import { SessionData } from "../types"
+import { SessionData, SessionDataStore } from "../types"
 import {
   AuthClient,
   AuthorizationParameters,
@@ -16,7 +16,6 @@ import { RequestCookies, ResponseCookies } from "./cookies"
 import {
   AbstractSessionStore,
   SessionConfiguration,
-  SessionDataStore,
 } from "./session/abstract-session-store"
 import { StatefulSessionStore } from "./session/stateful-session-store"
 import { StatelessSessionStore } from "./session/stateless-session-store"

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -1,34 +1,10 @@
-import type { SessionData } from "../../types"
+import type { SessionData, SessionDataStore } from "../../types"
 import {
   CookieOptions,
   ReadonlyRequestCookies,
   RequestCookies,
   ResponseCookies,
 } from "../cookies"
-
-export type LogoutToken = { sub?: string; sid?: string }
-
-export interface SessionDataStore {
-  /**
-   * Gets the session from the store given a session ID.
-   */
-  get(id: string): Promise<SessionData | null>
-
-  /**
-   * Upsert a session in the store given a session ID and `SessionData`.
-   */
-  set(id: string, session: SessionData): Promise<void>
-
-  /**
-   * Destroys the session with the given session ID.
-   */
-  delete(id: string): Promise<void>
-
-  /**
-   * Deletes the session with the given logout token which may contain a session ID or a user ID, or both.
-   */
-  deleteByLogoutToken?(logoutToken: LogoutToken): Promise<void>
-}
 
 export interface SessionConfiguration {
   /**

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -109,6 +109,9 @@ export class StatefulSessionStore extends AbstractSessionStore {
       maxAge,
     })
     await this.store.set(sessionId, session)
+
+    // to enable read-after-write in the same request for middleware
+    reqCookies.set(this.SESSION_COOKIE_NAME, jwe.toString())
   }
 
   async delete(

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -1,9 +1,6 @@
-import { SessionData } from "../../types"
+import { SessionData, SessionDataStore } from "../../types"
 import * as cookies from "../cookies"
-import {
-  AbstractSessionStore,
-  SessionDataStore,
-} from "./abstract-session-store"
+import { AbstractSessionStore } from "./abstract-session-store"
 
 // the value of the stateful session cookie containing a unique session ID to identify
 // the current session

--- a/src/testing/generate-session-cookie.test.ts
+++ b/src/testing/generate-session-cookie.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+
+import { decrypt } from "../server/cookies"
+import { generateSecret } from "../test/utils"
+import { SessionData } from "../types"
+import {
+  generateSessionCookie,
+  GenerateSessionCookieConfig,
+} from "./generate-session-cookie"
+
+describe("generateSessionCookie", async () => {
+  it("should use the session data provided", async () => {
+    const createdAt = Math.floor(Date.now() / 1000)
+    const session: SessionData = {
+      user: { sub: "user_123" },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: {
+        sid: "auth0-sid",
+        createdAt,
+      },
+    }
+    const secret = await generateSecret(32)
+    const config: GenerateSessionCookieConfig = {
+      secret,
+    }
+    const sessionCookie = await generateSessionCookie(session, config)
+    expect(sessionCookie).toEqual(expect.any(String))
+    expect(await decrypt(sessionCookie, secret)).toEqual({
+      user: {
+        sub: "user_123",
+      },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: {
+        sid: "auth0-sid",
+        createdAt: createdAt,
+      },
+    })
+  })
+
+  it("should populate the internal property if it was not provided", async () => {
+    const session: Partial<SessionData> = {
+      user: { sub: "user_123" },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+    }
+    const secret = await generateSecret(32)
+    const config: GenerateSessionCookieConfig = {
+      secret,
+    }
+    const sessionCookie = await generateSessionCookie(session, config)
+    expect(sessionCookie).toEqual(expect.any(String))
+    expect(await decrypt(sessionCookie, secret)).toEqual({
+      user: {
+        sub: "user_123",
+      },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: {
+        sid: "auth0-sid",
+        createdAt: expect.any(Number),
+      },
+    })
+  })
+
+  it("should not populate the internal property if a null was provided", async () => {
+    const session: Partial<SessionData> = {
+      user: { sub: "user_123" },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      // @ts-expect-error
+      internal: null,
+    }
+    const secret = await generateSecret(32)
+    const config: GenerateSessionCookieConfig = {
+      secret,
+    }
+    const sessionCookie = await generateSessionCookie(session, config)
+    expect(sessionCookie).toEqual(expect.any(String))
+    expect(await decrypt(sessionCookie, secret)).toEqual({
+      user: {
+        sub: "user_123",
+      },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: null,
+    })
+  })
+
+  it("should not populate the internal property if a undefine was provided", async () => {
+    const session: Partial<SessionData> = {
+      user: { sub: "user_123" },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: undefined,
+    }
+    const secret = await generateSecret(32)
+    const config: GenerateSessionCookieConfig = {
+      secret,
+    }
+    const sessionCookie = await generateSessionCookie(session, config)
+    expect(sessionCookie).toEqual(expect.any(String))
+    expect(await decrypt(sessionCookie, secret)).toEqual({
+      user: {
+        sub: "user_123",
+      },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_123",
+        expiresAt: 123456,
+      },
+      internal: undefined,
+    })
+  })
+})

--- a/src/testing/generate-session-cookie.ts
+++ b/src/testing/generate-session-cookie.ts
@@ -1,0 +1,25 @@
+import { encrypt } from "../server/cookies"
+import { SessionData } from "../types"
+
+export type GenerateSessionCookieConfig = {
+  /**
+   * The secret used to derive an encryption key for the session cookie.
+   *
+   * **IMPORTANT**: you must use the same value as in the SDK configuration.
+   */
+  secret: string
+}
+
+export const generateSessionCookie = async (
+  session: Partial<SessionData>,
+  config: GenerateSessionCookieConfig
+): Promise<string> => {
+  if (!("internal" in session)) {
+    session.internal = {
+      sid: "auth0-sid",
+      createdAt: Math.floor(Date.now() / 1000),
+    }
+  }
+
+  return encrypt(session, config.secret)
+}

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,4 @@
+export {
+  GenerateSessionCookieConfig,
+  generateSessionCookie,
+} from "./generate-session-cookie"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,30 @@ export interface SessionData {
   [key: string]: unknown
 }
 
+export interface SessionDataStore {
+  /**
+   * Gets the session from the store given a session ID.
+   */
+  get(id: string): Promise<SessionData | null>
+
+  /**
+   * Upsert a session in the store given a session ID and `SessionData`.
+   */
+  set(id: string, session: SessionData): Promise<void>
+
+  /**
+   * Destroys the session with the given session ID.
+   */
+  delete(id: string): Promise<void>
+
+  /**
+   * Deletes the session with the given logout token which may contain a session ID or a user ID, or both.
+   */
+  deleteByLogoutToken?(logoutToken: LogoutToken): Promise<void>
+}
+
+export type LogoutToken = { sub?: string; sid?: string }
+
 export interface User {
   sub: string
   name?: string


### PR DESCRIPTION
* fix: propagate session data updates within the same request (fixes:  https://github.com/auth0/nextjs-auth0/issues/1841)
* chore: export SessionDataStore and LogoutToken types (closes: https://github.com/auth0/nextjs-auth0/issues/1852)
* feat: add generateSessionCookie testing helper (closes: https://github.com/auth0/nextjs-auth0/issues/1857)