### PR TITLE
chore: reduce session lifetime defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,8 +699,8 @@ export const auth0 = new Auth0Client({
 | Option             | Type      | Description                                                                                                                                                                                                                                   |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | rolling            | `boolean` | When enabled, the session will continue to be extended as long as it is used within the inactivity duration. Once the upper bound, set via the `absoluteDuration`, has been reached, the session will no longer be extended. Default: `true`. |
-| absoluteDuration   | `number`  | The absolute duration after which the session will expire. The value must be specified in seconds. Default: `30 days`.                                                                                                                        |
-| inactivityDuration | `number`  | The duration of inactivity after which the session will expire. The value must be specified in seconds. Default: `7 days`.                                                                                                                    |
+| absoluteDuration   | `number`  | The absolute duration after which the session will expire. The value must be specified in seconds. Default: `3 days`.                                                                                                                         |
+| inactivityDuration | `number`  | The duration of inactivity after which the session will expire. The value must be specified in seconds. Default: `1 day`.                                                                                                                     |
 
 ## Database sessions
 

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -21,7 +21,7 @@ export interface SessionConfiguration {
    *
    * Once the absolute duration has been reached, the session will no longer be extended.
    *
-   * Default: 30 days.
+   * Default: 3 days.
    */
   absoluteDuration?: number
   /**
@@ -29,7 +29,7 @@ export interface SessionConfiguration {
    *
    * The session will be extended as long as it was active before the inactivity duration has been reached.
    *
-   * Default: 7 days.
+   * Default: 1 day.
    */
   inactivityDuration?: number
 }
@@ -57,8 +57,8 @@ export abstract class AbstractSessionStore {
     secret,
 
     rolling = true,
-    absoluteDuration = 60 * 60 * 24 * 30, // 30 days in seconds
-    inactivityDuration = 60 * 60 * 24 * 7, // 7 days in seconds
+    absoluteDuration = 60 * 60 * 24 * 3, // 3 days in seconds
+    inactivityDuration = 60 * 60 * 24 * 1, // 1 day in seconds
     store,
 
     cookieOptions,

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -12,8 +12,8 @@ interface StatefulSessionStoreOptions {
   secret: string
 
   rolling?: boolean // defaults to true
-  absoluteDuration?: number // defaults to 30 days
-  inactivityDuration?: number // defaults to 7 days
+  absoluteDuration?: number // defaults to 3 days
+  inactivityDuration?: number // defaults to 1 day
 
   store: SessionDataStore
 

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -6,8 +6,8 @@ interface StatelessSessionStoreOptions {
   secret: string
 
   rolling?: boolean // defaults to true
-  absoluteDuration?: number // defaults to 30 days
-  inactivityDuration?: number // defaults to 7 days
+  absoluteDuration?: number // defaults to 3 days
+  inactivityDuration?: number // defaults to 1 day
 
   cookieOptions?: Partial<Pick<cookies.CookieOptions, "secure">>
 }


### PR DESCRIPTION
Reduces session lifetime defaults to 1 day of inactivity and 3 days absolute.