### PR TITLE
fix: persist access token scope in tokenset

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -3086,6 +3086,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           tokenEndpointResponse: {
             token_type: "Bearer",
             access_token: newAccessToken,
+            scope: "openid profile email",
             expires_in: 86400, // expires in 10 days
           } as oauth.TokenEndpointResponse,
         }),
@@ -3102,6 +3103,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         },
         tokenSet: {
           accessToken: currentAccessToken,
+          scope: "openid profile email",
           refreshToken: DEFAULT.refreshToken,
           expiresAt,
         },
@@ -3125,6 +3127,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       expect(response.status).toEqual(200)
       expect(await response.json()).toEqual({
         token: newAccessToken,
+        scope: "openid profile email",
         expires_at: expect.any(Number),
       })
 

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -453,6 +453,7 @@ export class AuthClient {
       user: idTokenClaims,
       tokenSet: {
         accessToken: oidcRes.access_token,
+        scope: oidcRes.scope,
         refreshToken: oidcRes.refresh_token,
         expiresAt: Math.floor(Date.now() / 1000) + Number(oidcRes.expires_in),
       },
@@ -530,6 +531,7 @@ export class AuthClient {
 
     const res = NextResponse.json({
       token: updatedTokenSet.accessToken,
+      scope: updatedTokenSet.scope,
       expires_at: updatedTokenSet.expiresAt,
     })
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -290,7 +290,7 @@ export class Auth0Client {
   async getAccessToken(
     req?: PagesRouterRequest | NextRequest,
     res?: PagesRouterResponse | NextResponse
-  ): Promise<{ token: string; expiresAt: number }> {
+  ): Promise<{ token: string; expiresAt: number; scope?: string }> {
     let session: SessionData | null = null
 
     if (req) {
@@ -371,6 +371,7 @@ export class Auth0Client {
 
     return {
       token: tokenSet.accessToken,
+      scope: tokenSet.scope,
       expiresAt: tokenSet.expiresAt,
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export interface TokenSet {
   accessToken: string
+  scope?: string
   refreshToken?: string
   expiresAt: number // the time at which the access token expires in seconds since epoch
 }


### PR DESCRIPTION
Persist the Access Token scopes in the tokenset to make the available in `getAccessToken` helper.

Fixes: https://github.com/auth0/nextjs-auth0/issues/1867