### PR TITLE
fix: do not forward custom params from query when using PAR

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -1424,77 +1424,79 @@ ca/T0LLtgmbMmxSv/MmzIg==
         })
       })
 
-      it("should forward any custom parameters to the authorization server in the PAR request", async () => {
-        const secret = await generateSecret(32)
-        const transactionStore = new TransactionStore({
-          secret,
-        })
-        const sessionStore = new StatelessSessionStore({
-          secret,
-        })
+      describe("custom parameters to the authorization server", async () => {
+        it("should not forward any custom parameters sent via the query parameters to /auth/login", async () => {
+          const secret = await generateSecret(32)
+          const transactionStore = new TransactionStore({
+            secret,
+          })
+          const sessionStore = new StatelessSessionStore({
+            secret,
+          })
 
-        // set custom parameters in the login URL which should be forwarded to the authorization server (in PAR request)
-        const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl)
-        loginUrl.searchParams.set("ext-custom_param", "custom_value")
-        loginUrl.searchParams.set("audience", "urn:mystore:api")
-        const request = new NextRequest(loginUrl, {
-          method: "GET",
-        })
+          // set custom parameters in the login URL which should not be forwarded to the authorization server (in PAR request)
+          const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl)
+          loginUrl.searchParams.set("ext-custom_param", "custom_value")
+          loginUrl.searchParams.set("audience", "urn:mystore:api")
+          const request = new NextRequest(loginUrl, {
+            method: "GET",
+          })
 
-        const authClient = new AuthClient({
-          transactionStore,
-          sessionStore,
-          domain: DEFAULT.domain,
-          clientId: DEFAULT.clientId,
-          clientSecret: DEFAULT.clientSecret,
-          pushedAuthorizationRequests: true,
-          secret,
-          appBaseUrl: DEFAULT.appBaseUrl,
-          fetch: getMockAuthorizationServer({
-            onParRequest: async (request) => {
-              const params = new URLSearchParams(await request.text())
-              expect(params.get("ext-custom_param")).toEqual("custom_value")
-              expect(params.get("audience")).toEqual("urn:mystore:api")
-            },
-          }),
-        })
+          const authClient = new AuthClient({
+            transactionStore,
+            sessionStore,
+            domain: DEFAULT.domain,
+            clientId: DEFAULT.clientId,
+            clientSecret: DEFAULT.clientSecret,
+            pushedAuthorizationRequests: true,
+            secret,
+            appBaseUrl: DEFAULT.appBaseUrl,
+            fetch: getMockAuthorizationServer({
+              onParRequest: async (request) => {
+                const params = new URLSearchParams(await request.text())
+                expect(params.get("ext-custom_param")).toBeNull()
+                expect(params.get("audience")).toBeNull()
+              },
+            }),
+          })
 
-        const response = await authClient.handleLogin(request)
-        expect(response.status).toEqual(307)
-        expect(response.headers.get("Location")).not.toBeNull()
-        const authorizationUrl = new URL(response.headers.get("Location")!)
-        expect(authorizationUrl.origin).toEqual(`https://${DEFAULT.domain}`)
-        // query parameters should only include the `request_uri` and not the standard auth params
-        expect(authorizationUrl.searchParams.get("request_uri")).toEqual(
-          DEFAULT.requestUri
-        )
-        expect(authorizationUrl.searchParams.get("client_id")).toEqual(
-          DEFAULT.clientId
-        )
-        expect(authorizationUrl.searchParams.get("redirect_uri")).toBeNull()
-        expect(authorizationUrl.searchParams.get("response_type")).toBeNull()
-        expect(authorizationUrl.searchParams.get("code_challenge")).toBeNull()
-        expect(
-          authorizationUrl.searchParams.get("code_challenge_method")
-        ).toBeNull()
-        expect(authorizationUrl.searchParams.get("state")).toBeNull()
-        expect(authorizationUrl.searchParams.get("nonce")).toBeNull()
-        expect(authorizationUrl.searchParams.get("scope")).toBeNull()
+          const response = await authClient.handleLogin(request)
+          expect(response.status).toEqual(307)
+          expect(response.headers.get("Location")).not.toBeNull()
+          const authorizationUrl = new URL(response.headers.get("Location")!)
+          expect(authorizationUrl.origin).toEqual(`https://${DEFAULT.domain}`)
+          // query parameters should only include the `request_uri` and not the standard auth params
+          expect(authorizationUrl.searchParams.get("request_uri")).toEqual(
+            DEFAULT.requestUri
+          )
+          expect(authorizationUrl.searchParams.get("client_id")).toEqual(
+            DEFAULT.clientId
+          )
+          expect(authorizationUrl.searchParams.get("redirect_uri")).toBeNull()
+          expect(authorizationUrl.searchParams.get("response_type")).toBeNull()
+          expect(authorizationUrl.searchParams.get("code_challenge")).toBeNull()
+          expect(
+            authorizationUrl.searchParams.get("code_challenge_method")
+          ).toBeNull()
+          expect(authorizationUrl.searchParams.get("state")).toBeNull()
+          expect(authorizationUrl.searchParams.get("nonce")).toBeNull()
+          expect(authorizationUrl.searchParams.get("scope")).toBeNull()
 
-        // transaction state
-        const transactionCookies = response.cookies
-          .getAll()
-          .filter((c) => c.name.startsWith("__txn_"))
-        expect(transactionCookies.length).toEqual(1)
-        const transactionCookie = transactionCookies[0]
-        const state = transactionCookie.name.replace("__txn_", "")
-        expect(transactionCookie).toBeDefined()
-        expect(await decrypt(transactionCookie!.value, secret)).toEqual({
-          nonce: expect.any(String),
-          codeVerifier: expect.any(String),
-          responseType: "code",
-          state,
-          returnTo: "/",
+          // transaction state
+          const transactionCookies = response.cookies
+            .getAll()
+            .filter((c) => c.name.startsWith("__txn_"))
+          expect(transactionCookies.length).toEqual(1)
+          const transactionCookie = transactionCookies[0]
+          const state = transactionCookie.name.replace("__txn_", "")
+          expect(transactionCookie).toBeDefined()
+          expect(await decrypt(transactionCookie!.value, secret)).toEqual({
+            nonce: expect.any(String),
+            codeVerifier: expect.any(String),
+            responseType: "code",
+            state,
+            returnTo: "/",
+          })
         })
       })
     })

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -290,12 +290,15 @@ export class AuthClient {
       }
     })
 
-    // any custom params to forward to /authorize passed as query parameters
-    req.nextUrl.searchParams.forEach((val, key) => {
-      if (!INTERNAL_AUTHORIZE_PARAMS.includes(key)) {
-        authorizationParams.set(key, val)
-      }
-    })
+    // custom parameters passed in via the query params to ensure only the confidential client can set them
+    if (!this.pushedAuthorizationRequests) {
+      // any custom params to forward to /authorize passed as query parameters
+      req.nextUrl.searchParams.forEach((val, key) => {
+        if (!INTERNAL_AUTHORIZE_PARAMS.includes(key)) {
+          authorizationParams.set(key, val)
+        }
+      })
+    }
 
     const transactionState: TransactionState = {
       nonce,


### PR DESCRIPTION
This PR introduces a fix to prevent forwarding custom parameters to the `/authorize` endpoint specified via query parameters to the login route when using PAR.

Previously, when using PAR, it was possible to forward parameters to the authorization server that were specified in the query params of the login route. This is undesirable as the confidential client should only be able to specify the parameters to the authorization server.

⚠️ This bug fix introduces an intentional change in behaviour which is considered breaking.