### PR TITLE
Add support for Federated Connection Access Token (#1911)

### DIFF
--- a/examples/with-shadcn/middleware.ts
+++ b/examples/with-shadcn/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server"
 import { auth0 } from "./lib/auth0"
 
 export async function middleware(request: NextRequest) {
-  return await auth0.middleware(request)
+  return await auth0.middleware(request);
 }
 
 export const config = {

--- a/examples/with-shadcn/package.json
+++ b/examples/with-shadcn/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^4.0.0",
+    "@auth0/nextjs-auth0": "^4.0.1",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/examples/with-shadcn/pnpm-lock.yaml
+++ b/examples/with-shadcn/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@auth0/nextjs-auth0':
-        specifier: ^4.0.0
-        version: 4.0.0(next@15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028))(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+        specifier: ^4.0.1
+        version: 4.0.1(next@15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028))(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
       '@radix-ui/react-avatar':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
@@ -91,8 +91,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@auth0/nextjs-auth0@4.0.0':
-    resolution: {integrity: sha512-pFnbGXMjNNYRB4jHvjBDOZdvsvYeyIJn0LILD+g8tl8dUStS90spAd3ziPY/YOiaeIejqm5Iy7uYhNlHITJlUg==}
+  '@auth0/nextjs-auth0@4.0.1':
+    resolution: {integrity: sha512-K9XY9e0DWWdqwhsAUK3ZKJ6PJsyFzfPnWl3Dof3YXcJyqgGs/d1G7ZJT9qFeHqa61zIUYNybCmyzLP41DCN00g==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
@@ -2158,7 +2158,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@auth0/nextjs-auth0@4.0.0(next@15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028))(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)':
+  '@auth0/nextjs-auth0@4.0.1(next@15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028))(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)':
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       '@panva/hkdf': 1.2.1

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -98,3 +98,46 @@ export class AccessTokenError extends SdkError {
     this.code = code;
   }
 }
+
+/**
+ * Enum representing error codes related to federated connection access tokens.
+ */
+export enum FederatedConnectionAccessTokenErrorCode {
+  /**
+   * The session is missing.
+   */
+  MISSING_SESSION = "missing_session",
+
+  /**
+   * The refresh token is missing.
+   */
+  MISSING_REFRESH_TOKEN = "missing_refresh_token",
+
+  /**
+   * Failed to exchange the refresh token.
+   */
+  FAILED_TO_EXCHANGE = "failed_to_exchange_refresh_token"
+}
+
+/**
+ * Error class representing an access token error for federated connections.
+ * Extends the `SdkError` class.
+ */
+export class FederatedConnectionsAccessTokenError extends SdkError {
+  /**
+   * The error code associated with the access token error.
+   */
+  public code: string;
+
+  /**
+   * Constructs a new `FederatedConnectionsAccessTokenError` instance.
+   *
+   * @param code - The error code.
+   * @param message - The error message.
+   */
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "FederatedConnectionAccessTokenError";
+    this.code = code;
+  }
+}

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -9,12 +9,20 @@ import {
   AuthorizationError,
   BackchannelLogoutError,
   DiscoveryError,
+  FederatedConnectionAccessTokenErrorCode,
+  FederatedConnectionsAccessTokenError,
   InvalidStateError,
   MissingStateError,
   OAuth2Error,
   SdkError
 } from "../errors";
-import { LogoutToken, SessionData, TokenSet } from "../types";
+import {
+  FederatedConnectionTokenSet,
+  GetFederatedConnectionAccessTokenOptions,
+  LogoutToken,
+  SessionData,
+  TokenSet
+} from "../types";
 import { toSafeRedirect } from "../utils/url-helpers";
 import { AbstractSessionStore } from "./session/abstract-session-store";
 import { TransactionState, TransactionStore } from "./transaction-store";
@@ -48,6 +56,35 @@ const INTERNAL_AUTHORIZE_PARAMS = [
 const DEFAULT_SCOPES = ["openid", "profile", "email", "offline_access"].join(
   " "
 );
+
+/**
+ * A constant representing the grant type for federated connection access token exchange.
+ *
+ * This grant type is used in OAuth token exchange scenarios where a federated connection
+ * access token is required. It is specific to Auth0's implementation and follows the
+ * "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token" format.
+ */
+const GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+  "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
+
+/**
+ * Constant representing the subject type for a refresh token.
+ * This is used in OAuth 2.0 token exchange to specify that the token being exchanged is a refresh token.
+ *
+ * @see {@link https://tools.ietf.org/html/rfc8693#section-3.1 RFC 8693 Section 3.1}
+ */
+const SUBJECT_TYPE_REFRESH_TOKEN =
+  "urn:ietf:params:oauth:token-type:refresh_token";
+
+/**
+ * A constant representing the token type for federated connection access tokens.
+ * This is used to specify the type of token being requested from Auth0.
+ *
+ * @constant
+ * @type {string}
+ */
+const REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+  "http://auth0.com/oauth/token-type/federated-connection-access-token";
 
 export interface AuthorizationParameters {
   /**
@@ -935,6 +972,122 @@ export class AuthClient {
       this.domain.startsWith("https://")
       ? this.domain
       : `https://${this.domain}`;
+  }
+
+  /**
+   * Exchanges a refresh token for a federated connection access token.
+   *
+   * This method performs a token exchange using the provided refresh token and connection details.
+   * It first checks if the refresh token is present in the `tokenSet`. If not, it returns an error.
+   * Then, it constructs the necessary parameters for the token exchange request and performs
+   * the request to the authorization server's token endpoint.
+   *
+   * @returns {Promise<[SdkError, null] | [null, FederatedConnectionTokenSet]>} A promise that resolves to a tuple.
+   *          The first element is either an `SdkError` if an error occurred, or `null` if the request was successful.
+   *          The second element is either `null` if an error occurred, or a `FederatedConnectionTokenSet` object
+   *          containing the access token, expiration time, and scope if the request was successful.
+   *
+   * @throws {FederatedConnectionsAccessTokenError} If the refresh token is missing or if there is an error during the token exchange process.
+   */
+  async getFederatedConnectionTokenSet(
+    tokenSet: TokenSet,
+    federatedConnectionTokenSet: FederatedConnectionTokenSet | undefined,
+    options: GetFederatedConnectionAccessTokenOptions
+  ): Promise<[SdkError, null] | [null, FederatedConnectionTokenSet]> {
+    // If we do not have a refresh token
+    // and we do not have a federated connection token set in the cache or the one we have is expired,
+    // there is noting to retrieve and we return an error.
+    if (
+      !tokenSet.refreshToken &&
+      (!federatedConnectionTokenSet ||
+        federatedConnectionTokenSet.expiresAt <= Date.now() / 1000)
+    ) {
+      return [
+        new FederatedConnectionsAccessTokenError(
+          FederatedConnectionAccessTokenErrorCode.MISSING_REFRESH_TOKEN,
+          "A refresh token was not present, Federated Connection Access Token requires a refresh token. The user needs to re-authenticate."
+        ),
+        null
+      ];
+    }
+
+    // If we do have a refresh token,
+    // and we do not have a federated connection token set in the cache or the one we have is expired,
+    // we need to exchange the refresh token for a federated connection access token.
+    if (
+      tokenSet.refreshToken &&
+      (!federatedConnectionTokenSet ||
+        federatedConnectionTokenSet.expiresAt <= Date.now() / 1000)
+    ) {
+      const params = new URLSearchParams();
+
+      params.append("connection", options.connection);
+      params.append("subject_token_type", SUBJECT_TYPE_REFRESH_TOKEN);
+      params.append("subject_token", tokenSet.refreshToken);
+      params.append(
+        "requested_token_type",
+        REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN
+      );
+
+      if (options.login_hint) {
+        params.append("login_hint", options.login_hint);
+      }
+
+      const [discoveryError, authorizationServerMetadata] =
+        await this.discoverAuthorizationServerMetadata();
+
+      if (discoveryError) {
+        console.error(discoveryError);
+        return [discoveryError, null];
+      }
+
+      const httpResponse = await oauth.genericTokenEndpointRequest(
+        authorizationServerMetadata,
+        this.clientMetadata,
+        await this.getClientAuth(),
+        GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN,
+        params,
+        {
+          [oauth.customFetch]: this.fetch,
+          [oauth.allowInsecureRequests]: this.allowInsecureRequests
+        }
+      );
+
+      let tokenEndpointResponse: oauth.TokenEndpointResponse;
+      try {
+        tokenEndpointResponse = await oauth.processGenericTokenEndpointResponse(
+          authorizationServerMetadata,
+          this.clientMetadata,
+          httpResponse
+        );
+      } catch (err) {
+        console.error(err);
+        return [
+          new FederatedConnectionsAccessTokenError(
+            FederatedConnectionAccessTokenErrorCode.FAILED_TO_EXCHANGE,
+            "There was an error trying to exchange the refresh token for a federated connection access token. Check the server logs for more information."
+          ),
+          null
+        ];
+      }
+
+      return [
+        null,
+        {
+          accessToken: tokenEndpointResponse.access_token,
+          expiresAt:
+            Math.floor(Date.now() / 1000) +
+            Number(tokenEndpointResponse.expires_in),
+          scope: tokenEndpointResponse.scope,
+          connection: options.connection
+        }
+      ];
+    }
+
+    return [null, federatedConnectionTokenSet] as [
+      null,
+      FederatedConnectionTokenSet
+    ];
   }
 }
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -3,8 +3,17 @@ import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
-import { AccessTokenError, AccessTokenErrorCode } from "../errors";
-import { SessionData, SessionDataStore } from "../types";
+import {
+  AccessTokenError,
+  AccessTokenErrorCode,
+  FederatedConnectionAccessTokenErrorCode,
+  FederatedConnectionsAccessTokenError
+} from "../errors";
+import {
+  GetFederatedConnectionAccessTokenOptions,
+  SessionData,
+  SessionDataStore
+} from "../types";
 import {
   AuthClient,
   AuthorizationParameters,
@@ -314,20 +323,8 @@ export class Auth0Client {
     req?: PagesRouterRequest | NextRequest,
     res?: PagesRouterResponse | NextResponse
   ): Promise<{ token: string; expiresAt: number; scope?: string }> {
-    let session: SessionData | null = null;
-
-    if (req) {
-      if (req instanceof NextRequest) {
-        // middleware usage
-        session = await this.sessionStore.get(req.cookies);
-      } else {
-        // pages router usage
-        session = await this.sessionStore.get(this.createRequestCookies(req));
-      }
-    } else {
-      // app router usage: Server Components, Server Actions, Route Handlers
-      session = await this.sessionStore.get(await cookies());
-    }
+    const session: SessionData | null =
+      req ? await this.getSession(req) : await this.getSession();
 
     if (!session) {
       throw new AccessTokenError(
@@ -349,53 +346,136 @@ export class Auth0Client {
       tokenSet.expiresAt !== session.tokenSet.expiresAt ||
       tokenSet.refreshToken !== session.tokenSet.refreshToken
     ) {
-      if (req && res) {
-        if (req instanceof NextRequest && res instanceof NextResponse) {
-          // middleware usage
-          await this.sessionStore.set(req.cookies, res.cookies, {
-            ...session,
-            tokenSet
-          });
-        } else {
-          // pages router usage
-          const resHeaders = new Headers();
-          const resCookies = new ResponseCookies(resHeaders);
-          const pagesRouterRes = res as PagesRouterResponse;
-
-          await this.sessionStore.set(
-            this.createRequestCookies(req as PagesRouterRequest),
-            resCookies,
-            {
-              ...session,
-              tokenSet
-            }
-          );
-
-          for (const [key, value] of resHeaders.entries()) {
-            pagesRouterRes.setHeader(key, value);
-          }
-        }
-      } else {
-        // app router usage: Server Components, Server Actions, Route Handlers
-        try {
-          await this.sessionStore.set(await cookies(), await cookies(), {
-            ...session,
-            tokenSet
-          });
-        } catch (e) {
-          if (process.env.NODE_ENV === "development") {
-            console.warn(
-              "Failed to persist the updated token set. `getAccessToken()` was likely called from a Server Component which cannot set cookies."
-            );
-          }
-        }
-      }
+      await this.saveToSession(
+        {
+          ...session,
+          tokenSet
+        },
+        req,
+        res
+      );
     }
 
     return {
       token: tokenSet.accessToken,
       scope: tokenSet.scope,
       expiresAt: tokenSet.expiresAt
+    };
+  }
+
+  /**
+   * Retrieves an access token for a federated connection.
+   *
+   * This method can be used in Server Components, Server Actions, and Route Handlers in the **App Router**.
+   *
+   * NOTE: Server Components cannot set cookies. Calling `getFederatedConnectionAccessToken()` in a Server Component will cause the access token to be refreshed, if it is expired, and the updated token set will not to be persisted.
+   * It is recommended to call `getFederatedConnectionAccessToken(req, res)` in the middleware if you need to retrieve the access token in a Server Component to ensure the updated token set is persisted.
+   */
+  async getFederatedConnectionAccessToken(
+    options: GetFederatedConnectionAccessTokenOptions
+  ): Promise<{ token: string; expiresAt: number }>;
+
+  /**
+   * Retrieves an access token for a federated connection.
+   *
+   * This method can be used in middleware and `getServerSideProps`, API routes in the **Pages Router**.
+   */
+  async getFederatedConnectionAccessToken(
+    options: GetFederatedConnectionAccessTokenOptions,
+    req: PagesRouterRequest | NextRequest | undefined,
+    res: PagesRouterResponse | NextResponse | undefined
+  ): Promise<{ token: string; expiresAt: number }>;
+
+  /**
+   * Retrieves an access token for a federated connection.
+   *
+   * This method attempts to obtain an access token for a specified federated connection.
+   * It first checks if a session exists, either from the provided request or from cookies.
+   * If no session is found, it throws a `FederatedConnectionsAccessTokenError` indicating
+   * that the user does not have an active session.
+   *
+   * @param {GetFederatedConnectionAccessTokenOptions} options - Options for retrieving a federated connection access token.
+   * @param {PagesRouterRequest | NextRequest} [req] - An optional request object from which to extract session information.
+   * @param {PagesRouterResponse | NextResponse} [res] - An optional response object from which to extract session information.
+   *
+   * @throws {FederatedConnectionsAccessTokenError} If the user does not have an active session.
+   * @throws {Error} If there is an error during the token exchange process.
+   *
+   * @returns {Promise<{ token: string; expiresAt: number; scope?: string }} An object containing the access token and its expiration time.
+   */
+  async getFederatedConnectionAccessToken(
+    options: GetFederatedConnectionAccessTokenOptions,
+    req?: PagesRouterRequest | NextRequest,
+    res?: PagesRouterResponse | NextResponse
+  ): Promise<{ token: string; expiresAt: number; scope?: string }> {
+    const session: SessionData | null =
+    req ? await this.getSession(req) : await this.getSession();
+
+    if (!session) {
+      throw new FederatedConnectionsAccessTokenError(
+        FederatedConnectionAccessTokenErrorCode.MISSING_SESSION,
+        "The user does not have an active session."
+      );
+    }
+
+    // Find the federated connection token set in the session
+    const existingTokenSet = session.federatedConnectionTokenSets?.find(
+      (tokenSet) => tokenSet.connection === options.connection
+    );
+
+    const [error, retrievedTokenSet] =
+      await this.authClient.getFederatedConnectionTokenSet(
+        session.tokenSet,
+        existingTokenSet,
+        options
+      );
+
+    if (error !== null) {
+      throw error;
+    }
+
+    // If we didnt have a corresponding federated connection token set in the session
+    // or if the one we have in the session does not match the one we received
+    // We want to update the store incase we retrieved a token set.
+    if (
+      retrievedTokenSet &&
+      (!existingTokenSet ||
+        retrievedTokenSet.accessToken !== existingTokenSet.accessToken ||
+        retrievedTokenSet.expiresAt !== existingTokenSet.expiresAt ||
+        retrievedTokenSet.scope !== existingTokenSet.scope)
+    ) {
+      let tokenSets;
+
+      // If we already had the federated connection token set in the session
+      // we need to update the item in the array
+      // If not, we need to add it.
+      if (existingTokenSet) {
+        tokenSets = session.federatedConnectionTokenSets?.map((tokenSet) =>
+          tokenSet.connection === options.connection
+            ? retrievedTokenSet
+            : tokenSet
+        );
+      } else {
+        tokenSets = [
+          ...(session.federatedConnectionTokenSets || []),
+          retrievedTokenSet
+        ];
+      }
+
+      await this.saveToSession(
+        {
+          ...session,
+          federatedConnectionTokenSets: tokenSets
+        },
+        req,
+        res
+      );
+    }
+
+    return {
+      token: retrievedTokenSet.accessToken,
+      scope: retrievedTokenSet.scope,
+      expiresAt: retrievedTokenSet.expiresAt
     };
   }
 
@@ -509,5 +589,44 @@ export class Auth0Client {
     }
 
     return new RequestCookies(headers);
+  }
+
+  private async saveToSession(
+    data: SessionData,
+    req?: PagesRouterRequest | NextRequest,
+    res?: PagesRouterResponse | NextResponse
+  ) {
+    if (req && res) {
+      if (req instanceof NextRequest && res instanceof NextResponse) {
+        // middleware usage
+        await this.sessionStore.set(req.cookies, res.cookies, data);
+      } else {
+        // pages router usage
+        const resHeaders = new Headers();
+        const resCookies = new ResponseCookies(resHeaders);
+        const pagesRouterRes = res as PagesRouterResponse;
+
+        await this.sessionStore.set(
+          this.createRequestCookies(req as PagesRouterRequest),
+          resCookies,
+          data
+        );
+
+        for (const [key, value] of resHeaders.entries()) {
+          pagesRouterRes.setHeader(key, value);
+        }
+      }
+    } else {
+      // app router usage: Server Components, Server Actions, Route Handlers
+      try {
+        await this.sessionStore.set(await cookies(), await cookies(), data);
+      } catch (e) {
+        if (process.env.NODE_ENV === "development") {
+          console.warn(
+            "Failed to persist the updated token set. `getAccessToken()` was likely called from a Server Component which cannot set cookies."
+          );
+        }
+      }
+    }
   }
 }

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -45,6 +45,40 @@ describe("Stateless Session Store", async () => {
 
       expect(await sessionStore.get(requestCookies)).toBeNull();
     });
+
+    it("should return the decrypted session cookie if it exists with federated connection", async () => {
+      const secret = await generateSecret(32);
+      const session: SessionData = {
+        user: { sub: "user_123" },
+        tokenSet: {
+          accessToken: "at_123",
+          refreshToken: "rt_123",
+          expiresAt: 123456
+        },
+        internal: {
+          sid: "auth0-sid",
+          createdAt: Math.floor(Date.now() / 1000)
+        },
+        federatedConnectionTokenSets: [
+          {
+            connection: "google-oauth",
+            accessToken: "google-at-123",
+            expiresAt: 123456
+          }
+        ]
+      };
+      const encryptedCookieValue = await encrypt(session, secret);
+
+      const headers = new Headers();
+      headers.append("cookie", `__session=${encryptedCookieValue}`);
+      const requestCookies = new RequestCookies(headers);
+
+      const sessionStore = new StatelessSessionStore({
+        secret
+      });
+
+      expect(await sessionStore.get(requestCookies)).toEqual(session);
+    });
   });
 
   describe("set", async () => {

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -1,4 +1,6 @@
-import { SessionData } from "../../types";
+import type { JWTPayload } from "jose";
+
+import { FederatedConnectionTokenSet, SessionData } from "../../types";
 import * as cookies from "../cookies";
 import {
   AbstractSessionStore,
@@ -16,6 +18,8 @@ interface StatelessSessionStoreOptions {
 }
 
 export class StatelessSessionStore extends AbstractSessionStore {
+  federatedConnectionTokenSetsCookieName = "__FC";
+
   constructor({
     secret,
     rolling,
@@ -39,7 +43,30 @@ export class StatelessSessionStore extends AbstractSessionStore {
       return null;
     }
 
-    return cookies.decrypt<SessionData>(cookieValue, this.secret);
+    const originalSession = await cookies.decrypt<SessionData>(
+      cookieValue,
+      this.secret
+    );
+
+    // As federated connection access tokens are stored in seperate cookies,
+    // we need to get all cookies and only use those that are prefixed with `this.federatedConnectionTokenSetsCookieName`
+    const federatedConnectionTokenSets = await Promise.all(
+      this.getFederatedConnectionTokenSetsCookies(reqCookies).map(
+        (fcatCookie) =>
+          cookies.decrypt<FederatedConnectionTokenSet>(
+            fcatCookie.value,
+            this.secret
+          )
+      )
+    );
+
+    return {
+      ...originalSession,
+      // Ensure that when there are no federated connection token sets, we omit the property.
+      ...(federatedConnectionTokenSets.length
+        ? { federatedConnectionTokenSets }
+        : {})
+    };
   }
 
   /**
@@ -50,36 +77,93 @@ export class StatelessSessionStore extends AbstractSessionStore {
     resCookies: cookies.ResponseCookies,
     session: SessionData
   ) {
-    const jwe = await cookies.encrypt(session, this.secret);
+    const { federatedConnectionTokenSets, ...originalSession } = session;
     const maxAge = this.calculateMaxAge(session.internal.createdAt);
-    const cookieValue = jwe.toString();
 
-    resCookies.set(this.sessionCookieName, jwe.toString(), {
-      ...this.cookieConfig,
+    await this.storeInCookie(
+      reqCookies,
+      resCookies,
+      originalSession,
+      this.sessionCookieName,
       maxAge
-    });
-    // to enable read-after-write in the same request for middleware
-    reqCookies.set(this.sessionCookieName, cookieValue);
+    );
 
-    // check if the session cookie size exceeds 4096 bytes, and if so, log a warning
-    const cookieJarSizeTest = new cookies.ResponseCookies(new Headers());
-    cookieJarSizeTest.set(this.sessionCookieName, cookieValue, {
-      ...this.cookieConfig,
-      maxAge
-    });
-    if (new TextEncoder().encode(cookieJarSizeTest.toString()).length >= 4096) {
-      console.warn(
-        "The session cookie size exceeds 4096 bytes, which may cause issues in some browsers. " +
-          "Consider removing any unnecessary custom claims from the access token or the user profile. " +
-          "Alternatively, you can use a stateful session implementation to store the session data in a data store."
+    // Store federated connection access tokens, each in its own cookie
+    if (federatedConnectionTokenSets?.length) {
+      await Promise.all(
+        federatedConnectionTokenSets.map((federatedConnectionTokenSet, index) =>
+          this.storeInCookie(
+            reqCookies,
+            resCookies,
+            federatedConnectionTokenSet,
+            `${this.federatedConnectionTokenSetsCookieName}_${index}`,
+            maxAge
+          )
+        )
       );
     }
   }
 
   async delete(
-    _reqCookies: cookies.RequestCookies,
+    reqCookies: cookies.RequestCookies,
     resCookies: cookies.ResponseCookies
   ) {
-    await resCookies.delete(this.sessionCookieName);
+    resCookies.delete(this.sessionCookieName);
+    this.getFederatedConnectionTokenSetsCookies(reqCookies).forEach((cookie) =>
+      resCookies.delete(cookie.name)
+    );
+  }
+
+  private async storeInCookie(
+    reqCookies: cookies.RequestCookies,
+    resCookies: cookies.ResponseCookies,
+    session: JWTPayload,
+    cookieName: string,
+    maxAge: number
+  ) {
+    const jwe = await cookies.encrypt(session, this.secret);
+
+    const cookieValue = jwe.toString();
+
+    resCookies.set(cookieName, jwe.toString(), {
+      ...this.cookieConfig,
+      maxAge
+    });
+    // to enable read-after-write in the same request for middleware
+    reqCookies.set(cookieName, cookieValue);
+
+    // check if the session cookie size exceeds 4096 bytes, and if so, log a warning
+    const cookieJarSizeTest = new cookies.ResponseCookies(new Headers());
+    cookieJarSizeTest.set(cookieName, cookieValue, {
+      ...this.cookieConfig,
+      maxAge
+    });
+
+    if (new TextEncoder().encode(cookieJarSizeTest.toString()).length >= 4096) {
+      // if the cookie is the session cookie, log a warning with additional information about the claims and user profile.
+      if (cookieName === this.sessionCookieName) {
+        console.warn(
+          `The ${cookieName} cookie size exceeds 4096 bytes, which may cause issues in some browsers. ` +
+            "Consider removing any unnecessary custom claims from the access token or the user profile. " +
+            "Alternatively, you can use a stateful session implementation to store the session data in a data store."
+        );
+      } else {
+        console.warn(
+          `The ${cookieName} cookie size exceeds 4096 bytes, which may cause issues in some browsers. ` +
+            "You can use a stateful session implementation to store the session data in a data store."
+        );
+      }
+      
+    }
+  }
+
+  private getFederatedConnectionTokenSetsCookies(
+    cookies: cookies.RequestCookies | cookies.ResponseCookies
+  ) {
+    return cookies
+      .getAll()
+      .filter((cookie) =>
+        cookie.name.startsWith(this.federatedConnectionTokenSetsCookieName)
+      );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,14 @@ export interface TokenSet {
   expiresAt: number; // the time at which the access token expires in seconds since epoch
 }
 
+export interface FederatedConnectionTokenSet {
+  accessToken: string;
+  scope?: string;
+  expiresAt: number; // the time at which the access token expires in seconds since epoch
+  connection: string;
+  [key: string]: unknown;
+}
+
 export interface SessionData {
   user: User;
   tokenSet: TokenSet;
@@ -14,6 +22,7 @@ export interface SessionData {
     // the time at which the session was created in seconds since epoch
     createdAt: number;
   };
+  federatedConnectionTokenSets?: FederatedConnectionTokenSet[];
   [key: string]: unknown;
 }
 
@@ -85,3 +94,18 @@ export type {
   TransactionStoreOptions,
   TransactionState
 } from "../server/transaction-store";
+
+/**
+ * Options for retrieving a federated connection access token.
+ */
+export interface GetFederatedConnectionAccessTokenOptions {
+  /**
+   * The connection name for while you want to retrieve the access token.
+   */
+  connection: string;
+
+  /**
+   * An optiona login hint to pass to the authorization server.
+   */
+  login_hint?: string;
+}


### PR DESCRIPTION
### 📋 Changes

This PR adds support for `getFederatedConnectionAccessToken({ connection: string; login_hint?: string })`, which can be used to obtain federated connection access token using the `oauth/token` endpoint.

In order to retrieve a federated connection access token, we call `oauth/token` using the following payload:

```
{
  "connection": "<connection(e.g. google-oauth2)>",
  "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
  "subject_token": "<refresh_token>",
  "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
  "client_id": "<client_id>",
  "client_secret": "<client_secret>",
  "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token"
}
```
The retrieved token will also be stored in the session store, comparable to regular session information.

Stateless
As the browser has a limit to the size of the cookie, each federated connection access token is stored in its own cookie, using the` __FC_{index}` name.

image

When an application needs to us many access tokens, it's recommended to consider using a stateful session store.

Stateful
For the stateful session store, nothing changes other than the fact that the provided SessionData, now has an additional federatedConnectionTokenSets property, being either undefined, or an array of `FederatedConnectionTokenSet`.

Just like `getAccessToken()`, the newly added `getFederatedConnectionAccessToken()` can not write to the cookies when called from a Server Component, and will log a warning when either of these two methods are called from such Server Component.

📎 References
N/A

🎯 Testing
I have tested this against the only environment that has the feature enabled, and I ensured the following scenario's:

When not logged in, calling `getFederatedConnectionAccessToken` throws the `MISSING_REFRESH_TOKEN` error.
When logged in, and no Federated Connection Access Token is in the cache, a call to `oauth/token` is mad, the resulting access token is stored in the stateless or stateful session store and returned.
When logged in, and a non expired Federated Connection Access token is in the cache, no call to `oauth/token` is made, and the access token from the cache is returned.
When logged in, and an expired Federated Connection Access token is in the cache, a call to `oauth/token` is mad, the resulting access token is stored in the stateless or stateful session store and returned.
When logging out, the `__FC cookies` are also removed.