### PR TITLE
fix: read and migrate v3 session format to v4

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -440,7 +440,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         // assert session has been updated
         const updatedSessionCookie = response.cookies.get("__session");
         expect(updatedSessionCookie).toBeDefined();
-        const updatedSessionCookieValue = await decrypt(
+        const { payload: updatedSessionCookieValue } = await decrypt(
           updatedSessionCookie!.value,
           secret
         );
@@ -795,13 +795,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         `__txn_${authorizationUrl.searchParams.get("state")}`
       );
       expect(transactionCookie).toBeDefined();
-      expect(await decrypt(transactionCookie!.value, secret)).toEqual({
-        nonce: authorizationUrl.searchParams.get("nonce"),
-        codeVerifier: expect.any(String),
-        responseType: "code",
-        state: authorizationUrl.searchParams.get("state"),
-        returnTo: "/"
-      });
+      expect((await decrypt(transactionCookie!.value, secret)).payload).toEqual(
+        {
+          nonce: authorizationUrl.searchParams.get("nonce"),
+          codeVerifier: expect.any(String),
+          responseType: "code",
+          state: authorizationUrl.searchParams.get("state"),
+          returnTo: "/"
+        }
+      );
     });
 
     it("should return an error if the discovery endpoint could not be fetched", async () => {
@@ -911,7 +913,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
           `__txn_${authorizationUrl.searchParams.get("state")}`
         );
         expect(transactionCookie).toBeDefined();
-        expect(await decrypt(transactionCookie!.value, secret)).toEqual({
+        expect(
+          (await decrypt(transactionCookie!.value, secret)).payload
+        ).toEqual({
           nonce: authorizationUrl.searchParams.get("nonce"),
           codeVerifier: expect.any(String),
           responseType: "code",
@@ -1243,14 +1247,16 @@ ca/T0LLtgmbMmxSv/MmzIg==
         `__txn_${authorizationUrl.searchParams.get("state")}`
       );
       expect(transactionCookie).toBeDefined();
-      expect(await decrypt(transactionCookie!.value, secret)).toEqual({
-        nonce: authorizationUrl.searchParams.get("nonce"),
-        maxAge: 3600,
-        codeVerifier: expect.any(String),
-        responseType: "code",
-        state: authorizationUrl.searchParams.get("state"),
-        returnTo: "/"
-      });
+      expect((await decrypt(transactionCookie!.value, secret)).payload).toEqual(
+        {
+          nonce: authorizationUrl.searchParams.get("nonce"),
+          maxAge: 3600,
+          codeVerifier: expect.any(String),
+          responseType: "code",
+          state: authorizationUrl.searchParams.get("state"),
+          returnTo: "/"
+        }
+      );
     });
 
     it("should store the returnTo path in the transaction state", async () => {
@@ -1288,13 +1294,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         `__txn_${authorizationUrl.searchParams.get("state")}`
       );
       expect(transactionCookie).toBeDefined();
-      expect(await decrypt(transactionCookie!.value, secret)).toEqual({
-        nonce: authorizationUrl.searchParams.get("nonce"),
-        codeVerifier: expect.any(String),
-        responseType: "code",
-        state: authorizationUrl.searchParams.get("state"),
-        returnTo: "https://example.com/dashboard"
-      });
+      expect((await decrypt(transactionCookie!.value, secret)).payload).toEqual(
+        {
+          nonce: authorizationUrl.searchParams.get("nonce"),
+          codeVerifier: expect.any(String),
+          responseType: "code",
+          state: authorizationUrl.searchParams.get("state"),
+          returnTo: "https://example.com/dashboard"
+        }
+      );
     });
 
     it("should prevent open redirects originating from the returnTo parameter", async () => {
@@ -1332,13 +1340,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         `__txn_${authorizationUrl.searchParams.get("state")}`
       );
       expect(transactionCookie).toBeDefined();
-      expect(await decrypt(transactionCookie!.value, secret)).toEqual({
-        nonce: authorizationUrl.searchParams.get("nonce"),
-        codeVerifier: expect.any(String),
-        responseType: "code",
-        state: authorizationUrl.searchParams.get("state"),
-        returnTo: "/"
-      });
+      expect((await decrypt(transactionCookie!.value, secret)).payload).toEqual(
+        {
+          nonce: authorizationUrl.searchParams.get("nonce"),
+          codeVerifier: expect.any(String),
+          responseType: "code",
+          state: authorizationUrl.searchParams.get("state"),
+          returnTo: "/"
+        }
+      );
     });
 
     describe("with pushed authorization requests", async () => {
@@ -1463,7 +1473,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
         const transactionCookie = transactionCookies[0];
         const state = transactionCookie.name.replace("__txn_", "");
         expect(transactionCookie).toBeDefined();
-        expect(await decrypt(transactionCookie!.value, secret)).toEqual({
+        expect(
+          (await decrypt(transactionCookie!.value, secret)).payload
+        ).toEqual({
           nonce: expect.any(String),
           codeVerifier: expect.any(String),
           responseType: "code",
@@ -1540,7 +1552,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
           const transactionCookie = transactionCookies[0];
           const state = transactionCookie.name.replace("__txn_", "");
           expect(transactionCookie).toBeDefined();
-          expect(await decrypt(transactionCookie!.value, secret)).toEqual({
+          expect(
+            (await decrypt(transactionCookie!.value, secret)).payload
+          ).toEqual({
             nonce: expect.any(String),
             codeVerifier: expect.any(String),
             responseType: "code",
@@ -1618,7 +1632,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
           const transactionCookie = transactionCookies[0];
           const state = transactionCookie.name.replace("__txn_", "");
           expect(transactionCookie).toBeDefined();
-          expect(await decrypt(transactionCookie!.value, secret)).toEqual({
+          expect(
+            (await decrypt(transactionCookie!.value, secret)).payload
+          ).toEqual({
             nonce: expect.any(String),
             codeVerifier: expect.any(String),
             responseType: "code",
@@ -2122,7 +2138,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // validate the session cookie
       const sessionCookie = response.cookies.get("__session");
       expect(sessionCookie).toBeDefined();
-      const session = await decrypt(sessionCookie!.value, secret);
+      const { payload: session } = await decrypt(sessionCookie!.value, secret);
       expect(session).toEqual({
         user: {
           sub: DEFAULT.sub
@@ -2230,7 +2246,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // validate the session cookie
       const sessionCookie = response.cookies.get("__session");
       expect(sessionCookie).toBeDefined();
-      const session = await decrypt(sessionCookie!.value, secret);
+      const { payload: session } = await decrypt(sessionCookie!.value, secret);
       expect(session).toEqual({
         user: {
           sub: DEFAULT.sub
@@ -2601,7 +2617,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         // validate the session cookie
         const sessionCookie = response.cookies.get("__session");
         expect(sessionCookie).toBeDefined();
-        const session = await decrypt(sessionCookie!.value, secret);
+        const { payload: session } = await decrypt(
+          sessionCookie!.value,
+          secret
+        );
         expect(session).toEqual(expectedSession);
       });
 
@@ -3051,7 +3070,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         // validate the session cookie
         const sessionCookie = response.cookies.get("__session");
         expect(sessionCookie).toBeDefined();
-        const session = await decrypt(sessionCookie!.value, secret);
+        const { payload: session } = await decrypt(
+          sessionCookie!.value,
+          secret
+        );
         expect(session).toEqual({
           user: {
             sub: DEFAULT.sub,
@@ -3177,7 +3199,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         // validate the session cookie
         const sessionCookie = response.cookies.get("__session");
         expect(sessionCookie).toBeDefined();
-        const session = await decrypt(sessionCookie!.value, secret);
+        const { payload: session } = await decrypt(
+          sessionCookie!.value,
+          secret
+        );
         expect(session).toEqual({
           user: {
             sub: DEFAULT.sub,
@@ -3273,7 +3298,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
 
       // validate that the session cookie has been updated
       const updatedSessionCookie = response.cookies.get("__session");
-      const updatedSession = await decrypt<SessionData>(
+      const { payload: updatedSession } = await decrypt<SessionData>(
         updatedSessionCookie!.value,
         secret
       );

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -390,14 +390,15 @@ export class AuthClient {
       return this.onCallback(new MissingStateError(), {}, null);
     }
 
-    const transactionState = await this.transactionStore.get(
+    const transactionStateCookie = await this.transactionStore.get(
       req.cookies,
       state
     );
-    if (!transactionState) {
+    if (!transactionStateCookie) {
       return this.onCallback(new InvalidStateError(), {}, null);
     }
 
+    const transactionState = transactionStateCookie.payload;
     const onCallbackCtx: OnCallbackContext = {
       returnTo: transactionState.returnTo
     };

--- a/src/server/cookies.test.ts
+++ b/src/server/cookies.test.ts
@@ -12,7 +12,7 @@ describe("encrypt/decrypt", async () => {
     const encrypted = await encrypt(payload, secret);
     const decrypted = await decrypt(encrypted, secret);
 
-    expect(decrypted).toEqual(payload);
+    expect(decrypted.payload).toEqual(payload);
   });
 
   it("should fail to decrypt a payload with the incorrect secret", async () => {

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -46,9 +46,17 @@ export async function decrypt<T>(cookieValue: string, secret: string) {
   return cookie;
 }
 
+/**
+ * Derive a signing key from a given secret.
+ * This method is used solely to migrate signed, legacy cookies to the new encrypted cookie format (v4+).
+ */
 const signingSecret = (secret: string): Promise<Uint8Array> =>
   hkdf("sha256", secret, "", "JWS Cookie Signing", BYTE_LENGTH);
 
+/**
+ * Verify a signed cookie. If the cookie is valid, the value is returned. Otherwise, undefined is returned.
+ * This method is used solely to migrate signed, legacy cookies to the new encrypted cookie format (v4+).
+ */
 export async function verifySigned(
   k: string,
   v: string,
@@ -77,6 +85,10 @@ export async function verifySigned(
   }
 }
 
+/**
+ * Sign a cookie value using a secret.
+ * This method is used solely to migrate signed, legacy cookies to the new encrypted cookie format (v4+).
+ */
 export async function sign(
   name: string,
   value: string,

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -8,7 +8,15 @@ const DIGEST = "sha256";
 const BYTE_LENGTH = 32;
 const ENCRYPTION_INFO = "JWE CEK";
 
-export async function encrypt(payload: jose.JWTPayload, secret: string) {
+export async function encrypt(
+  payload: jose.JWTPayload,
+  secret: string,
+  additionalHeaders?: {
+    iat: number;
+    uat: number;
+    exp: number;
+  }
+) {
   const encryptionSecret = await hkdf(
     DIGEST,
     secret,
@@ -18,7 +26,7 @@ export async function encrypt(payload: jose.JWTPayload, secret: string) {
   );
 
   const encryptedCookie = await new jose.EncryptJWT(payload)
-    .setProtectedHeader({ enc: ENC, alg: ALG })
+    .setProtectedHeader({ enc: ENC, alg: ALG, ...additionalHeaders })
     .encrypt(encryptionSecret);
 
   return encryptedCookie.toString();
@@ -35,7 +43,52 @@ export async function decrypt<T>(cookieValue: string, secret: string) {
 
   const cookie = await jose.jwtDecrypt<T>(cookieValue, encryptionSecret, {});
 
-  return cookie.payload;
+  return cookie;
+}
+
+const signingSecret = (secret: string): Promise<Uint8Array> =>
+  hkdf("sha256", secret, "", "JWS Cookie Signing", BYTE_LENGTH);
+
+export async function verifySigned(
+  k: string,
+  v: string,
+  secret: string
+): Promise<string | undefined> {
+  if (!v) {
+    return undefined;
+  }
+  const [value, signature] = v.split(".");
+  const flattenedJWS = {
+    protected: jose.base64url.encode(
+      JSON.stringify({ alg: "HS256", b64: false, crit: ["b64"] })
+    ),
+    payload: `${k}=${value}`,
+    signature
+  };
+  const key = await signingSecret(secret);
+
+  try {
+    await jose.flattenedVerify(flattenedJWS, key, {
+      algorithms: ["HS256"]
+    });
+    return value;
+  } catch (e) {
+    return undefined;
+  }
+}
+
+export async function sign(
+  name: string,
+  value: string,
+  secret: string
+): Promise<string> {
+  const key = await signingSecret(secret);
+  const { signature } = await new jose.FlattenedSign(
+    new TextEncoder().encode(`${name}=${value}`)
+  )
+    .setProtectedHeader({ alg: "HS256", b64: false, crit: ["b64"] })
+    .sign(key);
+  return `${value}.${signature}`;
 }
 
 export interface CookieOptions {

--- a/src/server/session/normalize-session.ts
+++ b/src/server/session/normalize-session.ts
@@ -1,0 +1,136 @@
+import { JWTDecryptResult } from "jose";
+
+import { SessionData } from "../../types";
+
+export const LEGACY_COOKIE_NAME = "appSession";
+
+/**
+ * Key-value store for the user's claims.
+ */
+interface LegacyClaims {
+  [key: string]: any;
+}
+
+/**
+ * The user's session.
+ */
+export class LegacySession {
+  /**
+   * Any of the claims from the `id_token`.
+   */
+  user: LegacyClaims;
+
+  /**
+   * The ID token.
+   */
+  idToken?: string | undefined;
+
+  /**
+   * The access token.
+   */
+  accessToken?: string | undefined;
+
+  /**
+   * The access token scopes.
+   */
+  accessTokenScope?: string | undefined;
+
+  /**
+   * The expiration of the access token.
+   */
+  accessTokenExpiresAt?: number;
+
+  /**
+   * The refresh token, which is used to request a new access token.
+   *
+   * **IMPORTANT** You need to request the `offline_access` scope on login to get a refresh token
+   * from Auth0.
+   */
+  refreshToken?: string | undefined;
+
+  [key: string]: any;
+
+  constructor(user: LegacyClaims) {
+    this.user = user;
+  }
+}
+
+/**
+ * The legacy headers of the session.
+ */
+interface LegacyHeaders {
+  /**
+   * Timestamp (in secs) when the session was created.
+   */
+  iat: number;
+  /**
+   * Timestamp (in secs) when the session was last touched.
+   */
+  uat: number;
+  /**
+   * Timestamp (in secs) when the session expires.
+   */
+  exp: number;
+}
+
+export interface LegacySessionPayload {
+  /**
+   * The session header.
+   */
+  header: LegacyHeaders;
+
+  /**
+   * The session data.
+   */
+  data: LegacySession;
+}
+
+export function normalizeStatelessSession(
+  sessionCookie: JWTDecryptResult<LegacySessionPayload | SessionData>
+) {
+  // if the session cookie has an `iat` claim in the protected header, it's a legacy cookie
+  // otherwise, it's the new session cookie format and no transformation is needed
+  if (sessionCookie.protectedHeader.iat) {
+    const legacySession = sessionCookie as JWTDecryptResult<LegacySession>;
+    return convertFromLegacy(
+      legacySession.protectedHeader,
+      legacySession.payload
+    );
+  }
+
+  return sessionCookie.payload as SessionData;
+}
+
+export function normalizeStatefulSession(
+  sessionData: SessionData | LegacySessionPayload
+) {
+  if ((sessionData.header as LegacyHeaders | undefined)?.iat) {
+    const legacySession = sessionData as LegacySessionPayload;
+    return convertFromLegacy(legacySession.header, legacySession.data);
+  }
+
+  return sessionData as SessionData;
+}
+
+function convertFromLegacy(
+  header:
+    | LegacyHeaders
+    | JWTDecryptResult<LegacySessionPayload>["protectedHeader"],
+  session: LegacySession
+) {
+  const userClaims = session.user as LegacyClaims;
+
+  return {
+    user: userClaims,
+    tokenSet: {
+      accessToken: (session.accessToken as string) ?? undefined,
+      scope: session.accessTokenScope as string | undefined,
+      refreshToken: session.refreshToken as string | undefined,
+      expiresAt: session.accessTokenExpiresAt as number
+    },
+    internal: {
+      sid: userClaims.sid,
+      createdAt: header.iat
+    }
+  } as SessionData;
+}

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -66,6 +66,10 @@ export class StatefulSessionStore extends AbstractSessionStore {
       return null;
     }
 
+    // we attempt to extract the session ID by decrypting the cookie value (assuming it's a JWE, v4+) first
+    // if that fails, we attempt to verify the cookie value as a signed cookie (legacy, v3-)
+    // if both fail, we return null
+    // this ensures that v3 sessions are respected and can be transparently rolled over to v4+ sessions
     let sessionId: string | null = null;
     try {
       const { payload: sessionCookie } =

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -30,9 +30,9 @@ describe("Transaction Store", async () => {
         secret
       });
 
-      expect(await transactionStore.get(requestCookies, state)).toEqual(
-        transactionState
-      );
+      expect(
+        (await transactionStore.get(requestCookies, state))?.payload
+      ).toEqual(transactionState);
     });
 
     it("should return null if no transaction cookie with a matching state exists", async () => {
@@ -88,7 +88,9 @@ describe("Transaction Store", async () => {
       const cookie = responseCookies.get(cookieName);
 
       expect(cookie).toBeDefined();
-      expect(await decrypt(cookie!.value, secret)).toEqual(transactionState);
+      expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+        transactionState
+      );
       expect(cookie?.path).toEqual("/");
       expect(cookie?.httpOnly).toEqual(true);
       expect(cookie?.sameSite).toEqual("lax");
@@ -149,7 +151,9 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect(await decrypt(cookie!.value, secret)).toEqual(transactionState);
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          transactionState
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");
@@ -185,7 +189,9 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect(await decrypt(cookie!.value, secret)).toEqual(transactionState);
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          transactionState
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("strict");
@@ -221,7 +227,9 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect(await decrypt(cookie!.value, secret)).toEqual(transactionState);
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          transactionState
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");

--- a/src/testing/generate-session-cookie.test.ts
+++ b/src/testing/generate-session-cookie.test.ts
@@ -29,7 +29,7 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect(await decrypt(sessionCookie, secret)).toEqual({
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual({
       user: {
         sub: "user_123"
       },
@@ -60,7 +60,7 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect(await decrypt(sessionCookie, secret)).toEqual({
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual({
       user: {
         sub: "user_123"
       },
@@ -93,7 +93,7 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect(await decrypt(sessionCookie, secret)).toEqual({
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual({
       user: {
         sub: "user_123"
       },
@@ -122,7 +122,7 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect(await decrypt(sessionCookie, secret)).toEqual({
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual({
       user: {
         sub: "user_123"
       },


### PR DESCRIPTION
### 📋 Changes

When migrating from v3 to v4 of the SDK, the session format and cookie names differ. This results in the SDK not recognizing that the user has a session and treating them as logged-out.

This PR adds support for reading the v3 session format in both stateless and stateful modes and normalizes them to the v4 format. This ensures that users with existing sessions will be respected in v4.

### 📎 References

- fixes: https://github.com/auth0/nextjs-auth0/issues/1894

### 🎯 Testing

- Unit tests have been added for both stateful and stateless modes
- Manual tests were run by following the reproduction steps in the referenced issue above to confirm that v3 sessions are smoothly migrated (both stateful and stateless modes)
- Custom cookie names were also tested to ensure they are recognized and migrated
