### PR TITLE
Add ID Token to TokenSet

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -2146,6 +2146,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         tokenSet: {
           accessToken: DEFAULT.accessToken,
           refreshToken: DEFAULT.refreshToken,
+          idToken: expect.stringMatching(/^eyJhbGciOiJSUzI1NiJ9\..+\..+$/),
           expiresAt: expect.any(Number)
         },
         internal: {
@@ -2253,6 +2254,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         },
         tokenSet: {
           accessToken: DEFAULT.accessToken,
+          idToken: expect.any(String),
           refreshToken: DEFAULT.refreshToken,
           expiresAt: expect.any(Number)
         },
@@ -2597,6 +2599,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           tokenSet: {
             accessToken: DEFAULT.accessToken,
             refreshToken: DEFAULT.refreshToken,
+            idToken: expect.any(String),
             expiresAt: expect.any(Number)
           },
           internal: {
@@ -2990,6 +2993,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
             tokenSet: {
               accessToken: DEFAULT.accessToken,
               refreshToken: DEFAULT.refreshToken,
+              idToken: expect.any(String),
               expiresAt: expect.any(Number)
             },
             internal: {
@@ -3084,6 +3088,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           tokenSet: {
             accessToken: DEFAULT.accessToken,
             refreshToken: DEFAULT.refreshToken,
+            idToken: expect.any(String),
             expiresAt: expect.any(Number)
           },
           internal: {
@@ -3213,6 +3218,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           tokenSet: {
             accessToken: DEFAULT.accessToken,
             refreshToken: DEFAULT.refreshToken,
+            idToken: expect.any(String),
             expiresAt: expect.any(Number)
           },
           internal: {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -476,6 +476,7 @@ export class AuthClient {
       user: idTokenClaims,
       tokenSet: {
         accessToken: oidcRes.access_token,
+        idToken: oidcRes.id_token,
         scope: oidcRes.scope,
         refreshToken: oidcRes.refresh_token,
         expiresAt: Math.floor(Date.now() / 1000) + Number(oidcRes.expires_in)
@@ -551,7 +552,6 @@ export class AuthClient {
         }
       );
     }
-
     const res = NextResponse.json({
       token: updatedTokenSet.accessToken,
       scope: updatedTokenSet.scope,
@@ -670,6 +670,7 @@ export class AuthClient {
       const updatedTokenSet = {
         ...tokenSet, // contains the existing `iat` claim to maintain the session lifetime
         accessToken: oauthRes.access_token,
+        idToken: oauthRes.id_token,
         expiresAt: accessTokenExpiresAt
       };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export interface TokenSet {
   accessToken: string;
+  idToken?: string;
   scope?: string;
   refreshToken?: string;
   expiresAt: number; // the time at which the access token expires in seconds since epoch


### PR DESCRIPTION

### 📋 Changes

In v3, the ID Token was exposed in the session. In v4, although the ID Token claim is stored in SessionData, the actual ID Token is no longer exposed. This pull request reintroduces the ID Token to the session.

### 📎 References

*(None)*

### 🎯 Testing

A unit test has been added to verify that the ID Token provided by the authorization server is correctly stored in the session store.
