### PR TITLE
fix,refactor: use a single client assertion audience (v3.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "debug": "^4.3.4",
         "joi": "^17.6.0",
         "jose": "^4.9.2",
-        "oauth4webapi": "^2.3.0",
-        "openid-client": "^5.2.1",
+        "oauth4webapi": "^2.17.0",
+        "openid-client": "^5.7.1",
         "tslib": "^2.4.0",
         "url-join": "^4.0.1"
       },
@@ -10282,9 +10282,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
-      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -11462,9 +11463,10 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.4.0.tgz",
-      "integrity": "sha512-ZWl8ov8HeGVyc9Icl1cag76HvIcDAp23eIIT+UVGir+dEu8BMgMlvZeZwqLVd0P8DqaumH4N+QLQXN69G1QjSA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -11708,11 +11710,12 @@
       "dev": true
     },
     "node_modules/openid-client": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
-      "integrity": "sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.1",
+        "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
@@ -23025,9 +23028,9 @@
       }
     },
     "jose": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
-      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ=="
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
     },
     "js-message": {
       "version": "1.0.5",
@@ -23929,9 +23932,9 @@
       "dev": true
     },
     "oauth4webapi": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.4.0.tgz",
-      "integrity": "sha512-ZWl8ov8HeGVyc9Icl1cag76HvIcDAp23eIIT+UVGir+dEu8BMgMlvZeZwqLVd0P8DqaumH4N+QLQXN69G1QjSA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -24106,11 +24109,11 @@
       "dev": true
     },
     "openid-client": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
-      "integrity": "sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "requires": {
-        "jose": "^4.15.1",
+        "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "debug": "^4.3.4",
     "joi": "^17.6.0",
     "jose": "^4.9.2",
-    "oauth4webapi": "^2.3.0",
-    "openid-client": "^5.2.1",
+    "oauth4webapi": "^2.17.0",
+    "openid-client": "^5.7.1",
     "tslib": "^2.4.0",
     "url-join": "^4.0.1"
   },

--- a/src/auth0-session/client/edge-client.ts
+++ b/src/auth0-session/client/edge-client.ts
@@ -96,7 +96,25 @@ export class EdgeClient extends AbstractClient {
     const [as, client] = await this.getClient();
 
     if (this.config.pushedAuthorizationRequests) {
-      const response = await oauth.pushedAuthorizationRequest(as, client, parameters as Record<string, string>);
+      const { clientAssertionSigningKey, clientAssertionSigningAlg } = this.config;
+
+      let clientPrivateKey = clientAssertionSigningKey as CryptoKey | undefined;
+      /* c8 ignore next 3 */
+      if (clientPrivateKey && !(clientPrivateKey instanceof CryptoKey)) {
+        clientPrivateKey = await jose.importPKCS8<CryptoKey>(clientPrivateKey, clientAssertionSigningAlg || 'RS256');
+      }
+
+      const response = await oauth.pushedAuthorizationRequest(as, client, parameters as Record<string, string>, {
+        ...(clientPrivateKey && {
+          clientPrivateKey,
+          [oauth.modifyAssertion](_header: Record<string, oauth.JsonValue>, payload: Record<string, oauth.JsonValue>) {
+            if (Array.isArray(payload.aud)) {
+              payload.aud = as.issuer;
+            }
+          }
+        }),
+        ...this.httpOptions()
+      });
       const result = await oauth.processPushedAuthorizationResponse(as, client, response);
       if (oauth.isOAuth2Error(result)) {
         throw new IdentityProviderError({
@@ -163,7 +181,14 @@ export class EdgeClient extends AbstractClient {
       checks.code_verifier as string,
       {
         additionalParameters: extras.exchangeBody,
-        ...(clientPrivateKey && { clientPrivateKey }),
+        ...(clientPrivateKey && {
+          clientPrivateKey,
+          [oauth.modifyAssertion](_header: Record<string, oauth.JsonValue>, payload: Record<string, oauth.JsonValue>) {
+            if (Array.isArray(payload.aud)) {
+              payload.aud = as.issuer;
+            }
+          }
+        }),
         ...this.httpOptions()
       }
     );
@@ -233,8 +258,25 @@ export class EdgeClient extends AbstractClient {
 
   async refresh(refreshToken: string, extras: { exchangeBody: Record<string, any> }): Promise<TokenEndpointResponse> {
     const [as, client] = await this.getClient();
+
+    const { clientAssertionSigningKey, clientAssertionSigningAlg } = this.config;
+
+    let clientPrivateKey = clientAssertionSigningKey as CryptoKey | undefined;
+    /* c8 ignore next 3 */
+    if (clientPrivateKey && !(clientPrivateKey instanceof CryptoKey)) {
+      clientPrivateKey = await jose.importPKCS8<CryptoKey>(clientPrivateKey, clientAssertionSigningAlg || 'RS256');
+    }
+
     const res = await oauth.refreshTokenGrantRequest(as, client, refreshToken, {
       additionalParameters: extras.exchangeBody,
+      ...(clientPrivateKey && {
+        clientPrivateKey,
+        [oauth.modifyAssertion](_header: Record<string, oauth.JsonValue>, payload: Record<string, oauth.JsonValue>) {
+          if (Array.isArray(payload.aud)) {
+            payload.aud = as.issuer;
+          }
+        }
+      }),
       ...this.httpOptions()
     });
     const result = await oauth.processRefreshTokenResponse(as, client, res);


### PR DESCRIPTION
This PR updates v3.x

- it fixes the edge-client to properly authenticate using Private Key JWT Client Authentication during PAR and Refresh Token requests
- it fixes the edge-client to apply the httpSettings to PAR requests
- it updates the edge-client's JWT Client Authentication assertion to use a single string audience (the issuer identifier)
- it updates the node-client's JWT Client Authentication assertion to use a single string audience (the issuer identifier), this is done by bumping the required openid-client version within (within the same semver major constraints)