### PR TITLE
fix: stop importing named export from package.json

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import * as jose from "jose";
 import * as oauth from "oauth4webapi";
 
-import { version } from "../../package.json";
+import packageJson from "../../package.json";
 import {
   AccessTokenError,
   AccessTokenErrorCode,
@@ -155,6 +155,7 @@ export class AuthClient {
       const timeout = options.httpTimeout ?? 5000;
       if (enableTelemetry) {
         const name = "nextjs-auth0";
+        const version = packageJson.version;
 
         headers.set("User-Agent", `${name}/${version}`);
         headers.set(


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Importing the `version` named export from package.json caused errors during webpack builds for apps using this package (#1955). Instead, this imports the default export as `packageJson`, and then gets the version with `packageJson.version`.

### 📎 References

- #1955

### 🎯 Testing

See [this comment](https://github.com/auth0/nextjs-auth0/issues/1955#issuecomment-2719550444) for how to reproduce the warning with version 4.0.3 of nextjs-auth0. After these changes, the warning should no longer occur.
