### PR TITLE
fix: stop importing named export from package.json

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import * as jose from "jose";
 import * as oauth from "oauth4webapi";
 
-import { version } from "../../package.json";
+import packageJson from "../../package.json";
 import {
   AccessTokenError,
   AccessTokenErrorCode,
@@ -155,6 +155,7 @@ export class AuthClient {
       const timeout = options.httpTimeout ?? 5000;
       if (enableTelemetry) {
         const name = "nextjs-auth0";
+        const version = packageJson.version;
 
         headers.set("User-Agent", `${name}/${version}`);
         headers.set(


### PR DESCRIPTION
Duplicate of #1960, thanks @mogzol 

Importing the 'version' named export from package.json caused errors
during webpack builds for apps using this package (#1955). Instead,
this imports the default export as 'packageJson', and then gets the
version with 'packageJson.version'.

_Tests: PASSING
Build: PASSING_
