### PR TITLE
feat: pass along oauth2 error when fcat exchange fails

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -128,16 +128,19 @@ export class AccessTokenForConnectionError extends SdkError {
    * The error code associated with the access token error.
    */
   public code: string;
+  public cause?: OAuth2Error;
 
   /**
    * Constructs a new `AccessTokenForConnectionError` instance.
    *
    * @param code - The error code.
    * @param message - The error message.
+   * @param cause - The OAuth2 cause of the error.
    */
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, cause?: OAuth2Error) {
     super(message);
     this.name = "AccessTokenForConnectionError";
     this.code = code;
+    this.cause = cause;
   }
 }

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -56,6 +56,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
 
   function getMockAuthorizationServer({
     tokenEndpointResponse,
+    tokenEndpointErrorResponse,
     discoveryResponse,
     audience,
     nonce,
@@ -63,6 +64,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
     onParRequest
   }: {
     tokenEndpointResponse?: oauth.TokenEndpointResponse | oauth.OAuth2Error;
+    tokenEndpointErrorResponse?: oauth.OAuth2Error;
     discoveryResponse?: Response;
     audience?: string;
     nonce?: string;
@@ -96,6 +98,12 @@ ca/T0LLtgmbMmxSv/MmzIg==
             .setAudience(audience ?? DEFAULT.clientId)
             .setExpirationTime("2h")
             .sign(keyPair.privateKey);
+
+          if (tokenEndpointErrorResponse) {
+            return Response.json(tokenEndpointErrorResponse, {
+              status: 400
+            });
+          }
           return Response.json(
             tokenEndpointResponse ?? {
               token_type: "Bearer",
@@ -4154,7 +4162,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
     });
   });
 
-  describe("getonnectionTokenSet", async () => {
+  describe("getConnectionTokenSet", async () => {
     it("should call for an access token when no connection token set in the session", async () => {
       const secret = await generateSecret(32);
       const transactionStore = new TransactionStore({
@@ -4234,18 +4242,22 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const tokenSet = {
         accessToken: DEFAULT.accessToken,
         refreshToken: DEFAULT.refreshToken,
-        expiresAt,
+        expiresAt
       };
 
       const response = await authClient.getConnectionTokenSet(
         tokenSet,
-        { connection: 'google-oauth2', accessToken: 'fc_at', expiresAt: Math.floor(Date.now() / 1000) + 86400 },
+        {
+          connection: "google-oauth2",
+          accessToken: "fc_at",
+          expiresAt: Math.floor(Date.now() / 1000) + 86400
+        },
         { connection: "google-oauth2", login_hint: "000100123" }
       );
       const [error, connectionTokenSet] = response;
       expect(error).toBe(null);
       expect(connectionTokenSet).toEqual({
-        accessToken: 'fc_at',
+        accessToken: "fc_at",
         connection: "google-oauth2",
         expiresAt: expect.any(Number)
       });
@@ -4285,12 +4297,12 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const tokenSet = {
         accessToken: DEFAULT.accessToken,
         refreshToken: DEFAULT.refreshToken,
-        expiresAt,
+        expiresAt
       };
 
       const response = await authClient.getConnectionTokenSet(
         tokenSet,
-        { connection: 'google-oauth2', accessToken: 'fc_at', expiresAt },
+        { connection: "google-oauth2", accessToken: "fc_at", expiresAt },
         { connection: "google-oauth2", login_hint: "000100123" }
       );
       const [error, connectionTokenSet] = response;
@@ -4375,6 +4387,50 @@ ca/T0LLtgmbMmxSv/MmzIg==
           connection: "google-oauth2"
         });
       expect(error?.code).toEqual("missing_refresh_token");
+      expect(connectionTokenSet).toBeNull();
+    });
+
+    it("should return an error and capture it as the cause when exchange failed", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({
+        secret
+      });
+      const sessionStore = new StatelessSessionStore({
+        secret
+      });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+
+        fetch: getMockAuthorizationServer({
+          tokenEndpointErrorResponse: {
+            error: "some-error-code",
+            error_description: "some-error-description"
+          }
+        })
+      });
+
+      const expiresAt = Math.floor(Date.now() / 1000) - 10 * 24 * 60 * 60; // expired 10 days ago
+      const tokenSet = {
+        accessToken: DEFAULT.accessToken,
+        refreshToken: DEFAULT.refreshToken,
+        expiresAt
+      };
+
+      const [error, connectionTokenSet] =
+        await authClient.getConnectionTokenSet(tokenSet, undefined, {
+          connection: "google-oauth2"
+        });
+      expect(error?.code).toEqual("failed_to_exchange_refresh_token");
+      expect(error?.cause?.code).toEqual("some-error-code");
+      expect(error?.cause?.message).toEqual("some-error-description");
       expect(connectionTokenSet).toBeNull();
     });
   });

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -982,8 +982,8 @@ export class AuthClient {
    * Then, it constructs the necessary parameters for the token exchange request and performs
    * the request to the authorization server's token endpoint.
    *
-   * @returns {Promise<[SdkError, null] | [null, ConnectionTokenSet]>} A promise that resolves to a tuple.
-   *          The first element is either an `SdkError` if an error occurred, or `null` if the request was successful.
+   * @returns {Promise<[AccessTokenForConnectionError, null] | [null, ConnectionTokenSet]>} A promise that resolves to a tuple.
+   *          The first element is either an `AccessTokenForConnectionError` if an error occurred, or `null` if the request was successful.
    *          The second element is either `null` if an error occurred, or a `ConnectionTokenSet` object
    *          containing the access token, expiration time, and scope if the request was successful.
    *
@@ -993,7 +993,7 @@ export class AuthClient {
     tokenSet: TokenSet,
     connectionTokenSet: ConnectionTokenSet | undefined,
     options: AccessTokenForConnectionOptions
-  ): Promise<[SdkError, null] | [null, ConnectionTokenSet]> {
+  ): Promise<[AccessTokenForConnectionError, null] | [null, ConnectionTokenSet]> {
     // If we do not have a refresh token
     // and we do not have a connection token set in the cache or the one we have is expired,
     // there is noting to retrieve and we return an error.
@@ -1005,7 +1005,7 @@ export class AuthClient {
       return [
         new AccessTokenForConnectionError(
           AccessTokenForConnectionErrorCode.MISSING_REFRESH_TOKEN,
-          "A refresh token was not present, Connection Access Token requires a refresh token. The user needs to re-authenticate."
+          "A refresh token was not present, Connection Access Token requires a refresh token. The user needs to re-authenticate.",
         ),
         null
       ];
@@ -1060,12 +1060,16 @@ export class AuthClient {
           this.clientMetadata,
           httpResponse
         );
-      } catch (err) {
+      } catch (err: any) {
         console.error(err);
         return [
           new AccessTokenForConnectionError(
             AccessTokenForConnectionErrorCode.FAILED_TO_EXCHANGE,
-            "There was an error trying to exchange the refresh token for a connection access token. Check the server logs for more information."
+            "There was an error trying to exchange the refresh token for a connection access token. Check the server logs for more information.",
+            new OAuth2Error({
+              code: err.error,
+              message: err.error_description
+            })
           ),
           null
         ];


### PR DESCRIPTION
### 📋 Changes

Ensuring to OAuth2 Error is correctly propagated when calling `getAccessTokenForConnection`.

### 📎 References


### 🎯 Testing

Try and exchange a FCAT token in the test app, and catch any error:

```ts
try {
  const token = await auth0.getAccessTokenForConnection({ connection: 'google-oauth2' });
} catch(e: any) {
  console.log(e.cause);
}
```
