### PR TITLE
Update Release workflow to use v3 tag

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -44,7 +44,7 @@ runs:
         elif [[ "${VERSION}" == *"alpha"* ]]; then
           TAG="alpha"
         else
-          TAG="latest"
+          TAG="v3"
         fi
         npm publish --provenance --tag $TAG
       env:


### PR DESCRIPTION
Updating the tag to be v3 when a new v3 release is cut, to avoid it being marked as the latest version on npm.