### PR TITLE
fix: Remove obsolete warning about cookie-size

### DIFF
--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -235,9 +235,6 @@ If you'd like to customize the `user` object to include additional custom claims
 ## Additional changes
 
 - By default, v4 is edge-compatible and as such there is no longer a `@auth0/nextjs-auth0/edge` export.
-- Cookie chunking has been removed
-  - If the cookie size exceeds the browser limit of 4096 bytes, a warning will be logged
-  - To store large session data, please use a [custom data store](https://github.com/auth0/nextjs-auth0/tree/main?tab=readme-ov-file#database-sessions) with a SessionStore implementation
 - All cookies set by the SDK default to `SameSite=Lax`
 - `touchSession` method was removed. The middleware enables rolling sessions by default and can be configured via the [session configuration](https://github.com/auth0/nextjs-auth0/tree/main?tab=readme-ov-file#session-configuration).
 - `getAccessToken` can now be called in React Server Components.

--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -190,18 +190,6 @@ describe("Chunked Cookie Utils", () => {
       expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__4`);
     });
 
-    it("should log a warning when cookie size exceeds warning threshold", () => {
-      const name = "warningCookie";
-      const options = { path: "/" } as CookieOptions;
-
-      // Create a value that exceeds the warning threshold (4096 bytes)
-      const value = "a".repeat(4097);
-
-      setChunkedCookie(name, value, options, reqCookies, resCookies);
-
-      expect(console.warn).toHaveBeenCalled();
-    });
-
     describe("getChunkedCookie", () => {
       it("should return undefined when cookie does not exist", () => {
         const result = getChunkedCookie("nonexistent", reqCookies);

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -127,7 +127,6 @@ export { RequestCookies };
 const MAX_CHUNK_SIZE = 3500; // Slightly under 4KB
 const CHUNK_PREFIX = "__";
 const CHUNK_INDEX_REGEX = new RegExp(`${CHUNK_PREFIX}(\\d+)$`);
-const COOKIE_SIZE_WARNING_THRESHOLD = 4096;
 
 /**
  * Retrieves the index of a cookie based on its name.
@@ -171,8 +170,6 @@ const getAllChunkedCookies = (
  * @param options - Options for setting the cookie.
  * @param reqCookies - The request cookies object, used to enable read-after-write in the same request for middleware.
  * @param resCookies - The response cookies object, used to set the cookies in the response.
- *
- * @throws {Error} If the cookie size exceeds the warning threshold.
  */
 export function setChunkedCookie(
   name: string,
@@ -182,14 +179,6 @@ export function setChunkedCookie(
   resCookies: ResponseCookies
 ): void {
   const valueBytes = new TextEncoder().encode(value).length;
-
-  if (valueBytes > COOKIE_SIZE_WARNING_THRESHOLD) {
-    console.warn(
-      `The cookie size exceeds ${COOKIE_SIZE_WARNING_THRESHOLD} bytes, which may cause issues in some browsers. ` +
-        "Consider removing any unnecessary custom claims from the access token or the user profile. " +
-        "Alternatively, you can use a stateful session implementation to store the session data in a data store."
-    );
-  }
 
   // If value fits in a single cookie, set it directly
   if (valueBytes <= MAX_CHUNK_SIZE) {


### PR DESCRIPTION
With the fact that [we brought back cookie-chunking](https://github.com/auth0/nextjs-auth0/pull/1975), we no longer want to output a warning message when the cookie exceeds the limit in size. Instead, we chunk the cookie in that case.

Additionally, since we [added id token back in the session](https://github.com/auth0/nextjs-auth0/pull/1978), there is a high chance of users hitting the limit, ending up with chunked cookies, and the fact that they will see an irrelevant warning message.