### PR TITLE
fix: Ensure to delete cookies when switching from single to chunks and vica versa

### DIFF
--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -228,9 +228,13 @@ describe("Chunked Cookie Utils", () => {
       const largeValue = "a".repeat(8000);
       setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
 
-      expect(reqCookies.delete).toHaveBeenCalledTimes(2); 
+      // It is called 3 times.
+      // 2 times for the chunks
+      // 1 time for the non chunked cookie
+      expect(reqCookies.delete).toHaveBeenCalledTimes(3); 
       expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__3`);
       expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__4`);
+      expect(reqCookies.delete).toHaveBeenCalledWith(name);
     });
 
     describe("getChunkedCookie", () => {

--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -166,6 +166,49 @@ describe("Chunked Cookie Utils", () => {
       );
     });
 
+    it("should clear existing chunked cookies when setting a single cookie", () => {
+      const name = "testCookie";
+      const value = "small value";
+      const options = { path: "/" } as CookieOptions;
+
+      const chunk0 = "chunk0 value";
+      const chunk1 = "chunk1 value";
+      const chunk2 = "chunk2 value";
+
+      cookieStore.set(`${name}__1`, chunk1);
+      cookieStore.set(`${name}__0`, chunk0);
+      cookieStore.set(`${name}__2`, chunk2);
+
+      setChunkedCookie(name, value, options, reqCookies, resCookies);
+
+      expect(resCookies.set).toHaveBeenCalledTimes(1);
+      expect(resCookies.set).toHaveBeenCalledWith(name, value, options);
+      expect(reqCookies.set).toHaveBeenCalledTimes(1);
+      expect(reqCookies.set).toHaveBeenCalledWith(name, value);
+      expect(reqCookies.delete).toHaveBeenCalledTimes(3);
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__0`);
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__1`);
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__2`);
+    });
+
+    it("should clear existing single cookies when setting a chunked cookie", () => {
+      const name = "testCookie";
+      const value = "small value";
+
+      cookieStore.set(`${name}`, value);
+
+      // Create a large string (8000 bytes)
+      const largeValue = "a".repeat(8000);
+      const options = { path: "/" } as CookieOptions;
+
+      setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
+
+      expect(reqCookies.delete).toHaveBeenCalledTimes(1);
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}`);
+      expect(resCookies.set).toHaveBeenCalledTimes(3);
+      expect(reqCookies.set).toHaveBeenCalledTimes(3);
+    });
+
     it("should clean up unused chunks when cookie shrinks", () => {
       const name = "testCookie";
       const options = { path: "/" } as CookieOptions;

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -196,6 +196,13 @@ export function setChunkedCookie(
     resCookies.set(name, value, options);
     // to enable read-after-write in the same request for middleware
     reqCookies.set(name, value);
+
+    // When we are writing a non-chunked cookie, we should remove the chunked cookies
+    getAllChunkedCookies(reqCookies, name).forEach(cookieChunk => {
+      resCookies.delete(cookieChunk.name);
+      reqCookies.delete(cookieChunk.name);
+    });
+
     return;
   }
 
@@ -226,6 +233,10 @@ export function setChunkedCookie(
       reqCookies.delete(chunkName);
     }
   }
+
+   // When we have written chunked cookies, we should remove the non-chunked cookie
+   resCookies.delete(name);
+   reqCookies.delete(name);
 }
 
 /**


### PR DESCRIPTION
When we reintroduced cookie chunking in #1975, we did not take into account cleaning up existing cookies:

- when we switch to chunked cookies, we want to remove the non chunked cookie
- when we switch back to non chunked cookies, we want to remove the chunked cookies.

Ideally, we would only ever have chunked cookies (with a single chunk when the cookie does not exceed the treshold) as that would simplify things alot.

However, with this PR I am addressing the issue reported in https://github.com/auth0/nextjs-auth0/issues/2009