### PR TITLE
fix: Clean up cookie chunks when cookie size shrinks

### DIFF
--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -166,6 +166,30 @@ describe("Chunked Cookie Utils", () => {
       );
     });
 
+    it("should clean up unused chunks when cookie shrinks", () => {
+      const name = "testCookie";
+      const options = { path: "/" } as CookieOptions;
+
+      const chunk0 = "chunk0 value";
+      const chunk1 = "chunk1 value";
+      const chunk2 = "chunk2 value";
+      const chunk3 = "chunk3 value";
+      const chunk4 = "chunk4 value";
+
+      cookieStore.set(`${name}__1`, chunk1);
+      cookieStore.set(`${name}__0`, chunk0);
+      cookieStore.set(`${name}__2`, chunk2);
+      cookieStore.set(`${name}__3`, chunk3);
+      cookieStore.set(`${name}__4`, chunk4);
+
+      const largeValue = "a".repeat(8000);
+      setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
+
+      expect(reqCookies.delete).toHaveBeenCalledTimes(2); 
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__3`);
+      expect(reqCookies.delete).toHaveBeenCalledWith(`${name}__4`);
+    });
+
     it("should log a warning when cookie size exceeds warning threshold", () => {
       const name = "warningCookie";
       const options = { path: "/" } as CookieOptions;

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -213,6 +213,19 @@ export function setChunkedCookie(
     position += MAX_CHUNK_SIZE;
     chunkIndex++;
   }
+
+  // clear unused chunks
+  const chunks = getAllChunkedCookies(reqCookies, name);
+  const chunksToRemove = chunks.length - chunkIndex;
+
+  if (chunksToRemove > 0) {
+    for (let i = 0; i < chunksToRemove; i++) {
+      const chunkIndexToRemove = chunkIndex + i;
+      const chunkName = `${name}${CHUNK_PREFIX}${chunkIndexToRemove}`;
+      resCookies.delete(chunkName);
+      reqCookies.delete(chunkName);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
When the cookie data would shrink, the SDK does not clean up unused cookie chunks.

This PR ensures to clean up obsolete cookie chunks.