### PR TITLE
fix: Ensure to pass-through enableAccessTokenEndpoint

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -254,7 +254,8 @@ export class Auth0Client {
 
       allowInsecureRequests: options.allowInsecureRequests,
       httpTimeout: options.httpTimeout,
-      enableTelemetry: options.enableTelemetry
+      enableTelemetry: options.enableTelemetry,
+      enableAccessTokenEndpoint: options.enableAccessTokenEndpoint,
     });
   }
 


### PR DESCRIPTION
The fix to hide the access-token endpoint in #1979 did not work as the value wasn't passed down.

This PR ensures it is passed down.