### PR TITLE
fix: Delete legacy cookie once v4 cookie is set

### DIFF
--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -147,6 +147,12 @@ export class StatefulSessionStore extends AbstractSessionStore {
 
     // to enable read-after-write in the same request for middleware
     reqCookies.set(this.sessionCookieName, jwe.toString());
+
+    // Any existing v3 cookie can also be deleted once we have set a v4 cookie.
+    // In stateful sessions, we do not have to worry about chunking.
+    if (reqCookies.has(LEGACY_COOKIE_NAME)) {
+      resCookies.delete(LEGACY_COOKIE_NAME);
+    }
   }
 
   async delete(

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -117,6 +117,10 @@ export class StatelessSessionStore extends AbstractSessionStore {
         )
       );
     }
+    
+    // Any existing v3 cookie can be deleted as soon as we have set a v4 cookie.
+    // In stateless sessions, we do have to ensure we delete all chunks.
+    cookies.deleteChunkedCookie(LEGACY_COOKIE_NAME, reqCookies, resCookies);
   }
 
   async delete(


### PR DESCRIPTION
### 📋 Changes

As reported in #2016, the legacy cookie is not cleanup correctly. 

This PR ensures that we clear up the v3 cookie once we have set a v4 cookie.

### 📎 References

#2016

### 🎯 Testing


