### PR TITLE
rebase onto contributors commit

### DIFF
--- a/src/client/providers/auth0-provider.tsx
+++ b/src/client/providers/auth0-provider.tsx
@@ -16,7 +16,7 @@ export function Auth0Provider({
     <SWRConfig
       value={{
         fallback: {
-          "/auth/profile": user
+          [process.env.NEXT_PUBLIC_PROFILE_ROUTE || "/auth/profile"]: user
         }
       }}
     >


### PR DESCRIPTION
Duplicate of #1966, thanks @seanparmelee 

### 📋 Changes

Similar to what's done in `useUser`, first check `process.env.NEXT_PUBLIC_PROFILE_ROUTE` and fallback to `"/auth/profile"` when setting the `fallback` data for the profile route.

### 📎 References

Fixes #1965 

### 🎯 Testing

1. Configure a custom profile route via the `NEXT_PUBLIC_PROFILE_ROUTE` environment variable. (ex: `NEXT_PUBLIC_PROFILE_ROUTE=/api/me`.
2. In a server component, fetch a user and pass it to the `Auth0Provider`:
```jsx
const session = await auth0.getSession();

...

return (
  <Auth0Provider user={session?.user}>
    {children}
  </Auth0Provider>
);
```
3. In a child client component, use the `useUser()` hook to retrieve the user and render a field, such as the `sub`:
```jsx
const user = userUser()

...

return (
  <div>User: {user?.sub || 'undefined'}</div>
);
```

4. Log into your application and navigate to a page that uses the component from the previous step.
5. Confirm that the logged-in user's `sub` is immediately visible on the screen and that there isn't a brief period where "undefined" is first shown.
