### PR TITLE
fix: Properly configure SDK to be distributed as ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@auth0/nextjs-auth0",
   "version": "4.4.0",
   "description": "Auth0 Next.js SDK",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc -w",
@@ -60,19 +61,19 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/client/index.js"
+      "default": "./dist/client/index.js"
     },
     "./server": {
-      "import": "./dist/server/index.js"
+      "default": "./dist/server/index.js"
     },
     "./errors": {
-      "import": "./dist/errors/index.js"
+      "default": "./dist/errors/index.js"
     },
     "./types": {
-      "import": "./dist/types/index.d.ts"
+      "default": "./dist/types/index.d.ts"
     },
     "./testing": {
-      "import": "./dist/testing/index.js"
+      "default": "./dist/testing/index.js"
     }
   },
   "dependencies": {

--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -1,4 +1,4 @@
-import { AccessTokenError } from "../../errors";
+import { AccessTokenError } from "../../errors/index.js";
 
 export async function getAccessToken() {
   const tokenRes = await fetch(

--- a/src/client/hooks/use-user.ts
+++ b/src/client/hooks/use-user.ts
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 
-import type { User } from "../../types";
+import type { User } from "../../types/index.js";
 
 export function useUser() {
   const { data, error, isLoading } = useSWR<User, Error, string>(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,3 @@
-export { useUser } from "./hooks/use-user";
-export { getAccessToken } from "./helpers/get-access-token";
-export { Auth0Provider } from "./providers/auth0-provider";
+export { useUser } from "./hooks/use-user.js";
+export { getAccessToken } from "./helpers/get-access-token.js";
+export { Auth0Provider } from "./providers/auth0-provider.js";

--- a/src/client/providers/auth0-provider.tsx
+++ b/src/client/providers/auth0-provider.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { SWRConfig } from "swr";
 
-import { User } from "../../types";
+import { User } from "../../types/index.js";
 
 export function Auth0Provider({
   user,

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -1,15 +1,15 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server.js";
 import * as jose from "jose";
 import * as oauth from "oauth4webapi";
 import { describe, expect, it, vi } from "vitest";
 
-import { generateSecret } from "../test/utils";
-import { SessionData } from "../types";
-import { AuthClient } from "./auth-client";
-import { decrypt, encrypt } from "./cookies";
-import { StatefulSessionStore } from "./session/stateful-session-store";
-import { StatelessSessionStore } from "./session/stateless-session-store";
-import { TransactionState, TransactionStore } from "./transaction-store";
+import { generateSecret } from "../test/utils.js";
+import { SessionData } from "../types/index.js";
+import { AuthClient } from "./auth-client.js";
+import { decrypt, encrypt } from "./cookies.js";
+import { StatefulSessionStore } from "./session/stateful-session-store.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { TransactionState, TransactionStore } from "./transaction-store.js";
 
 describe("Authentication Client", async () => {
   const DEFAULT = {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -1,8 +1,8 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server.js";
 import * as jose from "jose";
 import * as oauth from "oauth4webapi";
 
-import packageJson from "../../package.json";
+import packageJson from "../../package.json" with { type: "json" };
 import {
   AccessTokenError,
   AccessTokenErrorCode,
@@ -16,7 +16,7 @@ import {
   MissingStateError,
   OAuth2Error,
   SdkError
-} from "../errors";
+} from "../errors/index.js";
 import {
   AuthorizationParameters,
   ConnectionTokenSet,
@@ -25,16 +25,16 @@ import {
   SessionData,
   StartInteractiveLoginOptions,
   TokenSet
-} from "../types";
+} from "../types/index.js";
 import {
   ensureNoLeadingSlash,
   ensureTrailingSlash,
   removeTrailingSlash
-} from "../utils/pathUtils";
-import { toSafeRedirect } from "../utils/url-helpers";
-import { AbstractSessionStore } from "./session/abstract-session-store";
-import { TransactionState, TransactionStore } from "./transaction-store";
-import { filterClaims } from "./user";
+} from "../utils/pathUtils.js";
+import { toSafeRedirect } from "../utils/url-helpers.js";
+import { AbstractSessionStore } from "./session/abstract-session-store.js";
+import { TransactionState, TransactionStore } from "./transaction-store.js";
+import { filterClaims } from "./user.js";
 
 export type BeforeSessionSavedHook = (
   session: SessionData,

--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -7,7 +7,7 @@ import {
   RequestCookies,
   ResponseCookies,
   setChunkedCookie
-} from "./cookies";
+} from "./cookies.js";
 
 // Create mock implementation for RequestCookies and ResponseCookies
 const createMocks = () => {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1,39 +1,39 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
-import { NextApiRequest, NextApiResponse } from "next/types";
+import { cookies } from "next/headers.js";
+import { NextRequest, NextResponse } from "next/server.js";
+import { NextApiRequest, NextApiResponse } from "next/types.js";
 
 import {
   AccessTokenError,
   AccessTokenErrorCode,
   AccessTokenForConnectionError,
   AccessTokenForConnectionErrorCode,
-} from "../errors";
+} from "../errors/index.js";
 import {
   AuthorizationParameters,
   AccessTokenForConnectionOptions,
   SessionData,
   SessionDataStore,
   StartInteractiveLoginOptions
-} from "../types";
+} from "../types/index.js";
 import {
   AuthClient,
   BeforeSessionSavedHook,
   OnCallbackHook,
   RoutesOptions
-} from "./auth-client";
-import { RequestCookies, ResponseCookies } from "./cookies";
+} from "./auth-client.js";
+import { RequestCookies, ResponseCookies } from "./cookies.js";
 import {
   AbstractSessionStore,
   SessionConfiguration,
   SessionCookieOptions
-} from "./session/abstract-session-store";
-import { StatefulSessionStore } from "./session/stateful-session-store";
-import { StatelessSessionStore } from "./session/stateless-session-store";
+} from "./session/abstract-session-store.js";
+import { StatefulSessionStore } from "./session/stateful-session-store.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import {
   TransactionCookieOptions,
   TransactionStore
-} from "./transaction-store";
+} from "./transaction-store.js";
 
 export interface Auth0ClientOptions {
   // authorization server configuration

--- a/src/server/cookies.test.ts
+++ b/src/server/cookies.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { generateSecret } from "../test/utils";
-import { decrypt, encrypt } from "./cookies";
+import { generateSecret } from "../test/utils.js";
+import { decrypt, encrypt } from "./cookies.js";
 
 describe("encrypt/decrypt", async () => {
   const secret = await generateSecret(32);

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -3,7 +3,7 @@ import {
   RequestCookies,
   ResponseCookies
 } from "@edge-runtime/cookies";
-import hkdf from "@panva/hkdf";
+import { hkdf } from "@panva/hkdf";
 import * as jose from "jose";
 
 const ENC = "A256GCM";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
-export { Auth0Client } from "./client";
+export { Auth0Client } from "./client.js";
 
-export { AuthClient } from "./auth-client";
+export { AuthClient } from "./auth-client.js";
 
-export { TransactionStore } from "./transaction-store";
+export { TransactionStore } from "./transaction-store.js";
 
-export { AbstractSessionStore } from "./session/abstract-session-store";
+export { AbstractSessionStore } from "./session/abstract-session-store.js";

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -1,10 +1,10 @@
-import type { SessionData, SessionDataStore } from "../../types";
+import type { SessionData, SessionDataStore } from "../../types/index.js";
 import {
   CookieOptions,
   ReadonlyRequestCookies,
   RequestCookies,
   ResponseCookies
-} from "../cookies";
+} from "../cookies.js";
 
 export interface SessionCookieOptions {
   /**

--- a/src/server/session/normalize-session.ts
+++ b/src/server/session/normalize-session.ts
@@ -1,6 +1,6 @@
 import { JWTDecryptResult } from "jose";
 
-import { SessionData } from "../../types";
+import { SessionData } from "../../types/index.js";
 
 export const LEGACY_COOKIE_NAME = "appSession";
 

--- a/src/server/session/stateful-session-store.test.ts
+++ b/src/server/session/stateful-session-store.test.ts
@@ -1,16 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateSecret } from "../../test/utils";
-import { SessionData } from "../../types";
+import { generateSecret } from "../../test/utils.js";
+import { SessionData } from "../../types/index.js";
 import {
   decrypt,
   encrypt,
   RequestCookies,
   ResponseCookies,
   sign
-} from "../cookies";
-import { LEGACY_COOKIE_NAME, LegacySessionPayload } from "./normalize-session";
-import { StatefulSessionStore } from "./stateful-session-store";
+} from "../cookies.js";
+import { LEGACY_COOKIE_NAME, LegacySessionPayload } from "./normalize-session.js";
+import { StatefulSessionStore } from "./stateful-session-store.js";
+
 
 describe("Stateful Session Store", async () => {
   describe("get", async () => {

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -1,13 +1,13 @@
-import { SessionData, SessionDataStore } from "../../types";
-import * as cookies from "../cookies";
+import { SessionData, SessionDataStore } from "../../types/index.js";
+import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
   SessionCookieOptions
-} from "./abstract-session-store";
+} from "./abstract-session-store.js";
 import {
   LEGACY_COOKIE_NAME,
   normalizeStatefulSession
-} from "./normalize-session";
+} from "./normalize-session.js";
 
 // the value of the stateful session cookie containing a unique session ID to identify
 // the current session

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateSecret } from "../../test/utils";
-import { SessionData } from "../../types";
-import { decrypt, encrypt, RequestCookies, ResponseCookies } from "../cookies";
-import { LEGACY_COOKIE_NAME, LegacySession } from "./normalize-session";
-import { StatelessSessionStore } from "./stateless-session-store";
+import { generateSecret } from "../../test/utils.js";
+import { SessionData } from "../../types/index.js";
+import { decrypt, encrypt, RequestCookies, ResponseCookies } from "../cookies.js";
+import { LEGACY_COOKIE_NAME, LegacySession } from "./normalize-session.js";
+import { StatelessSessionStore } from "./stateless-session-store.js";
 
 describe("Stateless Session Store", async () => {
   describe("get", async () => {

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -1,17 +1,17 @@
-import { CookieOptions, ConnectionTokenSet, SessionData } from "../../types";
+import { CookieOptions, ConnectionTokenSet, SessionData } from "../../types/index.js";
 
 import type { JWTPayload } from "jose";
 
-import * as cookies from "../cookies";
+import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
   SessionCookieOptions
-} from "./abstract-session-store";
+} from "./abstract-session-store.js";
 import {
   LEGACY_COOKIE_NAME,
   LegacySessionPayload,
   normalizeStatelessSession
-} from "./normalize-session";
+} from "./normalize-session.js";
 
 interface StatelessSessionStoreOptions {
   secret: string;

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -1,9 +1,9 @@
 import * as oauth from "oauth4webapi";
 import { describe, expect, it } from "vitest";
 
-import { generateSecret } from "../test/utils";
-import { decrypt, encrypt, RequestCookies, ResponseCookies } from "./cookies";
-import { TransactionState, TransactionStore } from "./transaction-store";
+import { generateSecret } from "../test/utils.js";
+import { decrypt, encrypt, RequestCookies, ResponseCookies } from "./cookies.js";
+import { TransactionState, TransactionStore } from "./transaction-store.js";
 
 describe("Transaction Store", async () => {
   describe("get", async () => {

--- a/src/server/transaction-store.ts
+++ b/src/server/transaction-store.ts
@@ -1,6 +1,6 @@
 import type * as jose from "jose";
 
-import * as cookies from "./cookies";
+import * as cookies from "./cookies.js";
 
 const TRANSACTION_COOKIE_PREFIX = "__txn_";
 

--- a/src/server/user.test.ts
+++ b/src/server/user.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { filterClaims } from "./user";
+import { filterClaims } from "./user.js";
 
 describe("filterClaims", async () => {
   it("should return only the allowed claims", () => {

--- a/src/server/user.ts
+++ b/src/server/user.ts
@@ -1,4 +1,4 @@
-import type { User } from "../types";
+import type { User } from "../types/index.js";
 
 const DEFAULT_ALLOWED_CLAIMS = [
   "sub",

--- a/src/testing/generate-session-cookie.test.ts
+++ b/src/testing/generate-session-cookie.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { decrypt } from "../server/cookies";
-import { generateSecret } from "../test/utils";
-import { SessionData } from "../types";
+import { decrypt } from "../server/cookies.js";
+import { generateSecret } from "../test/utils.js";
+import { SessionData } from "../types/index.js";
 import {
   generateSessionCookie,
   GenerateSessionCookieConfig
-} from "./generate-session-cookie";
+} from "./generate-session-cookie.js";
 
 describe("generateSessionCookie", async () => {
   it("should use the session data provided", async () => {

--- a/src/testing/generate-session-cookie.ts
+++ b/src/testing/generate-session-cookie.ts
@@ -1,5 +1,5 @@
-import { encrypt } from "../server/cookies";
-import { SessionData } from "../types";
+import { encrypt } from "../server/cookies.js";
+import { SessionData } from "../types/index.js";
 
 export type GenerateSessionCookieConfig = {
   /**

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,4 +1,4 @@
 export {
   GenerateSessionCookieConfig,
   generateSessionCookie
-} from "./generate-session-cookie";
+} from "./generate-session-cookie.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,7 +69,7 @@ export type {
   Auth0ClientOptions,
   PagesRouterRequest,
   PagesRouterResponse
-} from "../server/client";
+} from "../server/client.js";
 
 export type {
   BeforeSessionSavedHook,
@@ -78,22 +78,22 @@ export type {
   AuthClientOptions,
   OnCallbackContext,
   Routes
-} from "../server/auth-client";
+} from "../server/auth-client.js";
 
-export type { TransactionCookieOptions } from "../server/transaction-store";
+export type { TransactionCookieOptions } from "../server/transaction-store.js";
 
 export type {
   SessionConfiguration,
   SessionCookieOptions,
   SessionStoreOptions
-} from "../server/session/abstract-session-store";
+} from "../server/session/abstract-session-store.js";
 
-export type { CookieOptions, ReadonlyRequestCookies } from "../server/cookies";
+export type { CookieOptions, ReadonlyRequestCookies } from "../server/cookies.js";
 
 export type {
   TransactionStoreOptions,
   TransactionState
-} from "../server/transaction-store";
+} from "../server/transaction-store.js";
 
 export interface StartInteractiveLoginOptions {
   /**

--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -4,7 +4,7 @@ import {
   ensureNoLeadingSlash,
   ensureTrailingSlash,
   removeTrailingSlash
-} from "./pathUtils";
+} from "./pathUtils.js";
 
 describe("pathUtils", () => {
   describe("ensureTrailingSlash", () => {

--- a/src/utils/url-helpers.test.ts
+++ b/src/utils/url-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import payloads from "../test/fixtures/open-redirect-payloads.json";
-import { toSafeRedirect } from "./url-helpers";
+import payloads from "../test/fixtures/open-redirect-payloads.json" with { type: "json" };
+import { toSafeRedirect } from "./url-helpers.js";
 
 describe("url-helpers", () => {
   const safeBaseUrl = new URL("http://www.example.com");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "nodenext",
+    "module": "NodeNext",
     "rootDir": "./src",
     "outDir": "./dist",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
     "jsx": "react",
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Our SDK isnt correctly configured to publish ESM:

- we need to use `default`, not `import`
- we need to define `type: module` in the package.json
- we need to ensure we define file extensions when importing from files

This can cause issues as it may mean certain tools have to rely on auto resolving the module loading and failing as they think our SDK is CJS, but it is ESM.

Solves https://github.com/auth0/nextjs-auth0/issues/1945