### PR TITLE
Fix stacking transaction cookies

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -518,20 +518,22 @@ ca/T0LLtgmbMmxSv/MmzIg==
           updatedSessionCookie!.value,
           secret
         );
-        expect(updatedSessionCookieValue).toEqual(expect.objectContaining({
-          user: {
-            sub: DEFAULT.sub
-          },
-          tokenSet: {
-            accessToken: "at_123",
-            refreshToken: "rt_123",
-            expiresAt: expect.any(Number)
-          },
-          internal: {
-            sid: DEFAULT.sid,
-            createdAt: expect.any(Number)
-          }
-        }));
+        expect(updatedSessionCookieValue).toEqual(
+          expect.objectContaining({
+            user: {
+              sub: DEFAULT.sub
+            },
+            tokenSet: {
+              accessToken: "at_123",
+              refreshToken: "rt_123",
+              expiresAt: expect.any(Number)
+            },
+            internal: {
+              sid: DEFAULT.sid,
+              createdAt: expect.any(Number)
+            }
+          })
+        );
 
         // assert that the session expiry has been extended by the inactivity duration
         expect(updatedSessionCookie?.maxAge).toEqual(1800);
@@ -1025,13 +1027,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(transactionCookie).toBeDefined();
         expect(
           (await decrypt(transactionCookie!.value, secret)).payload
-        ).toEqual(expect.objectContaining({
-          nonce: authorizationUrl.searchParams.get("nonce"),
-          codeVerifier: expect.any(String),
-          responseType: "code",
-          state: authorizationUrl.searchParams.get("state"),
-          returnTo: "/"
-        }));
+        ).toEqual(
+          expect.objectContaining({
+            nonce: authorizationUrl.searchParams.get("nonce"),
+            codeVerifier: expect.any(String),
+            responseType: "code",
+            state: authorizationUrl.searchParams.get("state"),
+            returnTo: "/"
+          })
+        );
       });
 
       it("should forward the configured authorization parameters to the authorization server", async () => {
@@ -1585,13 +1589,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(transactionCookie).toBeDefined();
         expect(
           (await decrypt(transactionCookie!.value, secret)).payload
-        ).toEqual(expect.objectContaining({
-          nonce: expect.any(String),
-          codeVerifier: expect.any(String),
-          responseType: "code",
-          state,
-          returnTo: "/"
-        }));
+        ).toEqual(
+          expect.objectContaining({
+            nonce: expect.any(String),
+            codeVerifier: expect.any(String),
+            responseType: "code",
+            state,
+            returnTo: "/"
+          })
+        );
       });
 
       describe("custom parameters to the authorization server", async () => {
@@ -1664,13 +1670,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
           expect(transactionCookie).toBeDefined();
           expect(
             (await decrypt(transactionCookie!.value, secret)).payload
-          ).toEqual(expect.objectContaining({
-            nonce: expect.any(String),
-            codeVerifier: expect.any(String),
-            responseType: "code",
-            state,
-            returnTo: "/"
-          }));
+          ).toEqual(
+            expect.objectContaining({
+              nonce: expect.any(String),
+              codeVerifier: expect.any(String),
+              responseType: "code",
+              state,
+              returnTo: "/"
+            })
+          );
         });
 
         it("should forward custom parameters set in the configuration to the authorization server", async () => {
@@ -1744,13 +1752,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
           expect(transactionCookie).toBeDefined();
           expect(
             (await decrypt(transactionCookie!.value, secret)).payload
-          ).toEqual(expect.objectContaining({
-            nonce: expect.any(String),
-            codeVerifier: expect.any(String),
-            responseType: "code",
-            state,
-            returnTo: "/"
-          }));
+          ).toEqual(
+            expect.objectContaining({
+              nonce: expect.any(String),
+              codeVerifier: expect.any(String),
+              responseType: "code",
+              state,
+              returnTo: "/"
+            })
+          );
         });
       });
     });
@@ -2298,21 +2308,23 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const sessionCookie = response.cookies.get("__session");
       expect(sessionCookie).toBeDefined();
       const { payload: session } = await decrypt(sessionCookie!.value, secret);
-      expect(session).toEqual(expect.objectContaining({
-        user: {
-          sub: DEFAULT.sub
-        },
-        tokenSet: {
-          accessToken: DEFAULT.accessToken,
-          refreshToken: DEFAULT.refreshToken,
-          idToken: expect.stringMatching(/^eyJhbGciOiJSUzI1NiJ9\..+\..+$/),
-          expiresAt: expect.any(Number)
-        },
-        internal: {
-          sid: expect.any(String),
-          createdAt: expect.any(Number)
-        }
-      }));
+      expect(session).toEqual(
+        expect.objectContaining({
+          user: {
+            sub: DEFAULT.sub
+          },
+          tokenSet: {
+            accessToken: DEFAULT.accessToken,
+            refreshToken: DEFAULT.refreshToken,
+            idToken: expect.stringMatching(/^eyJhbGciOiJSUzI1NiJ9\..+\..+$/),
+            expiresAt: expect.any(Number)
+          },
+          internal: {
+            sid: expect.any(String),
+            createdAt: expect.any(Number)
+          }
+        })
+      );
 
       // validate the transaction cookie has been removed
       const transactionCookie = response.cookies.get(`__txn_${state}`);
@@ -2409,21 +2421,23 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const sessionCookie = response.cookies.get("__session");
       expect(sessionCookie).toBeDefined();
       const { payload: session } = await decrypt(sessionCookie!.value, secret);
-      expect(session).toEqual(expect.objectContaining({
-        user: {
-          sub: DEFAULT.sub
-        },
-        tokenSet: {
-          accessToken: DEFAULT.accessToken,
-          idToken: expect.any(String),
-          refreshToken: DEFAULT.refreshToken,
-          expiresAt: expect.any(Number)
-        },
-        internal: {
-          sid: expect.any(String),
-          createdAt: expect.any(Number)
-        }
-      }));
+      expect(session).toEqual(
+        expect.objectContaining({
+          user: {
+            sub: DEFAULT.sub
+          },
+          tokenSet: {
+            accessToken: DEFAULT.accessToken,
+            idToken: expect.any(String),
+            refreshToken: DEFAULT.refreshToken,
+            expiresAt: expect.any(Number)
+          },
+          internal: {
+            sid: expect.any(String),
+            createdAt: expect.any(Number)
+          }
+        })
+      );
 
       // validate the transaction cookie has been removed
       const transactionCookie = response.cookies.get(`__txn_${state}`);
@@ -2747,8 +2761,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
           returnTo: "/dashboard"
         };
         const maxAge = 60 * 60; // 1 hour
-      const expiration = Math.floor(Date.now() / 1000 + maxAge);
-      
+        const expiration = Math.floor(Date.now() / 1000 + maxAge);
+
         headers.set(
           "cookie",
           `__txn_${state}=${await encrypt(transactionState, secret, expiration)}`
@@ -3260,24 +3274,26 @@ ca/T0LLtgmbMmxSv/MmzIg==
           sessionCookie!.value,
           secret
         );
-        expect(session).toEqual(expect.objectContaining({
-          user: {
-            sub: DEFAULT.sub,
-            name: "John Doe",
-            email: "john@example.com",
-            custom: "value"
-          },
-          tokenSet: {
-            accessToken: DEFAULT.accessToken,
-            refreshToken: DEFAULT.refreshToken,
-            idToken: expect.any(String),
-            expiresAt: expect.any(Number)
-          },
-          internal: {
-            sid: expect.any(String),
-            createdAt: expect.any(Number)
-          }
-        }));
+        expect(session).toEqual(
+          expect.objectContaining({
+            user: {
+              sub: DEFAULT.sub,
+              name: "John Doe",
+              email: "john@example.com",
+              custom: "value"
+            },
+            tokenSet: {
+              accessToken: DEFAULT.accessToken,
+              refreshToken: DEFAULT.refreshToken,
+              idToken: expect.any(String),
+              expiresAt: expect.any(Number)
+            },
+            internal: {
+              sid: expect.any(String),
+              createdAt: expect.any(Number)
+            }
+          })
+        );
       });
 
       it("should not call the hook if the session is not established", async () => {
@@ -3392,24 +3408,26 @@ ca/T0LLtgmbMmxSv/MmzIg==
           sessionCookie!.value,
           secret
         );
-        expect(session).toEqual(expect.objectContaining({
-          user: {
-            sub: DEFAULT.sub,
-            name: "John Doe",
-            email: "john@example.com",
-            custom: "value"
-          },
-          tokenSet: {
-            accessToken: DEFAULT.accessToken,
-            refreshToken: DEFAULT.refreshToken,
-            idToken: expect.any(String),
-            expiresAt: expect.any(Number)
-          },
-          internal: {
-            sid: expect.any(String),
-            createdAt: expect.any(Number)
-          }
-        }));
+        expect(session).toEqual(
+          expect.objectContaining({
+            user: {
+              sub: DEFAULT.sub,
+              name: "John Doe",
+              email: "john@example.com",
+              custom: "value"
+            },
+            tokenSet: {
+              accessToken: DEFAULT.accessToken,
+              refreshToken: DEFAULT.refreshToken,
+              idToken: expect.any(String),
+              expiresAt: expect.any(Number)
+            },
+            internal: {
+              sid: expect.any(String),
+              createdAt: expect.any(Number)
+            }
+          })
+        );
       });
     });
   });

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -420,6 +420,15 @@ export class AuthClient {
 
       const res = NextResponse.redirect(url);
       await this.sessionStore.delete(req.cookies, res.cookies);
+
+      // Clear any orphaned transaction cookies
+      const txnPrefix = this.transactionStore.getCookiePrefix();
+      req.cookies.getAll().forEach((cookie) => {
+        if (cookie.name.startsWith(txnPrefix)) {
+          res.cookies.delete(cookie.name);
+        }
+      });
+
       return res;
     }
 
@@ -437,6 +446,14 @@ export class AuthClient {
 
     const res = NextResponse.redirect(url);
     await this.sessionStore.delete(req.cookies, res.cookies);
+
+    // Clear any orphaned transaction cookies
+    const txnPrefix = this.transactionStore.getCookiePrefix();
+    req.cookies.getAll().forEach((cookie) => {
+      if (cookie.name.startsWith(txnPrefix)) {
+        res.cookies.delete(cookie.name);
+      }
+    });
 
     return res;
   }

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -422,12 +422,7 @@ export class AuthClient {
       await this.sessionStore.delete(req.cookies, res.cookies);
 
       // Clear any orphaned transaction cookies
-      const txnPrefix = this.transactionStore.getCookiePrefix();
-      req.cookies.getAll().forEach((cookie) => {
-        if (cookie.name.startsWith(txnPrefix)) {
-          res.cookies.delete(cookie.name);
-        }
-      });
+      await this.transactionStore.deleteAll(req.cookies, res.cookies);
 
       return res;
     }
@@ -448,12 +443,7 @@ export class AuthClient {
     await this.sessionStore.delete(req.cookies, res.cookies);
 
     // Clear any orphaned transaction cookies
-    const txnPrefix = this.transactionStore.getCookiePrefix();
-    req.cookies.getAll().forEach((cookie) => {
-      if (cookie.name.startsWith(txnPrefix)) {
-        res.cookies.delete(cookie.name);
-      }
-    });
+    await this.transactionStore.deleteAll(req.cookies, res.cookies);
 
     return res;
   }

--- a/src/server/cookies.test.ts
+++ b/src/server/cookies.test.ts
@@ -31,16 +31,16 @@ describe("encrypt/decrypt", async () => {
     const payload = { key: "value" };
     const expiration = Math.floor(Date.now() / 1000 - 60); // 60 seconds in the past
     const encrypted = await encrypt(payload, secret, expiration);
-    await expect(() =>
-      decrypt(encrypted, secret)
-    ).rejects.toThrowError(`"exp" claim timestamp check failed`);
+    await expect(() => decrypt(encrypted, secret)).rejects.toThrowError(
+      `"exp" claim timestamp check failed`
+    );
   });
 
   it("should fail to encrypt if a secret is not provided", async () => {
     const payload = { key: "value" };
     const maxAge = 60 * 60; // 1 hour in seconds
     const expiration = Math.floor(Date.now() / 1000 + maxAge);
-    
+
     await expect(() => encrypt(payload, "", expiration)).rejects.toThrowError();
   });
 
@@ -48,7 +48,7 @@ describe("encrypt/decrypt", async () => {
     const payload = { key: "value" };
     const maxAge = 60 * 60; // 1 hour in seconds
     const expiration = Math.floor(Date.now() / 1000 + maxAge);
-    
+
     const encrypted = await encrypt(payload, secret, expiration);
     await expect(() => decrypt(encrypted, "")).rejects.toThrowError();
   });

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -1,0 +1,309 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { NextRequest } from "next/server";
+import * as oauth from "oauth4webapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InvalidStateError, MissingStateError } from "../errors";
+import { SessionData } from "../types";
+import { AuthClient, AuthClientOptions } from "./auth-client";
+import {
+  ReadonlyRequestCookies,
+  RequestCookies,
+  ResponseCookies
+} from "./cookies";
+import {
+  AbstractSessionStore,
+  SessionStoreOptions
+} from "./session/abstract-session-store";
+import { TransactionStore } from "./transaction-store";
+
+vi.mock("./transaction-store");
+vi.mock("oauth4webapi");
+vi.mock("jose");
+
+const MockTransactionStore = TransactionStore;
+
+class TestSessionStore extends AbstractSessionStore {
+  constructor(config: SessionStoreOptions) {
+    super(config);
+  }
+  async get(
+    _reqCookies: RequestCookies | ReadonlyRequestCookies
+  ): Promise<SessionData | null> {
+    return null;
+  }
+  async set(
+    _reqCookies: RequestCookies | ReadonlyRequestCookies,
+    _resCookies: ResponseCookies,
+    _session: SessionData,
+    _isNew?: boolean | undefined
+  ): Promise<void> {}
+  async delete(
+    _reqCookies: RequestCookies | ReadonlyRequestCookies,
+    _resCookies: ResponseCookies
+  ): Promise<void> {}
+}
+
+const baseOptions: Partial<AuthClientOptions> = {
+  domain: "test.auth0.com",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  secret: "a-sufficiently-long-secret-for-testing",
+  routes: {
+    login: "/api/auth/login",
+    logout: "/api/auth/logout",
+    callback: "/api/auth/callback"
+  }
+};
+
+describe("Ensure that redundant transaction cookies are deleted from auth-client methods", () => {
+  let authClient: AuthClient;
+  let mockTransactionStoreInstance: TransactionStore;
+  let mockSessionStoreInstance: TestSessionStore;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockTransactionStoreInstance = new MockTransactionStore({
+      secret: "a-sufficiently-long-secret-for-testing"
+    });
+    const testSessionStoreOptions: SessionStoreOptions = {
+      secret: "test-secret",
+      cookieOptions: { name: "__session", path: "/", sameSite: "lax" }
+    };
+    mockSessionStoreInstance = new TestSessionStore(testSessionStoreOptions);
+
+    mockTransactionStoreInstance.getCookiePrefix = vi
+      .fn()
+      .mockReturnValue("__txn_");
+    mockTransactionStoreInstance.delete = vi.fn().mockResolvedValue(undefined);
+    mockTransactionStoreInstance.get = vi.fn().mockResolvedValue({
+      payload: {
+        state: "test-state",
+        nonce: "test-nonce",
+        codeVerifier: "cv",
+        responseType: "code",
+        returnTo: "/"
+      }
+    });
+
+    mockSessionStoreInstance.get = vi.fn().mockResolvedValue({
+      user: { sub: "user123" },
+      internal: { sid: "sid123" },
+      tokenSet: { idToken: "idtoken123" }
+    });
+    mockSessionStoreInstance.delete = vi.fn().mockResolvedValue(undefined);
+    mockSessionStoreInstance.set = vi.fn().mockResolvedValue(undefined);
+
+    authClient = new AuthClient({
+      ...baseOptions,
+      sessionStore: mockSessionStoreInstance as any,
+      transactionStore: mockTransactionStoreInstance
+    } as AuthClientOptions);
+
+    (authClient as any).discoverAuthorizationServerMetadata = vi
+      .fn()
+      .mockResolvedValue([
+        null,
+        {
+          issuer: "https://test.auth0.com/",
+          authorization_endpoint: "https://test.auth0.com/authorize",
+          token_endpoint: "https://test.auth0.com/oauth/token",
+          jwks_uri: "https://test.auth0.com/.well-known/jwks.json",
+          end_session_endpoint: "https://test.auth0.com/v2/logout" // Mock RP-Initiated Logout endpoint
+        }
+      ]);
+
+    vi.spyOn(oauth, "validateAuthResponse").mockReturnValue(
+      new URLSearchParams("code=auth_code")
+    );
+    vi.spyOn(oauth, "authorizationCodeGrantRequest").mockResolvedValue(
+      new Response()
+    );
+    vi.spyOn(oauth, "processAuthorizationCodeResponse").mockResolvedValue({
+      token_type: "Bearer",
+      access_token: "access_token_123",
+      id_token: "id_token_456",
+      refresh_token: "refresh_token_789",
+      expires_in: 3600,
+      scope: "openid profile email"
+    } as oauth.TokenEndpointResponse);
+
+    const clientId = baseOptions.clientId ?? "test-client-id";
+    vi.spyOn(oauth, "getValidatedIdTokenClaims").mockReturnValue({
+      sub: "user123",
+      sid: "sid123",
+      nonce: "test-nonce",
+      aud: clientId,
+      iss: `https://${baseOptions.domain}/`,
+      iat: Math.floor(Date.now() / 1000) - 60,
+      exp: Math.floor(Date.now() / 1000) + 3600
+    });
+  });
+
+  describe("handleLogout", () => {
+    it("should delete session cookie but no transaction cookies if none exist", async () => {
+      const req = new NextRequest("http://localhost:3000/api/auth/logout");
+      req.cookies.set("__session", "session-value");
+
+      const res = await authClient.handleLogout(req);
+
+      expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
+      expect(
+        mockTransactionStoreInstance.getCookiePrefix
+      ).toHaveBeenCalledTimes(1);
+
+      const setCookieHeader = res.headers.get("set-cookie") || "";
+      expect(setCookieHeader).not.toMatch(/__txn_[^=]+=;/);
+
+      expect(res.status).toBeGreaterThanOrEqual(300); // Accept 302 or 307
+      expect(res.status).toBeLessThan(400);
+    });
+
+    it("should delete session cookie AND existing transaction cookies", async () => {
+      const req = new NextRequest("http://localhost:3000/api/auth/logout");
+      req.cookies.set("__session", "session-value");
+      req.cookies.set("__txn_state1", "txn-value1");
+      req.cookies.set("__txn_state2", "txn-value2");
+      req.cookies.set("other_cookie", "other-value");
+
+      const res = await authClient.handleLogout(req);
+
+      expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
+      expect(
+        mockTransactionStoreInstance.getCookiePrefix
+      ).toHaveBeenCalledTimes(1);
+
+      const setCookieHeader = res.headers.get("set-cookie") || "";
+      expect(setCookieHeader).toMatch(
+        /__txn_state1=;.*Expires=Thu, 01 Jan 1970/
+      );
+      8;
+      expect(setCookieHeader).toMatch(
+        /__txn_state2=;.*Expires=Thu, 01 Jan 1970/
+      );
+      expect(setCookieHeader).not.toMatch(/other_cookie=;/);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+    });
+
+    it("should delete transaction cookies even if no session exists", async () => {
+      mockSessionStoreInstance.get = vi.fn().mockResolvedValue(null);
+      const req = new NextRequest("http://localhost:3000/api/auth/logout");
+      req.cookies.set("__txn_state1", "txn-value1");
+
+      const res = await authClient.handleLogout(req);
+
+      expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
+      expect(
+        mockTransactionStoreInstance.getCookiePrefix
+      ).toHaveBeenCalledTimes(1);
+
+      const setCookieHeader = res.headers.get("set-cookie") || "";
+      expect(setCookieHeader).toMatch(
+        /__txn_state1=;.*Expires=Thu, 01 Jan 1970/
+      );
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+    });
+
+    it("should respect custom transaction cookie prefix", async () => {
+      const customPrefix = "__my_txn_";
+      mockTransactionStoreInstance.getCookiePrefix = vi
+        .fn()
+        .mockReturnValue(customPrefix);
+      authClient = new AuthClient({
+        ...baseOptions,
+        sessionStore: mockSessionStoreInstance as any,
+        transactionStore: mockTransactionStoreInstance
+      } as AuthClientOptions);
+      (authClient as any).discoverAuthorizationServerMetadata = vi
+        .fn()
+        .mockResolvedValue([null, { end_session_endpoint: "http://..." }]);
+
+      const req = new NextRequest("http://localhost:3000/api/auth/logout");
+      req.cookies.set("__session", "session-value");
+      req.cookies.set(`${customPrefix}state1`, "txn-value1");
+      req.cookies.set("__txn_state2", "default-prefix-value");
+
+      const res = await authClient.handleLogout(req);
+
+      expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
+      expect(
+        mockTransactionStoreInstance.getCookiePrefix
+      ).toHaveBeenCalledTimes(1);
+
+      const setCookieHeader = res.headers.get("set-cookie") || "";
+      expect(setCookieHeader).toMatch(
+        new RegExp(`${customPrefix}state1=;.*Expires=Thu, 01 Jan 1970`)
+      );
+      expect(setCookieHeader).not.toMatch(/__txn_state2=;/);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+    });
+  });
+
+  describe("handleCallback", () => {
+    it("should delete the correct transaction cookie on success", async () => {
+      const state = "test-state";
+      const req = new NextRequest(
+        `http://localhost:3000/api/auth/callback?code=auth_code&state=${state}`
+      );
+
+      const res = await authClient.handleCallback(req);
+
+      expect(mockTransactionStoreInstance.get).toHaveBeenCalledWith(
+        req.cookies,
+        state
+      );
+      expect(mockTransactionStoreInstance.delete).toHaveBeenCalledTimes(1);
+      expect(mockTransactionStoreInstance.delete).toHaveBeenCalledWith(
+        res.cookies,
+        state
+      );
+      expect(mockSessionStoreInstance.set).toHaveBeenCalledTimes(1);
+      expect(res.status).toBeGreaterThanOrEqual(300); // Accept redirects
+      expect(res.status).toBeLessThan(400);
+      expect(res.headers.get("location")).toBe("http://localhost:3000/");
+    });
+
+    it("should NOT delete transaction cookie on InvalidStateError", async () => {
+      const state = "invalid-state";
+      mockTransactionStoreInstance.get = vi.fn().mockResolvedValue(null);
+      const req = new NextRequest(
+        `http://localhost:3000/api/auth/callback?code=auth_code&state=${state}`
+      );
+
+      const res = await authClient.handleCallback(req);
+
+      expect(mockTransactionStoreInstance.get).toHaveBeenCalledWith(
+        req.cookies,
+        state
+      );
+      expect(mockTransactionStoreInstance.delete).not.toHaveBeenCalled();
+      expect(mockSessionStoreInstance.set).not.toHaveBeenCalled();
+      expect(res.status).toBe(500);
+      const body = await res.text();
+      expect(body).toContain(new InvalidStateError().message);
+    });
+
+    it("should NOT delete transaction cookie on MissingStateError", async () => {
+      const req = new NextRequest(
+        `http://localhost:3000/api/auth/callback?code=auth_code`
+      );
+
+      const res = await authClient.handleCallback(req);
+
+      expect(mockTransactionStoreInstance.get).not.toHaveBeenCalled();
+      expect(mockTransactionStoreInstance.delete).not.toHaveBeenCalled();
+      expect(mockSessionStoreInstance.set).not.toHaveBeenCalled();
+      expect(res.status).toBe(500);
+      const body = await res.text();
+      expect(body).toContain(new MissingStateError().message);
+    });
+  });
+});

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -179,7 +179,6 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       expect(setCookieHeader).toMatch(
         /__txn_state1=;.*Expires=Thu, 01 Jan 1970/
       );
-      8;
       expect(setCookieHeader).toMatch(
         /__txn_state2=;.*Expires=Thu, 01 Jan 1970/
       );

--- a/src/server/session/stateful-session-store.test.ts
+++ b/src/server/session/stateful-session-store.test.ts
@@ -41,7 +41,7 @@ describe("Stateful Session Store", async () => {
           id: sessionId
         },
         secret,
-        expiration,
+        expiration
       );
 
       const headers = new Headers();
@@ -109,7 +109,7 @@ describe("Stateful Session Store", async () => {
           id: sessionId
         },
         secret,
-        expiration,
+        expiration
       );
 
       const headers = new Headers();
@@ -477,7 +477,7 @@ describe("Stateful Session Store", async () => {
             id: sessionId
           },
           secret,
-          expiration,
+          expiration
         );
         const headers = new Headers();
         headers.append("cookie", `__session=${encryptedCookieValue}`);
@@ -765,7 +765,7 @@ describe("Stateful Session Store", async () => {
           id: sessionId
         },
         secret,
-        expiration,
+        expiration
       );
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -130,7 +130,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
     if (!sessionId) {
       sessionId = generateId();
     }
-    
+
     const maxAge = this.calculateMaxAge(session.internal.createdAt);
     const expiration = Date.now() / 1000 + maxAge;
     const jwe = await cookies.encrypt(
@@ -138,9 +138,9 @@ export class StatefulSessionStore extends AbstractSessionStore {
         id: sessionId
       },
       this.secret,
-      expiration,
+      expiration
     );
-    
+
     resCookies.set(this.sessionCookieName, jwe.toString(), {
       ...this.cookieConfig,
       maxAge

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -34,7 +34,9 @@ describe("Stateless Session Store", async () => {
         secret
       });
 
-      expect(await sessionStore.get(requestCookies)).toEqual(expect.objectContaining(session));
+      expect(await sessionStore.get(requestCookies)).toEqual(
+        expect.objectContaining(session)
+      );
     });
 
     it("should return null if no session cookie exists", async () => {
@@ -229,7 +231,9 @@ describe("Stateless Session Store", async () => {
         secret
       });
 
-      expect(await sessionStore.get(requestCookies)).toEqual(expect.objectContaining(session));
+      expect(await sessionStore.get(requestCookies)).toEqual(
+        expect.objectContaining(session)
+      );
     });
   });
 
@@ -277,7 +281,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("__session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");
@@ -320,9 +326,9 @@ describe("Stateless Session Store", async () => {
 
         expect(cookie).toBeDefined();
 
-        await expect(
-          decrypt(cookie!.value, secret)
-        ).rejects.toThrow(`"exp" claim timestamp check failed`);
+        await expect(decrypt(cookie!.value, secret)).rejects.toThrow(
+          `"exp" claim timestamp check failed`
+        );
       });
 
       it("should delete the legacy cookie if it exists", async () => {
@@ -424,7 +430,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("__session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");
@@ -464,7 +472,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("__session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");
@@ -503,7 +513,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("__session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("strict");
@@ -539,7 +551,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("__session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/custom-path");
       });
 
@@ -574,7 +588,9 @@ describe("Stateless Session Store", async () => {
         const cookie = responseCookies.get("custom-session");
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(session));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(session)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -22,7 +22,11 @@ describe("Transaction Store", async () => {
       };
       const maxAge = 60 * 60; // 1 hour in seconds
       const expiration = Math.floor(Date.now() / 1000 + maxAge);
-      const encryptedCookieValue = await encrypt(transactionState, secret, expiration);
+      const encryptedCookieValue = await encrypt(
+        transactionState,
+        secret,
+        expiration
+      );
 
       const headers = new Headers();
       headers.append("cookie", `__txn_${state}=${encryptedCookieValue}`);
@@ -52,7 +56,11 @@ describe("Transaction Store", async () => {
       };
       const maxAge = 60 * 60; // 1 hour in seconds
       const expiration = Math.floor(Date.now() / 1000 + maxAge);
-      const encryptedCookieValue = await encrypt(transactionState, secret, expiration);
+      const encryptedCookieValue = await encrypt(
+        transactionState,
+        secret,
+        expiration
+      );
 
       const headers = new Headers();
       headers.append("cookie", `__txn_incorrect-state=${encryptedCookieValue}`);
@@ -265,9 +273,9 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret)).payload).toEqual(expect.objectContaining(
-          transactionState
-        ));
+        expect((await decrypt(cookie!.value, secret)).payload).toEqual(
+          expect.objectContaining(transactionState)
+        );
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");

--- a/src/server/transaction-store.ts
+++ b/src/server/transaction-store.ts
@@ -120,4 +120,19 @@ export class TransactionStore {
   async delete(resCookies: cookies.ResponseCookies, state: string) {
     await resCookies.delete(this.getTransactionCookieName(state));
   }
+
+  /**
+   * Deletes all transaction cookies based on the configured prefix.
+   */
+  async deleteAll(
+    reqCookies: cookies.RequestCookies,
+    resCookies: cookies.ResponseCookies
+  ) {
+    const txnPrefix = this.getCookiePrefix();
+    reqCookies.getAll().forEach((cookie) => {
+      if (cookie.name.startsWith(txnPrefix)) {
+        resCookies.delete(cookie.name);
+      }
+    });
+  }
 }

--- a/src/server/transaction-store.ts
+++ b/src/server/transaction-store.ts
@@ -75,13 +75,25 @@ export class TransactionStore {
     return `${this.transactionCookiePrefix}${state}`;
   }
 
+  /**
+   * Returns the configured prefix for transaction cookies.
+   */
+  public getCookiePrefix(): string {
+    return this.transactionCookiePrefix;
+  }
+
   async save(
     resCookies: cookies.ResponseCookies,
     transactionState: TransactionState
   ) {
-
-    const expiration = Math.floor(Date.now() / 1000 + this.cookieConfig.maxAge!);
-    const jwe = await cookies.encrypt(transactionState, this.secret, expiration);
+    const expiration = Math.floor(
+      Date.now() / 1000 + this.cookieConfig.maxAge!
+    );
+    const jwe = await cookies.encrypt(
+      transactionState,
+      this.secret,
+      expiration
+    );
 
     if (!transactionState.state) {
       throw new Error("Transaction state is required");

--- a/src/testing/generate-session-cookie.test.ts
+++ b/src/testing/generate-session-cookie.test.ts
@@ -29,20 +29,22 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect((await decrypt(sessionCookie, secret)).payload).toEqual(expect.objectContaining({
-      user: {
-        sub: "user_123"
-      },
-      tokenSet: {
-        accessToken: "at_123",
-        refreshToken: "rt_123",
-        expiresAt: 123456
-      },
-      internal: {
-        sid: "auth0-sid",
-        createdAt: createdAt
-      }
-    }));
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual(
+      expect.objectContaining({
+        user: {
+          sub: "user_123"
+        },
+        tokenSet: {
+          accessToken: "at_123",
+          refreshToken: "rt_123",
+          expiresAt: 123456
+        },
+        internal: {
+          sid: "auth0-sid",
+          createdAt: createdAt
+        }
+      })
+    );
   });
 
   it("should populate the internal property if it was not provided", async () => {
@@ -60,20 +62,22 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect((await decrypt(sessionCookie, secret)).payload).toEqual(expect.objectContaining({
-      user: {
-        sub: "user_123"
-      },
-      tokenSet: {
-        accessToken: "at_123",
-        refreshToken: "rt_123",
-        expiresAt: 123456
-      },
-      internal: {
-        sid: "auth0-sid",
-        createdAt: expect.any(Number)
-      }
-    }));
+    expect((await decrypt(sessionCookie, secret)).payload).toEqual(
+      expect.objectContaining({
+        user: {
+          sub: "user_123"
+        },
+        tokenSet: {
+          accessToken: "at_123",
+          refreshToken: "rt_123",
+          expiresAt: 123456
+        },
+        internal: {
+          sid: "auth0-sid",
+          createdAt: expect.any(Number)
+        }
+      })
+    );
   });
 
   it("should not populate the internal property if a null was provided", async () => {
@@ -93,9 +97,11 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect((await decrypt(sessionCookie, secret)).payload).not.toEqual(expect.objectContaining({
-      internal: expect.anything()
-    }));
+    expect((await decrypt(sessionCookie, secret)).payload).not.toEqual(
+      expect.objectContaining({
+        internal: expect.anything()
+      })
+    );
   });
 
   it("should not populate the internal property if a undefined was provided", async () => {
@@ -114,8 +120,10 @@ describe("generateSessionCookie", async () => {
     };
     const sessionCookie = await generateSessionCookie(session, config);
     expect(sessionCookie).toEqual(expect.any(String));
-    expect((await decrypt(sessionCookie, secret)).payload).not.toEqual(expect.objectContaining({
-      internal: expect.anything()
-    }));
+    expect((await decrypt(sessionCookie, secret)).payload).not.toEqual(
+      expect.objectContaining({
+        internal: expect.anything()
+      })
+    );
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/auth0/nextjs-auth0/issues/1917

## Overview
The original logout handler (`handleLogout`) only deleted the session cookie, leaving transaction cookies behind. 
This caused potential accumulation of transaction state cookies (`__txn_{state}`) for users, particularly those who were unauthenticated or experienced interrupted login flows.

## Changes

*   Modified `AuthClient.handleLogout` to actively clear all transaction cookies (matching the transaction store's cookie prefix)
*   Added a public getter method `getCookiePrefix` to `TransactionStore`
* Added test file `redundant-txn-cookie-deletion.test.ts` to test this specific flow.
* Some linting changes.

## Tests
_PASSING_

## Usage
_No change in contract_
