### PR TITLE
Bugfix: Add clockTolerance to cookie decryption

### DIFF
--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -51,11 +51,10 @@ export async function decrypt<T>(
     BYTE_LENGTH
   );
 
-  const cookie = await jose.jwtDecrypt<T>(
-    cookieValue,
-    encryptionSecret,
-    options
-  );
+  const cookie = await jose.jwtDecrypt<T>(cookieValue, encryptionSecret, {
+    ...options,
+    ...{ clockTolerance: 15 }
+  });
 
   return cookie;
 }


### PR DESCRIPTION
Bugfix: Add clockTolerance to cookie decryption

This fixes `exp claim timestamp check failed`