### PR TITLE
fix(session): prevent accidental deletion of legacy-named session cookie

### DIFF
--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -152,7 +152,10 @@ export class StatefulSessionStore extends AbstractSessionStore {
 
     // Any existing v3 cookie can also be deleted once we have set a v4 cookie.
     // In stateful sessions, we do not have to worry about chunking.
-    if (reqCookies.has(LEGACY_COOKIE_NAME)) {
+    if (
+      this.sessionCookieName !== LEGACY_COOKIE_NAME &&
+      reqCookies.has(LEGACY_COOKIE_NAME)
+    ) {
       resCookies.delete(LEGACY_COOKIE_NAME);
     }
   }


### PR DESCRIPTION
When migrating from `nextjs-auth0` `v3` to `v4`, developers may want to preserve the legacy session cookie name (appSession). However, in stateful mode, the SDK deletes the legacy cookie unconditionally after setting the new session cookie which leads to the newly set cookie being immediately removed if the names match.

This behavior breaks login flows and causes unexpected session loss.

### 🛠️ Changes
This PR adds a conditional guard in StatefulSessionStore.set() to ensure that:
```
if (
    this.sessionCookieName !== LEGACY_COOKIE_NAME &&
    reqCookies.has(LEGACY_COOKIE_NAME)
) {
    resCookies.delete(LEGACY_COOKIE_NAME);
}
```

This prevents accidental deletion when session.name is set to `appSession` a common case during v3 to v4 upgrades.

Reported Issue: https://github.com/auth0/nextjs-auth0/issues/2111