### PR TITLE
fix(client): add type-safe return for getAccessToken

### DIFF
--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -1,6 +1,12 @@
 import { AccessTokenError } from "../../errors";
 
-export async function getAccessToken() {
+type AccessTokenResponse = {
+  token: string;
+  scope?: string;
+  expires_at?: number;
+};
+
+export async function getAccessToken(): Promise<string> {
   const tokenRes = await fetch(
     process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"
   );
@@ -23,6 +29,6 @@ export async function getAccessToken() {
     );
   }
 
-  const tokenSet = await tokenRes.json();
+  const tokenSet: AccessTokenResponse = await tokenRes.json();
   return tokenSet.token;
 }


### PR DESCRIPTION
### 🛠️ Changes
Adds explicit return type (`Promise<string>`) to `getAccessToken` and introduces a typed AccessTokenResponse interface for better `IntelliSense` and type safety. Helps prevent misuse of API response structure and ensures predictable access to the token.

Reported Issue: https://github.com/auth0/nextjs-auth0/issues/2113