### PR TITLE
bugfix/fix changelog v4 migration url 20250604152136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@ We will continue to add features and security upgrades in V4 going further. Plea
 
 **⚠️ BREAKING CHANGES**.
 
-Significant updates have been introduced in this release. Please refer to the V3 → V4 [MIGRATION GUIDE](https://github.com/auth0/nextjs-auth0/blob/v4/V4_MIGRATION_GUIDE.md) for details on upgrading.
+Significant updates have been introduced in this release. Please refer to the V3 → V4 [MIGRATION GUIDE](./V4_MIGRATION_GUIDE.md) for details on upgrading.
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## [v4.6.1](https://github.com/auth0/nextjs-auth0/tree/v4.6.1) (2025-06-04)
 [Full Changelog](https://github.com/auth0/nextjs-auth0/compare/v4.6.0...v4.6.1)
 
-**Changed**
-- Bump codecov/codecov-action from 5.4.2 to 5.4.3 [\#2102](https://github.com/auth0/nextjs-auth0/pull/2102) ([dependabot[bot]](https://github.com/apps/dependabot))
-
 **Fixed**
 - Fixes CVE-2025-48947
 - Fix Missing idToken during Session Migration from v3 to v4 #2116 [\#2120](https://github.com/auth0/nextjs-auth0/pull/2120) ([KentoMoriwaki](https://github.com/KentoMoriwaki))
@@ -21,29 +18,8 @@
 
 **Changed**
 - Update middleware combination example to prevent unintended backend execution [\#2076](https://github.com/auth0/nextjs-auth0/pull/2076) ([tusharpandey13](https://github.com/tusharpandey13))
-- Bump eslint-plugin-react from 7.37.4 to 7.37.5 [\#2091](https://github.com/auth0/nextjs-auth0/pull/2091) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump @playwright/test from 1.50.1 to 1.52.0 [\#2092](https://github.com/auth0/nextjs-auth0/pull/2092) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump @vitest/coverage-v8 from 2.1.4 to 2.1.9 [\#2093](https://github.com/auth0/nextjs-auth0/pull/2093) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump typescript-eslint from 8.32.0 to 8.32.1 [\#2094](https://github.com/auth0/nextjs-auth0/pull/2094) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump eslint-config-prettier from 10.0.1 to 10.1.5 [\#2090](https://github.com/auth0/nextjs-auth0/pull/2090) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump oauth4webapi from 3.1.4 to 3.5.1 [\#2085](https://github.com/auth0/nextjs-auth0/pull/2085) ([dependabot[bot]](https://github.com/apps/dependabot))
-- chore(deps): bump @eslint/plugin-kit from 0.2.2 to 0.2.7 in /examples/with-shadcn [\#1995](https://github.com/auth0/nextjs-auth0/pull/1995) ([dependabot[bot]](https://github.com/apps/dependabot))
-- build(deps): bump jose from 5.9.6 to 5.10.0 [\#1956](https://github.com/auth0/nextjs-auth0/pull/1956) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump codecov/codecov-action from 5.3.1 to 5.4.2 [\#2058](https://github.com/auth0/nextjs-auth0/pull/2058) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump swr from 2.3.2 to 2.3.3 [\#2086](https://github.com/auth0/nextjs-auth0/pull/2086) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump typescript-eslint from 8.24.0 to 8.32.0 [\#2084](https://github.com/auth0/nextjs-auth0/pull/2084) ([dependabot[bot]](https://github.com/apps/dependabot))
-- chore(deps): bump next from 15.0.2 to 15.2.3 in /examples/with-shadcn [\#1986](https://github.com/auth0/nextjs-auth0/pull/1986) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump next from 15.0.3 to 15.2.4 in /examples/with-next-intl [\#2029](https://github.com/auth0/nextjs-auth0/pull/2029) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Update deleteByLogoutToken arg type in EXAMPLES.md [\#2067](https://github.com/auth0/nextjs-auth0/pull/2067) ([ammubhave](https://github.com/ammubhave))
-- Bump @auth0/nextjs-auth0 from 4.0.1 to 4.5.1 in /examples/with-shadcn [\#2073](https://github.com/auth0/nextjs-auth0/pull/2073) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump @eslint/js from 9.20.0 to 9.26.0 [\#2078](https://github.com/auth0/nextjs-auth0/pull/2078) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump vite from 5.4.14 to 5.4.19 [\#2075](https://github.com/auth0/nextjs-auth0/pull/2075) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump typedoc from 0.27.7 to 0.28.4 [\#2079](https://github.com/auth0/nextjs-auth0/pull/2079) ([dependabot[bot]](https://github.com/apps/dependabot))
-- chore(deps-dev): bump globals from 15.14.0 to 15.15.0 [\#1969](https://github.com/auth0/nextjs-auth0/pull/1969) ([dependabot[bot]](https://github.com/apps/dependabot))
-- chore(deps-dev): bump prettier from 3.4.2 to 3.5.3 [\#1967](https://github.com/auth0/nextjs-auth0/pull/1967) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 **Fixed**
-- Usability upgrades to V4 Migration Guide [\#2095](https://github.com/auth0/nextjs-auth0/pull/2095) ([nandan-bhat](https://github.com/nandan-bhat))
 - Bugfix: Add clockTolerance to cookie decryption [\#2097](https://github.com/auth0/nextjs-auth0/pull/2097) ([tusharpandey13](https://github.com/tusharpandey13))
 - Fix stacking transaction cookies [\#2077](https://github.com/auth0/nextjs-auth0/pull/2077) ([tusharpandey13](https://github.com/tusharpandey13))
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -77,7 +77,7 @@ For example: `/auth/login?returnTo=/dashboard` would redirect the user to the `/
 
 The `returnTo` parameter can be appended to the logout to specify where you would like to redirect the user after they have logged out.
 
-For example: `/auth/login?returnTo=https://example.com/some-page` would redirect the user to the `https://example.com/some-page` URL after they have logged out.
+For example: `/auth/logout?returnTo=https://example.com/some-page` would redirect the user to the `https://example.com/some-page` URL after they have logged out.
 
 > [!NOTE]  
 > The URL specified as `returnTo` parameters must be registered in your client's **Allowed Logout URLs**.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.5.3
       typedoc:
         specifier: ^0.28.4
-        version: 0.28.4(typescript@5.7.3)
+        version: 0.28.5(typescript@5.7.3)
       typescript:
         specifier: ^5.6.3
         version: 5.7.3
@@ -404,8 +404,8 @@ packages:
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gerrit0/mini-shiki@3.4.0':
-    resolution: {integrity: sha512-48lKoQegmfJ0iyR/jRz5OrYOSM3WewG9YWCPqUvYFEC54shQO8RsAaspaK/2PRHVVnjekRqfAFvq8pwCpIo5ig==}
+  '@gerrit0/mini-shiki@3.4.2':
+    resolution: {integrity: sha512-3jXo5bNjvvimvdbIhKGfFxSnKCX+MA8wzHv55ptzk/cx8wOzT+BRcYgj8aFN3yTiTs+zvQQiaZFr7Jce1ZG3fw==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -790,17 +790,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@shikijs/engine-oniguruma@3.4.0':
-    resolution: {integrity: sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==}
+  '@shikijs/engine-oniguruma@3.4.2':
+    resolution: {integrity: sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==}
 
-  '@shikijs/langs@3.4.0':
-    resolution: {integrity: sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==}
+  '@shikijs/langs@3.4.2':
+    resolution: {integrity: sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==}
 
-  '@shikijs/themes@3.4.0':
-    resolution: {integrity: sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==}
+  '@shikijs/themes@3.4.2':
+    resolution: {integrity: sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==}
 
-  '@shikijs/types@3.4.0':
-    resolution: {integrity: sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==}
+  '@shikijs/types@3.4.2':
+    resolution: {integrity: sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -2349,8 +2349,8 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typedoc@0.28.4:
-    resolution: {integrity: sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==}
+  typedoc@0.28.5:
+    resolution: {integrity: sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
@@ -2539,9 +2539,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@21.1.1:
@@ -2809,12 +2809,12 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  '@gerrit0/mini-shiki@3.4.0':
+  '@gerrit0/mini-shiki@3.4.2':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.4.0
-      '@shikijs/langs': 3.4.0
-      '@shikijs/themes': 3.4.0
-      '@shikijs/types': 3.4.0
+      '@shikijs/engine-oniguruma': 3.4.2
+      '@shikijs/langs': 3.4.2
+      '@shikijs/themes': 3.4.2
+      '@shikijs/types': 3.4.2
       '@shikijs/vscode-textmate': 10.0.2
 
   '@humanfs/core@0.19.1': {}
@@ -3097,20 +3097,20 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.2':
     optional: true
 
-  '@shikijs/engine-oniguruma@3.4.0':
+  '@shikijs/engine-oniguruma@3.4.2':
     dependencies:
-      '@shikijs/types': 3.4.0
+      '@shikijs/types': 3.4.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.4.0':
+  '@shikijs/langs@3.4.2':
     dependencies:
-      '@shikijs/types': 3.4.0
+      '@shikijs/types': 3.4.2
 
-  '@shikijs/themes@3.4.0':
+  '@shikijs/themes@3.4.2':
     dependencies:
-      '@shikijs/types': 3.4.0
+      '@shikijs/types': 3.4.2
 
-  '@shikijs/types@3.4.0':
+  '@shikijs/types@3.4.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -4966,14 +4966,14 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc@0.28.4(typescript@5.7.3):
+  typedoc@0.28.5(typescript@5.7.3):
     dependencies:
-      '@gerrit0/mini-shiki': 3.4.0
+      '@gerrit0/mini-shiki': 3.4.2
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       typescript: 5.7.3
-      yaml: 2.7.1
+      yaml: 2.8.0
 
   typescript-eslint@8.33.1(eslint@9.20.0)(typescript@5.7.3):
     dependencies:
@@ -5171,7 +5171,7 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml@2.7.1: {}
+  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3)))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3)))
       eslint:
         specifier: ^9.20.0
         version: 9.20.0
@@ -77,7 +77,7 @@ importers:
         version: 26.1.0
       msw:
         specifier: ^2.7.5
-        version: 2.7.5(@types/node@22.13.1)(typescript@5.7.3)
+        version: 2.9.0(@types/node@22.13.1)(typescript@5.7.3)
       next:
         specifier: 15.2.3
         version: 15.2.3(@playwright/test@1.52.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -98,7 +98,7 @@ importers:
         version: 5.4.19(@types/node@22.13.1)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3))
+        version: 2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3))
 
 packages:
 
@@ -541,8 +541,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/confirm@5.1.9':
-    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
+  '@inquirer/confirm@5.1.12':
+    resolution: {integrity: sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -550,8 +550,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.10':
-    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
+  '@inquirer/core@10.1.13':
+    resolution: {integrity: sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -559,12 +559,12 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.11':
-    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+  '@inquirer/figures@1.0.12':
+    resolution: {integrity: sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==}
     engines: {node: '>=18'}
 
-  '@inquirer/type@3.0.6':
-    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
+  '@inquirer/type@3.0.7':
+    resolution: {integrity: sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -598,8 +598,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@mswjs/interceptors@0.37.6':
-    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
+  '@mswjs/interceptors@0.38.7':
+    resolution: {integrity: sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==}
     engines: {node: '>=18'}
 
   '@next/env@15.2.3':
@@ -1502,8 +1502,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql@16.10.0:
-    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+  graphql@16.11.0:
+    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
@@ -1827,8 +1827,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.7.5:
-    resolution: {integrity: sha512-00MyTlY3TJutBa5kiU+jWiz2z5pNJDYHn2TgPkGkh92kMmNH43RqvMXd8y/7HxNn8RjzUbvZWYZjcS36fdb6sw==}
+  msw@2.9.0:
+    resolution: {integrity: sha512-fNyrJ11YNbe2zl64EwtxM5OFkInFPAw5vipOljMsf9lY2ep9B2BslqQrS8EC9pB9961K61FqTUi0wsdqk6hwow==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -2329,8 +2329,8 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@4.40.0:
-    resolution: {integrity: sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==}
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
@@ -2916,17 +2916,17 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/confirm@5.1.9(@types/node@22.13.1)':
+  '@inquirer/confirm@5.1.12(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/core': 10.1.10(@types/node@22.13.1)
-      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      '@inquirer/core': 10.1.13(@types/node@22.13.1)
+      '@inquirer/type': 3.0.7(@types/node@22.13.1)
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/core@10.1.10(@types/node@22.13.1)':
+  '@inquirer/core@10.1.13(@types/node@22.13.1)':
     dependencies:
-      '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.6(@types/node@22.13.1)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@22.13.1)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -2936,9 +2936,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.1
 
-  '@inquirer/figures@1.0.11': {}
+  '@inquirer/figures@1.0.12': {}
 
-  '@inquirer/type@3.0.6(@types/node@22.13.1)':
+  '@inquirer/type@3.0.7(@types/node@22.13.1)':
     optionalDependencies:
       '@types/node': 22.13.1
 
@@ -2970,7 +2970,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mswjs/interceptors@0.37.6':
+  '@mswjs/interceptors@0.38.7':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -3315,7 +3315,7 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3)))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -3329,7 +3329,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3))
+      vitest: 2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -3340,13 +3340,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.19(@types/node@22.13.1))':
+  '@vitest/mocker@2.1.9(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.19(@types/node@22.13.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.5(@types/node@22.13.1)(typescript@5.7.3)
+      msw: 2.9.0(@types/node@22.13.1)(typescript@5.7.3)
       vite: 5.4.19(@types/node@22.13.1)
 
   '@vitest/pretty-format@2.1.9':
@@ -4013,7 +4013,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql@16.10.0: {}
+  graphql@16.11.0: {}
 
   has-bigints@1.1.0: {}
 
@@ -4361,25 +4361,25 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3):
+  msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.9(@types/node@22.13.1)
-      '@mswjs/interceptors': 0.37.6
+      '@inquirer/confirm': 5.1.12(@types/node@22.13.1)
+      '@mswjs/interceptors': 0.38.7
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
       '@types/statuses': 2.0.5
-      graphql: 16.10.0
+      graphql: 16.11.0
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
       strict-event-emitter: 0.5.1
-      type-fest: 4.40.0
+      type-fest: 4.41.0
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.7.3
@@ -4931,7 +4931,7 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@4.40.0: {}
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5040,10 +5040,10 @@ snapshots:
       '@types/node': 22.13.1
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3)):
+  vitest@2.1.9(@types/node@22.13.1)(jsdom@26.1.0)(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.7.5(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.19(@types/node@22.13.1))
+      '@vitest/mocker': 2.1.9(msw@2.9.0(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.19(@types/node@22.13.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9


### PR DESCRIPTION
- **Bump typedoc from 0.28.4 to 0.28.5 (#2121)**
- **Bump msw from 2.7.5 to 2.9.0 (#2139)**
- **update logout url in examples (#2133)**
- **docs: fix migration guide URL for v4**
- **Trim changelog (#2144)**
