### PR TITLE
remove redundant console error statement

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -732,7 +732,7 @@ export class AuthClient {
             refreshTokenRes
           );
         } catch (e: any) {
-          console.error(e);
+          // console.error(e);
           return [
             new AccessTokenError(
               AccessTokenErrorCode.FAILED_TO_REFRESH_TOKEN,


### PR DESCRIPTION
Fixes: #2107 

Removes redundant `console.error` statement.