### PR TITLE
release/v3.8.0

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -44,7 +44,7 @@ runs:
         elif [[ "${VERSION}" == *"alpha"* ]]; then
           TAG="alpha"
         else
-          TAG="v3"
+          TAG="legacy-v3"
         fi
         npm publish --provenance --tag $TAG
       env:


### PR DESCRIPTION
Changed the target tag name for v3 to "legacy-v3" to avoid the error
```log
npm error Tag name must not be a valid SemVer range: v3
```