### PR TITLE
chore: return a 204 from the profile endpoint when unauthenticated

### DIFF
--- a/src/client/hooks/use-user.integration.test.tsx
+++ b/src/client/hooks/use-user.integration.test.tsx
@@ -146,4 +146,28 @@ describe("useUser Integration with SWR Cache", () => {
     // Verify fetch was called twice
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("should handle unauthenticated requests to the profile endpoint", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 204
+      })
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <swrModule.SWRConfig value={{ provider: () => new Map() }}>
+        {children}
+      </swrModule.SWRConfig>
+    );
+
+    const { result } = renderHook(() => useUser(), { wrapper });
+
+    // Wait for the initial data to load
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.user).toEqual(null);
+    expect(result.current.error).toBe(undefined);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalledWith("/auth/profile");
+  });
 });

--- a/src/client/hooks/use-user.ts
+++ b/src/client/hooks/use-user.ts
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 
+import { FetchProfileError } from "../../errors";
 import type { User } from "../../types";
 
 export function useUser() {
@@ -10,8 +11,13 @@ export function useUser() {
     (...args) =>
       fetch(...args).then((res) => {
         if (!res.ok) {
-          throw new Error("Unauthorized");
+          throw new FetchProfileError(res.status);
         }
+
+        if (res.status === 204) {
+          return null;
+        }
+
         return res.json();
       })
   );

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -144,3 +144,14 @@ export class AccessTokenForConnectionError extends SdkError {
     this.cause = cause;
   }
 }
+
+export class FetchProfileError extends SdkError {
+  public code: string = "fetch_profile_error";
+  public status: number;
+
+  constructor(status: number) {
+    super();
+    this.name = "FetchProfileError";
+    this.status = status;
+  }
+}

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -2245,6 +2245,42 @@ ca/T0LLtgmbMmxSv/MmzIg==
       expect(response.status).toEqual(401);
       expect(response.body).toBeNull();
     });
+
+    it("should return a 204 if the user is not authenticated and emptyProfileResponseWhenUnauthenticated is enabled", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({
+        secret
+      });
+      const sessionStore = new StatelessSessionStore({
+        secret
+      });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+
+        fetch: getMockAuthorizationServer(),
+
+        emptyProfileResponseWhenUnauthenticated: true
+      });
+
+      const request = new NextRequest(
+        new URL("/auth/profile", DEFAULT.appBaseUrl),
+        {
+          method: "GET"
+        }
+      );
+
+      const response = await authClient.handleProfile(request);
+      expect(response.status).toEqual(204);
+      expect(response.body).toBeNull();
+    });
   });
 
   describe("handleCallback", async () => {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -135,6 +135,7 @@ export interface AuthClientOptions {
   httpTimeout?: number;
   enableTelemetry?: boolean;
   enableAccessTokenEndpoint?: boolean;
+  emptyProfileResponseWhenUnauthenticated?: boolean;
 }
 
 function createRouteUrl(url: string, base: string) {
@@ -169,6 +170,7 @@ export class AuthClient {
   private authorizationServerMetadata?: oauth.AuthorizationServer;
 
   private readonly enableAccessTokenEndpoint: boolean;
+  private readonly emptyProfileResponseWhenUnauthenticated: boolean;
 
   constructor(options: AuthClientOptions) {
     // dependencies
@@ -258,6 +260,8 @@ export class AuthClient {
     };
 
     this.enableAccessTokenEndpoint = options.enableAccessTokenEndpoint ?? true;
+    this.emptyProfileResponseWhenUnauthenticated =
+      options.emptyProfileResponseWhenUnauthenticated ?? false;
   }
 
   async handler(req: NextRequest): Promise<NextResponse> {
@@ -580,6 +584,12 @@ export class AuthClient {
     const session = await this.sessionStore.get(req.cookies);
 
     if (!session) {
+      if (this.emptyProfileResponseWhenUnauthenticated) {
+        return new NextResponse(null, {
+          status: 204
+        });
+      }
+
       return new NextResponse(null, {
         status: 401
       });

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -168,6 +168,14 @@ export interface Auth0ClientOptions {
    * See: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps#name-token-mediating-backend
    */
   enableAccessTokenEndpoint?: boolean;
+
+  /**
+   * If true, the profile endpoint will return a 204 No Content response when the user is not authenticated
+   * instead of returning a 401 Unauthorized response.
+   *
+   * Defaults to `false`.
+   */
+  emptyProfileResponseWhenUnauthenticated?: boolean;
 }
 
 export type PagesRouterRequest = IncomingMessage | NextApiRequest;
@@ -270,7 +278,9 @@ export class Auth0Client {
       allowInsecureRequests: options.allowInsecureRequests,
       httpTimeout: options.httpTimeout,
       enableTelemetry: options.enableTelemetry,
-      enableAccessTokenEndpoint: options.enableAccessTokenEndpoint
+      enableAccessTokenEndpoint: options.enableAccessTokenEndpoint,
+      emptyProfileResponseWhenUnauthenticated:
+        options.emptyProfileResponseWhenUnauthenticated
     });
   }
 


### PR DESCRIPTION
### 📋 Changes

This PR adds an configuration to return a `204 No Content` response from the profile endpoint when the user is not authenticated. This avoids undesirable few cases:

- Automatic retries on errors (401s)
- Clearing of the basic auth state (fixes: https://github.com/auth0/nextjs-auth0/issues/1933)
- Periodic logging of errors in the console/network tabs when attempting to revalidate while unauthenticated

### 📎 References

Relevant issue: https://github.com/auth0/nextjs-auth0/issues/1933

### 🎯 Testing

- PR includes tests for the `useUser()` hook and server components
- A sample repository for testing can also be found in the issue linked above
