### PR TITLE
Force Refresh Access Token Enhancements

### DIFF
--- a/e2e/app-router.spec.ts
+++ b/e2e/app-router.spec.ts
@@ -56,13 +56,33 @@ test("getAccessToken()", async ({ page }) => {
   await page.fill('input[id="password"]', process.env.TEST_USER_PASSWORD!);
   await page.getByText("Continue", { exact: true }).click();
 
-  // fetch a token
+  // request a token
   const requestPromise = page.waitForRequest("/auth/access-token");
-  await page.getByText("Get token").click();
+  await page.getByText("Get access token").click();
+  const request = await requestPromise;
+  const tokenRequest = await (await request?.response())?.json();
+  expect(tokenRequest).toHaveProperty("token");
+  expect(tokenRequest).toHaveProperty("expires_at");
+});
+
+test("getAccessToken() with force refresh", async ({ page }) => {
+  await page.goto("/auth/login?returnTo=/app-router/client");
+
+  // fill out Auth0 form
+  await page.fill('input[id="username"]', "test@example.com");
+  await page.fill('input[id="password"]', process.env.TEST_USER_PASSWORD!);
+  await page.getByText("Continue", { exact: true }).click();
+
+  // force refresh a token
+  const requestPromise = page.waitForRequest("/auth/access-token?refresh=true");
+  await page.getByText("Force refresh token").click();
   const request = await requestPromise;
   const tokenRequest = await (await request.response())?.json();
   expect(tokenRequest).toHaveProperty("token");
   expect(tokenRequest).toHaveProperty("expires_at");
+
+  // Verify that the request URL contains the refresh parameter
+  expect(request.url()).toContain("refresh=true");
 });
 
 test("protected server route", async ({ page, context }) => {

--- a/e2e/test-app/app/app-router/client/page.tsx
+++ b/e2e/test-app/app/app-router/client/page.tsx
@@ -21,6 +21,11 @@ export default function Profile() {
     )
   }
 
+  const handleForceRefresh = async () => {
+    // TypeScript workaround: cast to any to use the overloaded signature
+    await (getAccessToken as any)({ refresh: true })
+  }
+
   return (
     <main>
       <h1>Welcome, {user?.email}!</h1>
@@ -29,7 +34,12 @@ export default function Profile() {
           await getAccessToken()
         }}
       >
-        Get token
+        Get access token
+      </button>
+      <button
+        onClick={handleForceRefresh}
+      >
+        Force refresh token
       </button>
     </main>
   )

--- a/e2e/test-app/pages/pages-router/client/index.tsx
+++ b/e2e/test-app/pages/pages-router/client/index.tsx
@@ -21,6 +21,12 @@ export default function Profile() {
     )
   }
 
+  const handleForceRefresh = async () => {
+    // TypeScript workaround: cast to any to use the overloaded signature
+    const token = await (getAccessToken as any)({ refresh: true })
+    setToken(token)
+  }
+
   return (
     <main>
       <h1>Welcome, {user?.email}!</h1>
@@ -35,7 +41,12 @@ export default function Profile() {
           setToken(token)
         }}
       >
-        Get token
+        Get access token
+      </button>
+      <button
+        onClick={handleForceRefresh}
+      >
+        Force refresh token
       </button>
     </main>
   )

--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -6,10 +6,50 @@ type AccessTokenResponse = {
   expires_at?: number;
 };
 
-export async function getAccessToken(): Promise<string> {
-  const tokenRes = await fetch(
-    process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"
-  );
+export type GetAccessTokenOptions = {
+  /**
+   * Force a refresh of the access token.
+   */
+  refresh?: boolean;
+};
+
+/**
+ * Retrieves an access token from the `/auth/access-token` endpoint.
+ *
+ * @returns The access token string.
+ * @throws {AccessTokenError} If there's an error retrieving the access token.
+ */
+export async function getAccessToken(): Promise<string>;
+
+/**
+ * Retrieves an access token from the `/auth/access-token` endpoint.
+ *
+ * @param options Configuration for getting the access token.
+ * @returns The access token string.
+ * @throws {AccessTokenError} If there's an error retrieving the access token.
+ */
+export async function getAccessToken(
+  options: GetAccessTokenOptions
+): Promise<string>;
+
+/**
+ * Retrieves an access token from the `/auth/access-token` endpoint.
+ *
+ * @param options Optional configuration for getting the access token.
+ * @returns The access token string.
+ * @throws {AccessTokenError} If there's an error retrieving the access token.
+ */
+export async function getAccessToken(
+  options?: GetAccessTokenOptions
+): Promise<string> {
+  const searchParams = new URLSearchParams();
+  if (options?.refresh) {
+    searchParams.set("refresh", "true");
+  }
+
+  const url = `${process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+
+  const tokenRes = await fetch(url);
 
   if (!tokenRes.ok) {
     // try to parse it as JSON and throw the error from the API

--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -47,7 +47,9 @@ export async function getAccessToken(
     searchParams.set("refresh", "true");
   }
 
-  const url = `${process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+  const baseUrl = `${process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE}` || "/auth/access-token";
+  const queryParams = searchParams.toString() ? `?${searchParams.toString()}` : "";
+  const url = `${baseUrl}${queryParams}`;
 
   const tokenRes = await fetch(url);
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,6 @@
 export { useUser } from "./hooks/use-user";
-export { getAccessToken } from "./helpers/get-access-token";
+export {
+  getAccessToken,
+  type GetAccessTokenOptions
+} from "./helpers/get-access-token";
 export { Auth0Provider } from "./providers/auth0-provider";

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -590,6 +590,12 @@ export class AuthClient {
   }
 
   async handleAccessToken(req: NextRequest): Promise<NextResponse> {
+    if (!this.enableAccessTokenEndpoint) {
+      return new NextResponse("Not Found", {
+        status: 404
+      });
+    }
+
     const session = await this.sessionStore.get(req.cookies);
 
     if (!session) {
@@ -606,7 +612,11 @@ export class AuthClient {
       );
     }
 
-    const [error, updatedTokenSet] = await this.getTokenSet(session.tokenSet);
+    const refresh = req.nextUrl.searchParams.get("refresh") === "true";
+    const [error, updatedTokenSet] = await this.getTokenSet(
+      session.tokenSet,
+      refresh
+    );
 
     if (error) {
       return NextResponse.json(


### PR DESCRIPTION
- Added force refresh capability to client counterpart getAccessToken()
- Added a refresh:boolean searchParam /auth/access-token for force refresh
- Updated examples