### PR TITLE
Fix: Update getAccessToken import and usage in examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -533,12 +533,12 @@ When calling `getAccessToken` without request and response objects, you can pass
 
 ```typescript
 // app/api/my-api/route.ts
-import { getAccessToken } from '@auth0/nextjs-auth0';
+import { auth0 } from "@/lib/auth0"
 
 export async function GET() {
   try {
     // Force a refresh of the access token
-    const { token, expiresAt } = await getAccessToken({ refresh: true });
+    const { token, expiresAt } = await auth0.getAccessToken({ refresh: true });
 
     // Use the refreshed token
     // ...


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This commit updates the documentation examples for getAccessToken within Next.js API route handlers.

The previous examples inadvertently suggested importing getAccessToken directly from @auth0/nextjs-auth0, which is intended for client-side contexts. In server-rendered routes, getAccessToken should be accessed via the auth0 instance (e.g., auth0.getAccessToken()), aligning with how the Auth0 SDK is initialized for server-side operations.

This correction ensures the documentation accurately reflects the proper and recommended way to use getAccessToken, preventing confusion and potential implementation errors.

### 🎯 Testing

Change only affect docs
