### PR TITLE
feat: support `basePath` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Create an instance of the Auth0 client. This instance will be imported and used 
 Add the following contents to a file named `lib/auth0.ts`:
 
 ```ts
-import { Auth0Client } from "@auth0/nextjs-auth0/server"
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
-export const auth0 = new Auth0Client()
+export const auth0 = new Auth0Client();
 ```
 
 ### 4. Add the authentication middleware
@@ -70,12 +70,12 @@ export const auth0 = new Auth0Client()
 Create a `middleware.ts` file in the root of your project's directory:
 
 ```ts
-import type { NextRequest } from "next/server"
+import type { NextRequest } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function middleware(request: NextRequest) {
-  return await auth0.middleware(request)
+  return await auth0.middleware(request);
 }
 
 export const config = {
@@ -86,9 +86,9 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
-  ],
-}
+    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+  ]
+};
 ```
 
 > [!NOTE]  
@@ -97,10 +97,10 @@ export const config = {
 You can now begin to authenticate your users by redirecting them to your application's `/auth/login` route:
 
 ```tsx
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export default async function Home() {
-  const session = await auth0.getSession()
+  const session = await auth0.getSession();
 
   if (!session) {
     return (
@@ -108,14 +108,14 @@ export default async function Home() {
         <a href="/auth/login?screen_hint=signup">Sign up</a>
         <a href="/auth/login">Log in</a>
       </main>
-    )
+    );
   }
 
   return (
     <main>
       <h1>Welcome, {session.user.name}!</h1>
     </main>
-  )
+  );
 }
 ```
 
@@ -126,29 +126,31 @@ export default async function Home() {
 
 You can customize the client by using the options below:
 
-| Option                      | Type                      | Description                                                                                                                                                                                                                            |
-| --------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| domain                      | `string`                  | The Auth0 domain for the tenant (e.g.: `example.us.auth0.com` or `https://example.us.auth0.com`). If it's not specified, it will be loaded from the `AUTH0_DOMAIN` environment variable.                                               |
-| clientId                    | `string`                  | The Auth0 client ID. If it's not specified, it will be loaded from the `AUTH0_CLIENT_ID` environment variable.                                                                                                                         |
-| clientSecret                | `string`                  | The Auth0 client secret. If it's not specified, it will be loaded from the `AUTH0_CLIENT_SECRET` environment variable.                                                                                                                 |
-| authorizationParameters     | `AuthorizationParameters` | The authorization parameters to pass to the `/authorize` endpoint. See [Passing authorization parameters](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#passing-authorization-parameters) for more details.                                                                         |
-| clientAssertionSigningKey   | `string` or `CryptoKey`   | Private key for use with `private_key_jwt` clients. This can also be specified via the `AUTH0_CLIENT_ASSERTION_SIGNING_KEY` environment variable.                                                                                      |
-| clientAssertionSigningAlg   | `string`                  | The algorithm used to sign the client assertion JWT. This can also be provided via the `AUTH0_CLIENT_ASSERTION_SIGNING_ALG` environment variable.                                                                                      |
-| appBaseUrl                  | `string`                  | The URL of your application (e.g.: `http://localhost:3000`). If it's not specified, it will be loaded from the `APP_BASE_URL` environment variable.                                                                                    |
-| secret                      | `string`                  | A 32-byte, hex-encoded secret used for encrypting cookies. If it's not specified, it will be loaded from the `AUTH0_SECRET` environment variable.                                                                                      |
-| signInReturnToPath          | `string`                  | The path to redirect the user to after successfully authenticating. Defaults to `/`.                                                                                                                                                   |
-| session                     | `SessionConfiguration`    | Configure the session timeouts and whether to use rolling sessions or not. See [Session configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#session-configuration) for additional details. Also allows configuration of cookie attributes like `domain`, `path`, `secure`, `sameSite`, and `transient`. If not specified, these can be configured using `AUTH0_COOKIE_*` environment variables. Note: `httpOnly` is always `true`. See [Cookie Configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#cookie-configuration) for details.  |
-| beforeSessionSaved          | `BeforeSessionSavedHook`  | A method to manipulate the session before persisting it. See [beforeSessionSaved](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#beforesessionsaved) for additional details.                                                                                                         |
-| onCallback                  | `OnCallbackHook`          | A method to handle errors or manage redirects after attempting to authenticate. See [onCallback](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#oncallback) for additional details.                                                                                                  |
-| sessionStore                | `SessionStore`            | A custom session store implementation used to persist sessions to a data store. See [Database sessions](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#database-sessions) for additional details.                                                                                    |
-| pushedAuthorizationRequests | `boolean`                 | Configure the SDK to use the Pushed Authorization Requests (PAR) protocol when communicating with the authorization server.                                                                                                            |
-| routes                      | `Routes`                  | Configure the paths for the authentication routes. See [Custom routes](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#custom-routes) for additional details.                                                                                                                         |
-| allowInsecureRequests       | `boolean`                 | Allow insecure requests to be made to the authorization server. This can be useful when testing with a mock OIDC provider that does not support TLS, locally. This option can only be used when `NODE_ENV` is not set to `production`. |
-| httpTimeout                 | `number`                  | Integer value for the HTTP timeout in milliseconds for authentication requests. Defaults to `5000` milliseconds                                                                                                                        |
-| enableTelemetry             | `boolean`                 | Boolean value to opt-out of sending the library name and version to your authorization server via the `Auth0-Client` header. Defaults to `true`.                                                                                       |
+| Option                      | Type                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| domain                      | `string`                  | The Auth0 domain for the tenant (e.g.: `example.us.auth0.com` or `https://example.us.auth0.com`). If it's not specified, it will be loaded from the `AUTH0_DOMAIN` environment variable.                                                                                                                                                                                                                                                                                                                                                                                            |
+| clientId                    | `string`                  | The Auth0 client ID. If it's not specified, it will be loaded from the `AUTH0_CLIENT_ID` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| clientSecret                | `string`                  | The Auth0 client secret. If it's not specified, it will be loaded from the `AUTH0_CLIENT_SECRET` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| authorizationParameters     | `AuthorizationParameters` | The authorization parameters to pass to the `/authorize` endpoint. See [Passing authorization parameters](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#passing-authorization-parameters) for more details.                                                                                                                                                                                                                                                                                                                                                           |
+| clientAssertionSigningKey   | `string` or `CryptoKey`   | Private key for use with `private_key_jwt` clients. This can also be specified via the `AUTH0_CLIENT_ASSERTION_SIGNING_KEY` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| clientAssertionSigningAlg   | `string`                  | The algorithm used to sign the client assertion JWT. This can also be provided via the `AUTH0_CLIENT_ASSERTION_SIGNING_ALG` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| appBaseUrl                  | `string`                  | The URL of your application (e.g.: `http://localhost:3000`). If it's not specified, it will be loaded from the `APP_BASE_URL` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| secret                      | `string`                  | A 32-byte, hex-encoded secret used for encrypting cookies. If it's not specified, it will be loaded from the `AUTH0_SECRET` environment variable.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| signInReturnToPath          | `string`                  | The path to redirect the user to after successfully authenticating. Defaults to `/`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| session                     | `SessionConfiguration`    | Configure the session timeouts and whether to use rolling sessions or not. See [Session configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#session-configuration) for additional details. Also allows configuration of cookie attributes like `domain`, `path`, `secure`, `sameSite`, and `transient`. If not specified, these can be configured using `AUTH0_COOKIE_*` environment variables. Note: `httpOnly` is always `true`. See [Cookie Configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#cookie-configuration) for details. |
+| beforeSessionSaved          | `BeforeSessionSavedHook`  | A method to manipulate the session before persisting it. See [beforeSessionSaved](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#beforesessionsaved) for additional details.                                                                                                                                                                                                                                                                                                                                                                                           |
+| onCallback                  | `OnCallbackHook`          | A method to handle errors or manage redirects after attempting to authenticate. See [onCallback](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#oncallback) for additional details.                                                                                                                                                                                                                                                                                                                                                                                    |
+| sessionStore                | `SessionStore`            | A custom session store implementation used to persist sessions to a data store. See [Database sessions](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#database-sessions) for additional details.                                                                                                                                                                                                                                                                                                                                                                      |
+| pushedAuthorizationRequests | `boolean`                 | Configure the SDK to use the Pushed Authorization Requests (PAR) protocol when communicating with the authorization server.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| routes                      | `Routes`                  | Configure the paths for the authentication routes. See [Custom routes](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#custom-routes) for additional details.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| allowInsecureRequests       | `boolean`                 | Allow insecure requests to be made to the authorization server. This can be useful when testing with a mock OIDC provider that does not support TLS, locally. This option can only be used when `NODE_ENV` is not set to `production`.                                                                                                                                                                                                                                                                                                                                              |
+| httpTimeout                 | `number`                  | Integer value for the HTTP timeout in milliseconds for authentication requests. Defaults to `5000` milliseconds                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| enableTelemetry             | `boolean`                 | Boolean value to opt-out of sending the library name and version to your authorization server via the `Auth0-Client` header. Defaults to `true`.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ## Session Cookie Configuration
+
 You can specify the following environment variables to configure the session cookie:
+
 ```env
 AUTH0_COOKIE_DOMAIN=
 AUTH0_COOKIE_PATH=
@@ -156,7 +158,17 @@ AUTH0_COOKIE_TRANSIENT=
 AUTH0_COOKIE_SECURE=
 AUTH0_COOKIE_SAME_SITE=
 ```
-Respective counterparts are also available in the client configuration. See [Cookie Configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#cookie-configuration) for more details.  
+
+Respective counterparts are also available in the client configuration. See [Cookie Configuration](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#cookie-configuration) for more details.
+
+## Base Path
+
+Your Next.js application may be configured to use a base path (e.g.: `/dashboard`) — this is usually done by setting the `basePath` option in the `next.config.js` file. To configure the SDK to use the base path, you will also need to set the `NEXT_PUBLIC_BASE_PATH` environment variable which will be used when mounting the authentication routes.
+
+For example, if the `NEXT_PUBLIC_BASE_PATH` environment variable is set to `/dashboard`, the SDK will mount the authentication routes on `/dashboard/auth/login`, `/dashboard/auth/callback`, `/dashboard/auth/profile`, etc.
+
+> [!NOTE]
+> We do not recommend using the `NEXT_PUBLIC_BASE_PATH` environment variable in conjunction with a `APP_BASE_URL` that contains a path component. If your application is configured to use a base path, you should set the `APP_BASE_URL` to the root URL of your application (e.g.: `https://example.com`) and use the `NEXT_PUBLIC_BASE_PATH` environment variable to specify the base path (e.g.: `/dashboard`).
 
 ## Configuration Validation
 

--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -1,4 +1,5 @@
 import { AccessTokenError } from "../../errors";
+import { normailizeWithBasePath } from "../../utils/pathUtils";
 
 type AccessTokenResponse = {
   token: string;
@@ -8,7 +9,9 @@ type AccessTokenResponse = {
 
 export async function getAccessToken(): Promise<string> {
   const tokenRes = await fetch(
-    process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"
+    normailizeWithBasePath(
+      process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"
+    )
   );
 
   if (!tokenRes.ok) {

--- a/src/client/hooks/use-user.ts
+++ b/src/client/hooks/use-user.ts
@@ -3,10 +3,13 @@
 import useSWR from "swr";
 
 import type { User } from "../../types";
+import { normailizeWithBasePath } from "../../utils/pathUtils";
 
 export function useUser() {
   const { data, error, isLoading, mutate } = useSWR<User, Error, string>(
-    process.env.NEXT_PUBLIC_PROFILE_ROUTE || "/auth/profile",
+    normailizeWithBasePath(
+      process.env.NEXT_PUBLIC_PROFILE_ROUTE || "/auth/profile"
+    ),
     (...args) =>
       fetch(...args).then((res) => {
         if (!res.ok) {

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as jose from "jose";
 import * as oauth from "oauth4webapi";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { generateSecret } from "../test/utils";
 import { SessionData } from "../types";
@@ -806,6 +806,89 @@ ca/T0LLtgmbMmxSv/MmzIg==
         delete process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE;
       });
     });
+
+    describe("with a base path", async () => {
+      beforeAll(() => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "/base-path";
+      });
+
+      afterAll(() => {
+        delete process.env.NEXT_PUBLIC_BASE_PATH;
+      });
+
+      it("should call the appropriate handlers when routes are called with base path", async () => {
+        const testCases = [
+          {
+            path: "/auth/login",
+            method: "GET",
+            handler: "handleLogin"
+          },
+          {
+            path: "/auth/logout",
+            method: "GET",
+            handler: "handleLogout"
+          },
+          {
+            path: "/auth/callback",
+            method: "GET",
+            handler: "handleCallback"
+          },
+          {
+            path: "/auth/backchannel-logout",
+            method: "POST",
+            handler: "handleBackChannelLogout"
+          },
+          {
+            path: "/auth/profile",
+            method: "GET",
+            handler: "handleProfile"
+          },
+          {
+            path: "/auth/access-token",
+            method: "GET",
+            handler: "handleAccessToken"
+          }
+        ];
+
+        for (const testCase of testCases) {
+          const secret = await generateSecret(32);
+          const transactionStore = new TransactionStore({
+            secret
+          });
+          const sessionStore = new StatelessSessionStore({
+            secret
+          });
+          const authClient = new AuthClient({
+            transactionStore,
+            sessionStore,
+
+            domain: DEFAULT.domain,
+            clientId: DEFAULT.clientId,
+            clientSecret: DEFAULT.clientSecret,
+
+            secret,
+            appBaseUrl: DEFAULT.appBaseUrl,
+
+            fetch: getMockAuthorizationServer()
+          });
+
+          const request = new NextRequest(
+            // Next.js will strip the base path from the URL
+            new URL(
+              testCase.path,
+              `${DEFAULT.appBaseUrl}/${process.env.NEXT_PUBLIC_BASE_PATH}`
+            ),
+            {
+              method: testCase.method
+            }
+          );
+
+          (authClient as any)[testCase.handler] = vi.fn();
+          await authClient.handler(request);
+          expect((authClient as any)[testCase.handler]).toHaveBeenCalled();
+        }
+      });
+    });
   });
 
   describe("handleLogin", async () => {
@@ -916,6 +999,55 @@ ca/T0LLtgmbMmxSv/MmzIg==
       expect(authorizationUrl.searchParams.get("redirect_uri")).toEqual(
         `${DEFAULT.appBaseUrl}/sub-path/auth/callback`
       );
+    });
+
+    describe("with a base path", async () => {
+      beforeAll(() => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "/base-path";
+      });
+
+      afterAll(() => {
+        delete process.env.NEXT_PUBLIC_BASE_PATH;
+      });
+
+      it("should prepend the base path to the redirect_uri", async () => {
+        const secret = await generateSecret(32);
+        const transactionStore = new TransactionStore({
+          secret
+        });
+        const sessionStore = new StatelessSessionStore({
+          secret
+        });
+        const authClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+
+          secret,
+          appBaseUrl: `${DEFAULT.appBaseUrl}`,
+
+          fetch: getMockAuthorizationServer()
+        });
+        const request = new NextRequest(
+          new URL(
+            process.env.NEXT_PUBLIC_BASE_PATH + "/auth/login",
+            DEFAULT.appBaseUrl
+          ),
+          {
+            method: "GET"
+          }
+        );
+
+        const response = await authClient.handleLogin(request);
+        const authorizationUrl = new URL(response.headers.get("Location")!);
+
+        expect(authorizationUrl.searchParams.get("redirect_uri")).toEqual(
+          `${DEFAULT.appBaseUrl}/base-path/auth/callback`
+        );
+      });
     });
 
     it("should return an error if the discovery endpoint could not be fetched", async () => {
@@ -1598,6 +1730,79 @@ ca/T0LLtgmbMmxSv/MmzIg==
             returnTo: "/"
           })
         );
+      });
+
+      describe("with a base path", async () => {
+        beforeAll(() => {
+          process.env.NEXT_PUBLIC_BASE_PATH = "/base-path";
+        });
+
+        afterAll(() => {
+          delete process.env.NEXT_PUBLIC_BASE_PATH;
+        });
+
+        it("should prepend the base path to the redirect_uri", async () => {
+          const secret = await generateSecret(32);
+          const transactionStore = new TransactionStore({
+            secret
+          });
+          const sessionStore = new StatelessSessionStore({
+            secret
+          });
+          const authClient = new AuthClient({
+            transactionStore,
+            sessionStore,
+            domain: DEFAULT.domain,
+            clientId: DEFAULT.clientId,
+            clientSecret: DEFAULT.clientSecret,
+            pushedAuthorizationRequests: true,
+            secret,
+            appBaseUrl: DEFAULT.appBaseUrl,
+            fetch: getMockAuthorizationServer({
+              onParRequest: async (request) => {
+                const params = new URLSearchParams(await request.text());
+                expect(params.get("client_id")).toEqual(DEFAULT.clientId);
+                expect(params.get("redirect_uri")).toEqual(
+                  `${DEFAULT.appBaseUrl}/base-path/auth/callback`
+                );
+                expect(params.get("response_type")).toEqual("code");
+                expect(params.get("code_challenge")).toEqual(
+                  expect.any(String)
+                );
+                expect(params.get("code_challenge_method")).toEqual("S256");
+                expect(params.get("state")).toEqual(expect.any(String));
+                expect(params.get("nonce")).toEqual(expect.any(String));
+                expect(params.get("scope")).toEqual(
+                  "openid profile email offline_access"
+                );
+              }
+            })
+          });
+
+          const request = new NextRequest(
+            new URL(
+              process.env.NEXT_PUBLIC_BASE_PATH + "/auth/login",
+              DEFAULT.appBaseUrl
+            ),
+            {
+              method: "GET"
+            }
+          );
+
+          const response = await authClient.handleLogin(request);
+          expect(response.status).toEqual(307);
+          expect(response.headers.get("Location")).not.toBeNull();
+
+          const authorizationUrl = new URL(response.headers.get("Location")!);
+          expect(authorizationUrl.origin).toEqual(`https://${DEFAULT.domain}`);
+          // query parameters should only include the `request_uri` and not the standard auth params
+          expect(authorizationUrl.searchParams.get("request_uri")).toEqual(
+            DEFAULT.requestUri
+          );
+          expect(authorizationUrl.searchParams.get("client_id")).toEqual(
+            DEFAULT.clientId
+          );
+        });
       });
 
       describe("custom parameters to the authorization server", async () => {
@@ -2333,6 +2538,76 @@ ca/T0LLtgmbMmxSv/MmzIg==
       expect(transactionCookie!.expires).toEqual(
         new Date("1970-01-01T00:00:00.000Z")
       );
+    });
+
+    describe("when a base path is defined", async () => {
+      beforeAll(() => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "/base-path";
+      });
+
+      afterAll(() => {
+        delete process.env.NEXT_PUBLIC_BASE_PATH;
+      });
+
+      it("should generate a callback URL with the base path", async () => {
+        const state = "transaction-state";
+        const code = "auth-code";
+
+        const secret = await generateSecret(32);
+        const transactionStore = new TransactionStore({
+          secret
+        });
+        const sessionStore = new StatelessSessionStore({
+          secret
+        });
+        const authClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+
+          secret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+
+          fetch: getMockAuthorizationServer()
+        });
+
+        const url = new URL(
+          process.env.NEXT_PUBLIC_BASE_PATH + "/auth/callback",
+          DEFAULT.appBaseUrl
+        );
+        url.searchParams.set("code", code);
+        url.searchParams.set("state", state);
+
+        const headers = new Headers();
+        const transactionState: TransactionState = {
+          nonce: "nonce-value",
+          maxAge: 3600,
+          codeVerifier: "code-verifier",
+          responseType: "code",
+          state: state,
+          returnTo: "/dashboard"
+        };
+        const maxAge = 60 * 60; // 1 hour
+        const expiration = Math.floor(Date.now() / 1000 + maxAge);
+        headers.set(
+          "cookie",
+          `__txn_${state}=${await encrypt(transactionState, secret, expiration)}`
+        );
+        const request = new NextRequest(url, {
+          method: "GET",
+          headers
+        });
+
+        const response = await authClient.handleCallback(request);
+        expect(response.status).toEqual(307);
+        expect(response.headers.get("Location")).not.toBeNull();
+
+        const redirectUrl = new URL(response.headers.get("Location")!);
+        expect(redirectUrl.pathname).toEqual("/base-path/dashboard");
+      });
     });
 
     it("must use private_key_jwt when a clientAssertionSigningKey is specified", async () => {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -29,6 +29,7 @@ import {
 import {
   ensureNoLeadingSlash,
   ensureTrailingSlash,
+  normailizeWithBasePath,
   removeTrailingSlash
 } from "../utils/pathUtils";
 import { toSafeRedirect } from "../utils/url-helpers";
@@ -138,7 +139,10 @@ export interface AuthClientOptions {
 }
 
 function createRouteUrl(url: string, base: string) {
-  return new URL(ensureNoLeadingSlash(url), ensureTrailingSlash(base));
+  return new URL(
+    ensureNoLeadingSlash(normailizeWithBasePath(url)),
+    ensureTrailingSlash(base)
+  );
 }
 
 export class AuthClient {

--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  ensureLeadingSlash,
   ensureNoLeadingSlash,
   ensureTrailingSlash,
+  normailizeWithBasePath,
   removeTrailingSlash
 } from "./pathUtils";
 
@@ -48,6 +50,76 @@ describe("pathUtils", () => {
 
     it("should return the same string if it is empty", () => {
       expect(removeTrailingSlash("")).toBe("");
+    });
+  });
+
+  describe("ensureLeadingSlash", () => {
+    it("should add a leading slash if not present", () => {
+      expect(ensureLeadingSlash("example/path")).toBe("/example/path");
+    });
+
+    it("should not add a leading slash if already present", () => {
+      expect(ensureLeadingSlash("/example/path")).toBe("/example/path");
+    });
+
+    it("should return the same string if it is empty", () => {
+      expect(ensureLeadingSlash("")).toBe("");
+    });
+  });
+
+  describe("normailizeWithBasePath", () => {
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_BASE_PATH;
+    });
+
+    describe("when the base path does not have a leading slash", () => {
+      it("should correctly prepend the base path", () => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "docs";
+
+        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+          "/docs/path/to/resource"
+        );
+      });
+    });
+
+    describe("when the base path has a leading slash", () => {
+      it("should correctly prepend the base path", () => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "/docs";
+
+        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+          "/docs/path/to/resource"
+        );
+      });
+    });
+
+    describe("when the base path has a trailing slash", () => {
+      it("should correctly join the paths", () => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "/docs/";
+
+        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+          "/docs/path/to/resource"
+        );
+      });
+    });
+
+    describe("when the base path is empty", () => {
+      it("should return the original path", () => {
+        process.env.NEXT_PUBLIC_BASE_PATH = "";
+
+        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+          "/path/to/resource"
+        );
+      });
+    });
+
+    describe("when the base path is undefined", () => {
+      it("should return the same path if no base path is set", () => {
+        delete process.env.NEXT_PUBLIC_BASE_PATH;
+
+        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+          "/path/to/resource"
+        );
+      });
     });
   });
 });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,3 +1,7 @@
+export function ensureLeadingSlash(value: string) {
+  return value && !value.startsWith("/") ? `/${value}` : value;
+}
+
 export function ensureTrailingSlash(value: string) {
   return value && !value.endsWith("/") ? `${value}/` : value;
 }
@@ -10,3 +14,16 @@ export function ensureNoLeadingSlash(value: string) {
 
 export const removeTrailingSlash = (path: string) =>
   path.endsWith("/") ? path.slice(0, -1) : path;
+
+export const normailizeWithBasePath = (path: string) => {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+
+  if (!basePath) {
+    return path;
+  }
+
+  // basePath can be `docs` or `/docs`
+  const sanitizedBasePath = ensureLeadingSlash(basePath);
+
+  return ensureTrailingSlash(sanitizedBasePath) + ensureNoLeadingSlash(path);
+};


### PR DESCRIPTION
### 📋 Changes

This PR adds support for configuring a `basePath` with the SDK via the `NEXT_PUBLIC_BASE_PATH` environment variable.

For example, if the `NEXT_PUBLIC_BASE_PATH` environment variable is set to `/dashboard`, the SDK will mount the authentication routes on `/dashboard/auth/login`, `/dashboard/auth/callback`, `/dashboard/auth/profile`, etc.

### 📎 References

Fixes: https://github.com/auth0/nextjs-auth0/issues/2155

### 🎯 Testing

1. Configure a `basePath` in the `next.config.ts`
2. Set the `NEXT_PUBLIC_BASE_PATH` to the same value as the one set in `next.config.ts`
3. Attempt to: login, fetch an AT, fetch the user profile, logout, etc... and notice that the configured base path is prepended to the auth URLs.
