### PR TITLE
fix: typo in `normalizeWithBasePath` method

### DIFF
--- a/src/client/helpers/get-access-token.ts
+++ b/src/client/helpers/get-access-token.ts
@@ -1,5 +1,5 @@
 import { AccessTokenError } from "../../errors";
-import { normailizeWithBasePath } from "../../utils/pathUtils";
+import { normalizeWithBasePath } from "../../utils/pathUtils";
 
 type AccessTokenResponse = {
   token: string;
@@ -9,7 +9,7 @@ type AccessTokenResponse = {
 
 export async function getAccessToken(): Promise<string> {
   const tokenRes = await fetch(
-    normailizeWithBasePath(
+    normalizeWithBasePath(
       process.env.NEXT_PUBLIC_ACCESS_TOKEN_ROUTE || "/auth/access-token"
     )
   );

--- a/src/client/hooks/use-user.ts
+++ b/src/client/hooks/use-user.ts
@@ -3,11 +3,11 @@
 import useSWR from "swr";
 
 import type { User } from "../../types";
-import { normailizeWithBasePath } from "../../utils/pathUtils";
+import { normalizeWithBasePath } from "../../utils/pathUtils";
 
 export function useUser() {
   const { data, error, isLoading, mutate } = useSWR<User, Error, string>(
-    normailizeWithBasePath(
+    normalizeWithBasePath(
       process.env.NEXT_PUBLIC_PROFILE_ROUTE || "/auth/profile"
     ),
     (...args) =>

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -29,7 +29,7 @@ import {
 import {
   ensureNoLeadingSlash,
   ensureTrailingSlash,
-  normailizeWithBasePath,
+  normalizeWithBasePath,
   removeTrailingSlash
 } from "../utils/pathUtils";
 import { toSafeRedirect } from "../utils/url-helpers";
@@ -140,7 +140,7 @@ export interface AuthClientOptions {
 
 function createRouteUrl(url: string, base: string) {
   return new URL(
-    ensureNoLeadingSlash(normailizeWithBasePath(url)),
+    ensureNoLeadingSlash(normalizeWithBasePath(url)),
     ensureTrailingSlash(base)
   );
 }

--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -4,7 +4,7 @@ import {
   ensureLeadingSlash,
   ensureNoLeadingSlash,
   ensureTrailingSlash,
-  normailizeWithBasePath,
+  normalizeWithBasePath,
   removeTrailingSlash
 } from "./pathUtils";
 
@@ -67,7 +67,7 @@ describe("pathUtils", () => {
     });
   });
 
-  describe("normailizeWithBasePath", () => {
+  describe("normalizeWithBasePath", () => {
     afterEach(() => {
       delete process.env.NEXT_PUBLIC_BASE_PATH;
     });
@@ -76,7 +76,7 @@ describe("pathUtils", () => {
       it("should correctly prepend the base path", () => {
         process.env.NEXT_PUBLIC_BASE_PATH = "docs";
 
-        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+        expect(normalizeWithBasePath("/path/to/resource")).toBe(
           "/docs/path/to/resource"
         );
       });
@@ -86,7 +86,7 @@ describe("pathUtils", () => {
       it("should correctly prepend the base path", () => {
         process.env.NEXT_PUBLIC_BASE_PATH = "/docs";
 
-        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+        expect(normalizeWithBasePath("/path/to/resource")).toBe(
           "/docs/path/to/resource"
         );
       });
@@ -96,7 +96,7 @@ describe("pathUtils", () => {
       it("should correctly join the paths", () => {
         process.env.NEXT_PUBLIC_BASE_PATH = "/docs/";
 
-        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+        expect(normalizeWithBasePath("/path/to/resource")).toBe(
           "/docs/path/to/resource"
         );
       });
@@ -106,7 +106,7 @@ describe("pathUtils", () => {
       it("should return the original path", () => {
         process.env.NEXT_PUBLIC_BASE_PATH = "";
 
-        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+        expect(normalizeWithBasePath("/path/to/resource")).toBe(
           "/path/to/resource"
         );
       });
@@ -116,7 +116,7 @@ describe("pathUtils", () => {
       it("should return the same path if no base path is set", () => {
         delete process.env.NEXT_PUBLIC_BASE_PATH;
 
-        expect(normailizeWithBasePath("/path/to/resource")).toBe(
+        expect(normalizeWithBasePath("/path/to/resource")).toBe(
           "/path/to/resource"
         );
       });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -15,7 +15,7 @@ export function ensureNoLeadingSlash(value: string) {
 export const removeTrailingSlash = (path: string) =>
   path.endsWith("/") ? path.slice(0, -1) : path;
 
-export const normailizeWithBasePath = (path: string) => {
+export const normalizeWithBasePath = (path: string) => {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 
   if (!basePath) {


### PR DESCRIPTION
### 📋 Changes

Fixes typo in internal method `normalizeWithBasePath`

