### PR TITLE
fix: handle authorization code grant request errors

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -57,6 +57,18 @@ export class AuthorizationError extends SdkError {
   }
 }
 
+export class AuthorizationCodeGrantRequestError extends SdkError {
+  public code: string = "authorization_code_grant_request_error";
+
+  constructor(message?: string) {
+    super(
+      message ??
+        "An error occured while preparing or performing the authorization code grant request."
+    );
+    this.name = "AuthorizationCodeGrantRequestError";
+  }
+}
+
 export class AuthorizationCodeGrantError extends SdkError {
   public code: string = "authorization_code_grant_error";
   public cause: OAuth2Error;

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -3385,8 +3385,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
           },
           null
         );
-        expect(mockOnCallback.mock.calls[0][0].message).toEqual(
-          "Timeout error"
+        expect(mockOnCallback.mock.calls[0][0].code).toEqual(
+          "authorization_code_grant_request_error"
         );
       });
 

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -58,6 +58,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
   function getMockAuthorizationServer({
     tokenEndpointResponse,
     tokenEndpointErrorResponse,
+    tokenEndpointFetchError,
     discoveryResponse,
     audience,
     nonce,
@@ -66,6 +67,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
   }: {
     tokenEndpointResponse?: oauth.TokenEndpointResponse | oauth.OAuth2Error;
     tokenEndpointErrorResponse?: oauth.OAuth2Error;
+    tokenEndpointFetchError?: Error;
     discoveryResponse?: Response;
     audience?: string;
     nonce?: string;
@@ -86,6 +88,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
 
         if (url.pathname === "/oauth/token") {
+          if (tokenEndpointFetchError) {
+            throw tokenEndpointFetchError;
+          }
+
           const jwt = await new jose.SignJWT({
             sid: DEFAULT.sid,
             auth_time: Date.now(),
@@ -3303,6 +3309,85 @@ ca/T0LLtgmbMmxSv/MmzIg==
         // validate the session cookie has not been set
         const sessionCookie = response.cookies.get("__session");
         expect(sessionCookie).toBeUndefined();
+      });
+
+      it("should be called with an error when there is an error performing the authorization code grant request", async () => {
+        const state = "transaction-state";
+        const code = "auth-code";
+
+        const mockOnCallback = vi
+          .fn()
+          .mockResolvedValue(
+            NextResponse.redirect(new URL("/error-page", DEFAULT.appBaseUrl))
+          );
+
+        const secret = await generateSecret(32);
+        const transactionStore = new TransactionStore({
+          secret
+        });
+        const sessionStore = new StatelessSessionStore({
+          secret
+        });
+        const authClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+
+          secret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+
+          fetch: getMockAuthorizationServer({
+            tokenEndpointFetchError: new Error("Timeout error")
+          }),
+
+          onCallback: mockOnCallback
+        });
+
+        const url = new URL("/auth/callback", DEFAULT.appBaseUrl);
+        url.searchParams.set("code", code);
+        url.searchParams.set("state", state);
+
+        const headers = new Headers();
+        const transactionState: TransactionState = {
+          nonce: "nonce-value",
+          maxAge: 3600,
+          codeVerifier: "code-verifier",
+          responseType: "code",
+          state: state,
+          returnTo: "/dashboard"
+        };
+        const maxAge = 60 * 60; // 1 hour
+        const expiration = Math.floor(Date.now() / 1000 + maxAge);
+        headers.set(
+          "cookie",
+          `__txn_${state}=${await encrypt(transactionState, secret, expiration)}`
+        );
+        const request = new NextRequest(url, {
+          method: "GET",
+          headers
+        });
+
+        // validate the new response redirect
+        const response = await authClient.handleCallback(request);
+        expect(response.status).toEqual(307);
+        expect(response.headers.get("Location")).not.toBeNull();
+
+        const redirectUrl = new URL(response.headers.get("Location")!);
+        expect(redirectUrl.pathname).toEqual("/error-page");
+
+        expect(mockOnCallback).toHaveBeenCalledWith(
+          expect.any(Error),
+          {
+            returnTo: transactionState.returnTo
+          },
+          null
+        );
+        expect(mockOnCallback.mock.calls[0][0].message).toEqual(
+          "Timeout error"
+        );
       });
 
       it("should be called with an error if there was an error during the code exchange", async () => {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -502,20 +502,25 @@ export class AuthClient {
       );
     }
 
-    const redirectUri = createRouteUrl(this.routes.callback, this.appBaseUrl); // must be registed with the authorization server
-    const codeGrantResponse = await oauth.authorizationCodeGrantRequest(
-      authorizationServerMetadata,
-      this.clientMetadata,
-      await this.getClientAuth(),
-      codeGrantParams,
-      redirectUri.toString(),
-      transactionState.codeVerifier,
-      {
-        ...this.httpOptions(),
-        [oauth.customFetch]: this.fetch,
-        [oauth.allowInsecureRequests]: this.allowInsecureRequests
-      }
-    );
+    let codeGrantResponse: Response;
+    try {
+      const redirectUri = createRouteUrl(this.routes.callback, this.appBaseUrl); // must be registed with the authorization server
+      codeGrantResponse = await oauth.authorizationCodeGrantRequest(
+        authorizationServerMetadata,
+        this.clientMetadata,
+        await this.getClientAuth(),
+        codeGrantParams,
+        redirectUri.toString(),
+        transactionState.codeVerifier,
+        {
+          ...this.httpOptions(),
+          [oauth.customFetch]: this.fetch,
+          [oauth.allowInsecureRequests]: this.allowInsecureRequests
+        }
+      );
+    } catch (e: any) {
+      return this.onCallback(e, onCallbackCtx, null);
+    }
 
     let oidcRes: oauth.TokenEndpointResponse;
     try {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -9,6 +9,7 @@ import {
   AccessTokenForConnectionError,
   AccessTokenForConnectionErrorCode,
   AuthorizationCodeGrantError,
+  AuthorizationCodeGrantRequestError,
   AuthorizationError,
   BackchannelLogoutError,
   DiscoveryError,
@@ -519,7 +520,11 @@ export class AuthClient {
         }
       );
     } catch (e: any) {
-      return this.onCallback(e, onCallbackCtx, null);
+      return this.onCallback(
+        new AuthorizationCodeGrantRequestError(e.message),
+        onCallbackCtx,
+        null
+      );
     }
 
     let oidcRes: oauth.TokenEndpointResponse;


### PR DESCRIPTION
### 📋 Changes

Currently, when an error occurs when performing an authorization code grant request (e.g.: timeout), the error is thrown and displayed to the end-user without giving the developer the ability to handle it gracefully.

This PR catches the errors and passes it to the `onCallback` handler to give the developer and opportunity to handle it.

### 📎 References

- fixes: https://github.com/auth0/nextjs-auth0/issues/2060

### 🎯 Testing

- Trigger a timeout error in `fetch` when calling the token endpoint
- Observe the error displayed to the user
