### PR TITLE
fix: isolate the build, lint and coverage CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
           key: ${{ env.CACHE_KEY }}
 
   coverage:
-    needs: build
     name: Run Coverage Tests
     runs-on: ubuntu-latest
 
@@ -77,11 +76,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: "pnpm"
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@v4
-        with:
-          path: .
-          key: ${{ env.CACHE_KEY }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Test Coverage
         run: pnpm test:coverage
@@ -92,8 +88,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
-    needs: build # Require build to complete before running tests
-
     name: Lint Code
     runs-on: ubuntu-latest
 
@@ -112,11 +106,8 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - name: Restore build artifacts
-        uses: actions/cache/restore@v4
-        with:
-          path: .
-          key: ${{ env.CACHE_KEY }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Lint
         run: pnpm run lint


### PR DESCRIPTION
Our current CI relies on the following:

- Build job does `pnpm i`
- Build job then caches the output
- Other jobs then restore the cache.

Since recently, this has shown the be unreliable and randomly fails, e.g. https://github.com/auth0/nextjs-auth0/actions/runs/15728100833/job/44322581089?pr=2177

Build job:

```
Run actions/cache/save@v4
Sent 151864107 of 151864107 (100.0%), 79.7 MBs/sec
Cache saved with key: refs/pull/2177/merge-15728100833-1
```

Coverage job:

```
Run actions/cache/restore@v4
Cache not found for input keys: refs/pull/2177/merge-15728100833-1
```

As you see, it doesnt find the entry even though the key is identical.

This PR removes the dependency and runs the steps in isolation.