### PR TITLE
chore: remove unnecessary error logs

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -103,11 +103,13 @@ export enum AccessTokenErrorCode {
 
 export class AccessTokenError extends SdkError {
   public code: string;
+  public cause?: OAuth2Error;
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, cause?: OAuth2Error) {
     super(message);
     this.name = "AccessTokenError";
     this.code = code;
+    this.cause = cause;
   }
 }
 

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -39,7 +39,6 @@ import { AbstractSessionStore } from "./session/abstract-session-store.js";
 import { TransactionState, TransactionStore } from "./transaction-store.js";
 import { filterDefaultIdTokenClaims } from "./user.js";
 
-
 export type BeforeSessionSavedHook = (
   session: SessionData,
   idToken: string | null
@@ -733,7 +732,6 @@ export class AuthClient {
           await this.discoverAuthorizationServerMetadata();
 
         if (discoveryError) {
-          console.error(discoveryError);
           return [discoveryError, null];
         }
 
@@ -757,11 +755,14 @@ export class AuthClient {
             refreshTokenRes
           );
         } catch (e: any) {
-          console.error(e);
           return [
             new AccessTokenError(
               AccessTokenErrorCode.FAILED_TO_REFRESH_TOKEN,
-              "The access token has expired and there was an error while trying to refresh it. Check the server logs for more information."
+              "The access token has expired and there was an error while trying to refresh it.",
+              new OAuth2Error({
+                code: e.error,
+                message: e.error_description
+              })
             ),
             null
           ];
@@ -815,7 +816,7 @@ export class AuthClient {
       return [null, authorizationServerMetadata];
     } catch (e) {
       console.error(
-        `An error occured while performing the discovery request. Please make sure the AUTH0_DOMAIN environment variable is correctly configured — the format must be 'example.us.auth0.com'. issuer=${issuer.toString()}, error:`,
+        `An error occured while performing the discovery request. issuer=${issuer.toString()}, error:`,
         e
       );
       return [
@@ -1106,7 +1107,6 @@ export class AuthClient {
         await this.discoverAuthorizationServerMetadata();
 
       if (discoveryError) {
-        console.error(discoveryError);
         return [discoveryError, null];
       }
 
@@ -1130,11 +1130,10 @@ export class AuthClient {
           httpResponse
         );
       } catch (err: any) {
-        console.error(err);
         return [
           new AccessTokenForConnectionError(
             AccessTokenForConnectionErrorCode.FAILED_TO_EXCHANGE,
-            "There was an error trying to exchange the refresh token for a connection access token. Check the server logs for more information.",
+            "There was an error trying to exchange the refresh token for a connection access token.",
             new OAuth2Error({
               code: err.error,
               message: err.error_description


### PR DESCRIPTION
### 📋 Changes

There are a few cases where we log an error to the console where the necessary context is already in the error returned to the caller for handling. In the places this was not the case, the `cause` was added and made available to the caller.

### 📎 References

Fixes: https://github.com/auth0/nextjs-auth0/issues/2107
