### PR TITLE
feat: add `withPageAuthRequired` for protecting pages client side

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -9,6 +9,8 @@
   - [On the server (App Router)](#on-the-server-app-router)
   - [On the server (Pages Router)](#on-the-server-pages-router)
   - [Middleware](#middleware)
+- [Protecting a Client-Side Rendered (CSR) Page](#protecting-a-client-side-rendered-csr-page)
+- [Accessing the idToken](#accessing-the-idtoken)
 - [Updating the session](#updating-the-session)
   - [On the server (App Router)](#on-the-server-app-router-1)
   - [On the server (Pages Router)](#on-the-server-pages-router-1)
@@ -50,9 +52,9 @@ There are 2 ways to customize the authorization parameters that will be passed t
 export const auth0 = new Auth0Client({
   authorizationParameters: {
     scope: "openid profile email",
-    audience: "urn:custom:api",
-  },
-})
+    audience: "urn:custom:api"
+  }
+});
 ```
 
 The second option is through the query parameters to the `/auth/login` endpoint which allows you to specify the authorization parameters dynamically. For example, to specify an `audience`, the login URL would look like so:
@@ -72,7 +74,6 @@ For example: `/auth/login?returnTo=/dashboard` would redirect the user to the `/
 > [!NOTE]  
 > The URL specified as `returnTo` parameters must be registered in your client's **Allowed Callback URLs**.
 
-
 ### Redirecting the user after logging out
 
 The `returnTo` parameter can be appended to the logout to specify where you would like to redirect the user after they have logged out.
@@ -89,14 +90,14 @@ For example: `/auth/logout?returnTo=https://example.com/some-page` would redirec
 To access the currently authenticated user on the client, you can use the `useUser()` hook, like so:
 
 ```tsx
-"use client"
+"use client";
 
-import { useUser } from "@auth0/nextjs-auth0"
+import { useUser } from "@auth0/nextjs-auth0";
 
 export default function Profile() {
-  const { user, isLoading, error } = useUser()
+  const { user, isLoading, error } = useUser();
 
-  if (isLoading) return <div>Loading...</div>
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <main>
@@ -105,7 +106,7 @@ export default function Profile() {
         <pre>{JSON.stringify(user, null, 2)}</pre>
       </div>
     </main>
-  )
+  );
 }
 ```
 
@@ -114,20 +115,20 @@ export default function Profile() {
 On the server, the `getSession()` helper can be used in Server Components, Server Routes, and Server Actions to get the session of the currently authenticated user and to protect resources, like so:
 
 ```tsx
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export default async function Home() {
-  const session = await auth0.getSession()
+  const session = await auth0.getSession();
 
   if (!session) {
-    return <div>Not authenticated</div>
+    return <div>Not authenticated</div>;
   }
 
   return (
     <main>
       <h1>Welcome, {session.user.name}!</h1>
     </main>
-  )
+  );
 }
 ```
 
@@ -136,34 +137,34 @@ export default async function Home() {
 On the server, the `getSession(req)` helper can be used in `getServerSideProps` and API routes to get the session of the currently authenticated user and to protect resources, like so:
 
 ```tsx
-import type { GetServerSideProps, InferGetServerSidePropsType } from "next"
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export const getServerSideProps = (async (ctx) => {
-  const session = await auth0.getSession(ctx.req)
+  const session = await auth0.getSession(ctx.req);
 
-  if (!session) return { props: { user: null } }
+  if (!session) return { props: { user: null } };
 
-  return { props: { user: session.user ?? null } }
-}) satisfies GetServerSideProps<{ user: any | null }>
+  return { props: { user: session.user ?? null } };
+}) satisfies GetServerSideProps<{ user: any | null }>;
 
 export default function Page({
-  user,
+  user
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   if (!user) {
     return (
       <main>
         <p>Not authenticated!</p>
       </main>
-    )
+    );
   }
 
   return (
     <main>
       <p>Welcome, {user.name}!</p>
     </main>
-  )
+  );
 }
 ```
 
@@ -172,40 +173,57 @@ export default function Page({
 In middleware, the `getSession(req)` helper can be used to get the session of the currently authenticated user and to protect resources, like so:
 
 ```ts
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
   // the headers from the auth middleware should always be returned
-  return authRes
+  return authRes;
 }
 ```
 
 > [!IMPORTANT]  
 > The `request` object must be passed as a parameter to the `getSession(request)` method when called from a middleware to ensure that any updates to the session can be read within the same request.
 
+## Protecting a Client-Side Rendered (CSR) Page
+
+To protect a Client-Side Rendered (CSR) page, you can use the `withPageAuthRequired` higher-order function. Requests to `/profile` without a valid session cookie will be redirected to the login page.
+
+```tsx
+// app/profile/page.tsx
+"use client";
+
+import { withPageAuthRequired } from "@auth0/nextjs-auth0";
+
+export default withPageAuthRequired(function Page({ user }) {
+  return <div>Hello, {user.name}!</div>;
+});
+```
+
 ## Accessing the idToken
+
 `idToken` can be accessed from the session in the following way:
 
 ```js
 const session = await auth0.getSession();
 const idToken = session.tokenSet.idToken;
 ```
-
 
 ## Updating the session
 
@@ -219,23 +237,23 @@ The `updateSession` method could be used to update the session of the currently 
 On the server, the `updateSession()` helper can be used in Server Routes and Server Actions to update the session of the currently authenticated user, like so:
 
 ```tsx
-import { NextResponse } from "next/server"
+import { NextResponse } from "next/server";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function GET() {
-  const session = await auth0.getSession()
+  const session = await auth0.getSession();
 
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   await auth0.updateSession({
     ...session,
-    updatedAt: Date.now(),
-  })
+    updatedAt: Date.now()
+  });
 
-  return NextResponse.json(null, { status: 200 })
+  return NextResponse.json(null, { status: 200 });
 }
 ```
 
@@ -247,32 +265,32 @@ export async function GET() {
 On the server, the `updateSession(req, res, session)` helper can be used in `getServerSideProps` and API routes to update the session of the currently authenticated user, like so:
 
 ```tsx
-import type { NextApiRequest, NextApiResponse } from "next"
+import type { NextApiRequest, NextApiResponse } from "next";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 type ResponseData =
   | {}
   | {
-      error: string
-    }
+      error: string;
+    };
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ResponseData>
 ) {
-  const session = await auth0.getSession(req)
+  const session = await auth0.getSession(req);
 
   if (!session) {
-    return res.status(401).json({ error: "Unauthorized" })
+    return res.status(401).json({ error: "Unauthorized" });
   }
 
   await auth0.updateSession(req, res, {
     ...session,
-    updatedAt: Date.now(),
-  })
+    updatedAt: Date.now()
+  });
 
-  res.status(200).json({})
+  res.status(200).json({});
 }
 ```
 
@@ -281,22 +299,24 @@ export default async function handler(
 In middleware, the `updateSession(req, res, session)` helper can be used to update the session of the currently authenticated user, like so:
 
 ```ts
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
   await auth0.updateSession(request, authRes, {
@@ -304,12 +324,12 @@ export async function middleware(request: NextRequest) {
     user: {
       ...session.user,
       // add custom user data
-      updatedAt: Date.now(),
-    },
-  })
+      updatedAt: Date.now()
+    }
+  });
 
   // the headers from the auth middleware should always be returned
-  return authRes
+  return authRes;
 }
 ```
 
@@ -319,22 +339,24 @@ export async function middleware(request: NextRequest) {
 If you are using the Pages Router and need to read updates to the session made in the middleware within the same request, you will need to ensure that any updates to the session are propagated on the request object, like so:
 
 ```ts
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
   await auth0.updateSession(request, authRes, {
@@ -342,24 +364,24 @@ export async function middleware(request: NextRequest) {
     user: {
       ...session.user,
       // add custom user data
-      updatedAt: Date.now(),
-    },
-  })
+      updatedAt: Date.now()
+    }
+  });
 
   // create a new response with the updated request headers
   const resWithCombinedHeaders = NextResponse.next({
     request: {
-      headers: request.headers,
-    },
-  })
+      headers: request.headers
+    }
+  });
 
   // set the response headers (set-cookie) from the auth response
   authRes.headers.forEach((value, key) => {
-    resWithCombinedHeaders.headers.set(key, value)
-  })
+    resWithCombinedHeaders.headers.set(key, value);
+  });
 
   // the headers from the auth middleware should always be returned
-  return resWithCombinedHeaders
+  return resWithCombinedHeaders;
 }
 ```
 
@@ -372,14 +394,14 @@ The `getAccessToken()` helper can be used both in the browser and on the server 
 To obtain an access token to call an external API on the client, you can use the `getAccessToken()` helper, like so:
 
 ```tsx
-"use client"
+"use client";
 
-import { getAccessToken } from "@auth0/nextjs-auth0"
+import { getAccessToken } from "@auth0/nextjs-auth0";
 
 export default function Component() {
   async function fetchData() {
     try {
-      const token = await getAccessToken()
+      const token = await getAccessToken();
       // call external API with token...
     } catch (err) {
       // err will be an instance of AccessTokenError if an access token could not be obtained
@@ -390,7 +412,7 @@ export default function Component() {
     <main>
       <button onClick={fetchData}>Fetch Data</button>
     </main>
-  )
+  );
 }
 ```
 
@@ -406,21 +428,21 @@ On the server, the `getAccessToken()` helper can be used in Server Routes, Serve
 For example:
 
 ```ts
-import { NextResponse } from "next/server"
+import { NextResponse } from "next/server";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function GET() {
   try {
-    const token = await auth0.getAccessToken()
+    const token = await auth0.getAccessToken();
     // call external API with token...
   } catch (err) {
     // err will be an instance of AccessTokenError if an access token could not be obtained
   }
 
   return NextResponse.json({
-    message: "Success!",
-  })
+    message: "Success!"
+  });
 }
 ```
 
@@ -429,22 +451,22 @@ export async function GET() {
 On the server, the `getAccessToken(req, res)` helper can be used in `getServerSideProps` and API routes to get an access token to call external APIs, like so:
 
 ```ts
-import type { NextApiRequest, NextApiResponse } from "next"
+import type { NextApiRequest, NextApiResponse } from "next";
 
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ message: string }>
 ) {
   try {
-    const token = await auth0.getAccessToken(req, res)
+    const token = await auth0.getAccessToken(req, res);
     // call external API with token...
   } catch (err) {
     // err will be an instance of AccessTokenError if an access token could not be obtained
   }
 
-  res.status(200).json({ message: "Success!" })
+  res.status(200).json({ message: "Success!" });
 }
 ```
 
@@ -453,28 +475,30 @@ export default async function handler(
 In middleware, the `getAccessToken(req, res)` helper can be used to get an access token to call external APIs, like so:
 
 ```tsx
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
-  const accessToken = await auth0.getAccessToken(request, authRes)
+  const accessToken = await auth0.getAccessToken(request, authRes);
 
   // the headers from the auth middleware should always be returned
-  return authRes
+  return authRes;
 }
 ```
 
@@ -484,40 +508,42 @@ export async function middleware(request: NextRequest) {
 If you are using the Pages Router and are calling the `getAccessToken` method in both the middleware and an API Route or `getServerSideProps`, it's recommended to propagate the headers from the middleware, as shown below. This will ensure that calling `getAccessToken` in the API Route or `getServerSideProps` will not result in the access token being refreshed again.
 
 ```ts
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
-  const accessToken = await auth0.getAccessToken(request, authRes)
+  const accessToken = await auth0.getAccessToken(request, authRes);
 
   // create a new response with the updated request headers
   const resWithCombinedHeaders = NextResponse.next({
     request: {
-      headers: request.headers,
-    },
-  })
+      headers: request.headers
+    }
+  });
 
   // set the response headers (set-cookie) from the auth response
   authRes.headers.forEach((value, key) => {
-    resWithCombinedHeaders.headers.set(key, value)
-  })
+    resWithCombinedHeaders.headers.set(key, value);
+  });
 
   // the headers from the auth middleware should always be returned
-  return resWithCombinedHeaders
+  return resWithCombinedHeaders;
 }
 ```
 
@@ -533,7 +559,7 @@ When calling `getAccessToken` without request and response objects, you can pass
 
 ```typescript
 // app/api/my-api/route.ts
-import { auth0 } from "@/lib/auth0"
+import { auth0 } from "@/lib/auth0";
 
 export async function GET() {
   try {
@@ -543,8 +569,11 @@ export async function GET() {
     // Use the refreshed token
     // ...
   } catch (error) {
-    console.error('Error getting access token:', error);
-    return Response.json({ error: 'Failed to get access token' }, { status: 500 });
+    console.error("Error getting access token:", error);
+    return Response.json(
+      { error: "Failed to get access token" },
+      { status: 500 }
+    );
   }
 }
 ```
@@ -555,8 +584,8 @@ When calling `getAccessToken` with request and response objects (from `getServer
 
 ```typescript
 // pages/api/my-pages-api.ts
-import { getAccessToken, withApiAuthRequired } from '@auth0/nextjs-auth0';
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getAccessToken, withApiAuthRequired } from "@auth0/nextjs-auth0";
 
 export default withApiAuthRequired(async function handler(
   req: NextApiRequest,
@@ -571,7 +600,7 @@ export default withApiAuthRequired(async function handler(
     // Use the refreshed token
     // ...
   } catch (error: any) {
-    console.error('Error getting access token:', error);
+    console.error("Error getting access token:", error);
     res.status(error.status || 500).json({ error: error.message });
   }
 });
@@ -587,16 +616,16 @@ This will in turn, update the `access_token`, `id_token` and `expires_at` fields
 You can wrap your components in an `<Auth0Provider />` and pass an initial user object to make it available to your components using the `useUser()` hook. For example:
 
 ```tsx
-import { Auth0Provider } from "@auth0/nextjs-auth0"
+import { Auth0Provider } from "@auth0/nextjs-auth0";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export default async function RootLayout({
-  children,
+  children
 }: Readonly<{
-  children: React.ReactNode
+  children: React.ReactNode;
 }>) {
-  const session = await auth0.getSession()
+  const session = await auth0.getSession();
 
   return (
     <html lang="en">
@@ -604,7 +633,7 @@ export default async function RootLayout({
         <Auth0Provider user={session?.user}>{children}</Auth0Provider>
       </body>
     </html>
-  )
+  );
 }
 ```
 
@@ -621,7 +650,10 @@ The `beforeSessionSaved` hook is run right before the session is persisted. It p
 The hook recieves a `SessionData` object and an ID token. The function must return a Promise that resolves to a `SessionData` object: `(session: SessionData) => Promise<SessionData>`. For example:
 
 ```ts
-import { Auth0Client, filterDefaultIdTokenClaims } from "@auth0/nextjs-auth0/server"
+import {
+  Auth0Client,
+  filterDefaultIdTokenClaims
+} from "@auth0/nextjs-auth0/server";
 
 export const auth0 = new Auth0Client({
   async beforeSessionSaved(session, idToken) {
@@ -629,33 +661,34 @@ export const auth0 = new Auth0Client({
       ...session,
       user: {
         ...filterDefaultIdTokenClaims(session.user),
-        foo: session.user.foo, // keep the foo claim
-      },
-    }
-  },
-})
+        foo: session.user.foo // keep the foo claim
+      }
+    };
+  }
+});
 ```
 
 The `session.user` object passed to the `beforeSessionSaved` hook will contain every claim in the ID Token, including custom claims. You can use the `filterDefaultIdTokenClaims` utility to filter out the standard claims and only keep the custom claims you want to persist.
 
 > [!INFO]  
 > Incase you want to understand which claims are being considered the default Id Token Claims, you can refer to `DEFAULT_ID_TOKEN_CLAIMS`, which can be imported from the SDK from `@auth0/nextjs-auth0/server`:
-> 
+>
 > ```ts
-> import { DEFAULT_ID_TOKEN_CLAIMS } from "@auth0/nextjs-auth0/server"
+> import { DEFAULT_ID_TOKEN_CLAIMS } from "@auth0/nextjs-auth0/server";
 > ```
 
 Alternatively, you can use the entire `session.user` object if you would like to include every claim in the ID Token by just returning the `session` like so:
 
 ```ts
-import { Auth0Client } from "@auth0/nextjs-auth0/server"
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 export const auth0 = new Auth0Client({
   async beforeSessionSaved(session, idToken) {
-    return session
-  },
-})
+    return session;
+  }
+});
 ```
+
 Do realize that this has an impact on the size of the cookie being issued, so it's best to limit the claims to only those that are necessary for your application.
 
 ### `onCallback`
@@ -679,15 +712,15 @@ export const auth0 = new Auth0Client({
     if (error) {
       return NextResponse.redirect(
         new URL(`/error?error=${error.message}`, process.env.APP_BASE_URL)
-      )
+      );
     }
 
     // complete the redirect to the provided returnTo URL
     return NextResponse.redirect(
       new URL(context.returnTo || "/", process.env.APP_BASE_URL)
-    )
-  },
-})
+    );
+  }
+});
 ```
 
 ## Session configuration
@@ -699,9 +732,9 @@ export const auth0 = new Auth0Client({
   session: {
     rolling: true,
     absoluteDuration: 60 * 60 * 24 * 30, // 30 days in seconds
-    inactivityDuration: 60 * 60 * 24 * 7, // 7 days in seconds
-  },
-})
+    inactivityDuration: 60 * 60 * 24 * 7 // 7 days in seconds
+  }
+});
 ```
 
 | Option             | Type      | Description                                                                                                                                                                                                                                   |
@@ -737,33 +770,33 @@ The SDK will automatically pick up these values. Note that `httpOnly` is always 
 Configure the options directly when initializing the client:
 
 ```typescript
-import { Auth0Client } from "@auth0/nextjs-auth0/server"
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 export const auth0 = new Auth0Client({
   session: {
     cookie: {
-      domain: '.example.com',
-      path: '/app',
+      domain: ".example.com",
+      path: "/app",
       transient: true,
       // httpOnly is always true and cannot be configured
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'Lax',
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "Lax"
       // name: 'appSession', // Optional: custom cookie name, defaults to '__session'
-    },
+    }
     // ... other session options like absoluteDuration ...
-  },
+  }
   // ... other client options ...
 });
 ```
 
 **Session Cookie Options:**
 
-*   `domain` (String): Specifies the `Domain` attribute.
-*   `path` (String): Specifies the `Path` attribute. Defaults to `/`.
-*   `transient` (Boolean): If `true`, the `maxAge` attribute is omitted, making it a session cookie. Defaults to `false`.
-*   `secure` (Boolean): Specifies the `Secure` attribute. Defaults to `false` (or `true` if `AUTH0_COOKIE_SECURE=true` is set).
-*   `sameSite` ('Lax' | 'Strict' | 'None'): Specifies the `SameSite` attribute. Defaults to `Lax` (or the value of `AUTH0_COOKIE_SAME_SITE`).
-*   `name` (String): The name of the session cookie. Defaults to `__session`.
+- `domain` (String): Specifies the `Domain` attribute.
+- `path` (String): Specifies the `Path` attribute. Defaults to `/`.
+- `transient` (Boolean): If `true`, the `maxAge` attribute is omitted, making it a session cookie. Defaults to `false`.
+- `secure` (Boolean): Specifies the `Secure` attribute. Defaults to `false` (or `true` if `AUTH0_COOKIE_SECURE=true` is set).
+- `sameSite` ('Lax' | 'Strict' | 'None'): Specifies the `SameSite` attribute. Defaults to `Lax` (or the value of `AUTH0_COOKIE_SAME_SITE`).
+- `name` (String): The name of the session cookie. Defaults to `__session`.
 
 > [!INFO]
 > Options provided directly in `Auth0ClientOptions` take precedence over environment variables. The `httpOnly` attribute is always `true` regardless of configuration.
@@ -791,9 +824,9 @@ export const auth0 = new Auth0Client({
     },
     async deleteByLogoutToken({ sid, sub }: { sid?: string; sub?: string }) {
       // optional method to be implemented when using Back-Channel Logout
-    },
-  },
-})
+    }
+  }
+});
 ```
 
 ## Back-Channel Logout
@@ -810,36 +843,34 @@ By default, the middleware does not protect any pages. It is used to mount the a
 
 You can combine multiple middleware, like so:
 
-> [!WARNING]
-> **Handling `x-middleware-next` Header**
+> [!WARNING] > **Handling `x-middleware-next` Header**
 > The `auth0.middleware` response (`authResponse`) might contain an `x-middleware-next` header. This header signals to Next.js that the request should be forwarded to the backend application, regardless of the status code of the response you construct.
 >
 > When combining middleware, **do not** copy the `x-middleware-next` header from `authResponse` to your final response if your custom middleware intends to block the request (e.g., by returning a `NextResponse.json` with a 401 status, or a `NextResponse.redirect`). Copying this header in such cases will cause Next.js to still execute the backend route handler despite your middleware attempting to block access. Only copy headers that are necessary, like `set-cookie`.
 
-
 ```ts
 export async function middleware(request: NextRequest) {
-  const authResponse = await auth0.middleware(request)
+  const authResponse = await auth0.middleware(request);
 
   // if path starts with /auth, let the auth middleware handle it
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authResponse
+    return authResponse;
   }
 
   // call any other middleware here
-  const someOtherResponse = await someOtherMiddleware(request)
-  const shouldProceed = someOtherResponse.headers.get('x-middleware-next');
+  const someOtherResponse = await someOtherMiddleware(request);
+  const shouldProceed = someOtherResponse.headers.get("x-middleware-next");
 
   // add any headers from the auth middleware to the response
   for (const [key, value] of authResponse.headers) {
     // Only copy 'x-middleware-next' if the custom middleware response intends to proceed.
-    if (key.toLowerCase() === 'x-middleware-next' && !shouldProceed) {
+    if (key.toLowerCase() === "x-middleware-next" && !shouldProceed) {
       continue; // Skip copying this header if we are blocking/redirecting
     }
-    someOtherResponse.headers.set(key, value)
+    someOtherResponse.headers.set(key, value);
   }
 
-  return someOtherResponse
+  return someOtherResponse;
 }
 ```
 
@@ -880,17 +911,20 @@ The SDK mounts 6 routes:
 The default paths can be set using the `routes` configuration option. For example, when instantiating the client:
 
 ```ts
-import { Auth0Client } from "@auth0/nextjs-auth0/server"
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 export const auth0 = new Auth0Client({
   routes: {
     login: "/login",
     logout: "/logout",
     callback: "/callback",
-    backChannelLogout: "/backchannel-logout",
-  },
-})
+    backChannelLogout: "/backchannel-logout"
+  }
+});
 ```
+
+> [!NOTE]  
+> If you customize the login url you will need to set the environment variable `NEXT_PUBLIC_LOGIN_ROUTE` to this custom value for `withPageAuthRequired` to work correctly.
 
 To configure the profile and access token routes, you must use the `NEXT_PUBLIC_PROFILE_ROUTE` and `NEXT_PUBLIC_ACCESS_TOKEN_ROUTE`, respectively. For example:
 
@@ -912,23 +946,23 @@ NEXT_PUBLIC_ACCESS_TOKEN_ROUTE=/api/auth/token
 The `generateSessionCookie` helper can be used to generate a session cookie value for use during tests:
 
 ```ts
-import { generateSessionCookie } from "@auth0/nextjs-auth0/testing"
+import { generateSessionCookie } from "@auth0/nextjs-auth0/testing";
 
 const sessionCookieValue = await generateSessionCookie(
   {
     user: {
-      sub: "user_123",
+      sub: "user_123"
     },
     tokenSet: {
       accessToken: "at_123",
       refreshToken: "rt_123",
-      expiresAt: 123456789,
-    },
+      expiresAt: 123456789
+    }
   },
   {
-    secret: process.env.AUTH0_SECRET!,
+    secret: process.env.AUTH0_SECRET!
   }
-)
+);
 ```
 
 ## Programmatically starting interactive login
@@ -937,8 +971,9 @@ Additionally to the ability to initialize the interactive login process by redir
 the `startInteractiveLogin` method can also be called programmatically.
 
 ```typescript
-import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 import { NextRequest } from "next/server";
+
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export const GET = async (req: NextRequest) => {
   return auth0.startInteractiveLogin();
@@ -953,23 +988,24 @@ There are 2 ways to customize the authorization parameters that will be passed t
 export const auth0 = new Auth0Client({
   authorizationParameters: {
     scope: "openid profile email",
-    audience: "urn:custom:api",
-  },
+    audience: "urn:custom:api"
+  }
 });
 ```
 
 The second option is by configuring `authorizationParams` when calling `startInteractiveLogin`:
 
 ```ts
-import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 import { NextRequest } from "next/server";
+
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export const GET = async (req: NextRequest) => {
   // Call startInteractiveLogin with optional parameters
   return auth0.startInteractiveLogin({
     authorizationParameters: {
       scope: "openid profile email",
-      audience: "urn:custom:api",
+      audience: "urn:custom:api"
     }
   });
 };
@@ -982,12 +1018,13 @@ export const GET = async (req: NextRequest) => {
 When calling `startInteractiveLogin`, the `returnTo` parameter can be configured to specify where you would like to redirect the user to after they have completed their authentication and have returned to your application.
 
 ```ts
-import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 import { NextRequest } from "next/server";
+
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export const GET = async (req: NextRequest) => {
   return auth0.startInteractiveLogin({
-    returnTo: '/dashboard',
+    returnTo: "/dashboard"
   });
 };
 ```
@@ -995,9 +1032,10 @@ export const GET = async (req: NextRequest) => {
 > [!NOTE]  
 > The URLs specified as `returnTo` parameters must be registered in your client's **Allowed Callback URLs**.
 
-
 ## Getting access tokens for connections
+
 You can retrieve an access token for a connection using the `getAccessTokenForConnection()` method, which accepts an object with the following properties:
+
 - `connection`: The federated connection for which an access token should be retrieved.
 - `login_hint`: The optional login_hint parameter to pass to the `/authorize` endpoint.
 
@@ -1013,21 +1051,23 @@ On the server, the `getAccessTokenForConnection()` helper can be used in Server 
 For example:
 
 ```ts
-import { NextResponse } from "next/server"
+import { NextResponse } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function GET() {
   try {
-    const token = await auth0.getAccessTokenForConnection({ connection: 'google-oauth2' })
+    const token = await auth0.getAccessTokenForConnection({
+      connection: "google-oauth2"
+    });
     // call external API with token...
   } catch (err) {
     // err will be an instance of AccessTokenError if an access token could not be obtained
   }
 
   return NextResponse.json({
-    message: "Success!",
-  })
+    message: "Success!"
+  });
 }
 ```
 
@@ -1038,21 +1078,25 @@ Upon further calls for the same provider, the cached value will be used until it
 On the server, the `getAccessTokenForConnection({}, req, res)` helper can be used in `getServerSideProps` and API routes to get an access token for a connection, like so:
 
 ```ts
-import type { NextApiRequest, NextApiResponse } from "next"
+import type { NextApiRequest, NextApiResponse } from "next";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<{ message: string }>
 ) {
   try {
-    const token = await auth0.getAccessTokenForConnection({ connection: 'google-oauth2' }, req, res)
+    const token = await auth0.getAccessTokenForConnection(
+      { connection: "google-oauth2" },
+      req,
+      res
+    );
   } catch (err) {
     // err will be an instance of AccessTokenError if an access token could not be obtained
   }
 
-  res.status(200).json({ message: "Success!" })
+  res.status(200).json({ message: "Success!" });
 }
 ```
 
@@ -1061,28 +1105,34 @@ export default async function handler(
 In middleware, the `getAccessTokenForConnection({}, req, res)` helper can be used to get an access token for a connection, like so:
 
 ```tsx
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
-  const accessToken = await auth0.getAccessTokenForConnection({ connection: 'google-oauth2' }, request, authRes)
+  const accessToken = await auth0.getAccessTokenForConnection(
+    { connection: "google-oauth2" },
+    request,
+    authRes
+  );
 
   // the headers from the auth middleware should always be returned
-  return authRes
+  return authRes;
 }
 ```
 
@@ -1092,39 +1142,45 @@ export async function middleware(request: NextRequest) {
 If you are using the Pages Router and are calling the `getAccessTokenForConnection` method in both the middleware and an API Route or `getServerSideProps`, it's recommended to propagate the headers from the middleware, as shown below. This will ensure that calling `getAccessTokenForConnection` in the API Route or `getServerSideProps` will not result in the access token being refreshed again.
 
 ```ts
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server";
 
-import { auth0 } from "./lib/auth0" // Adjust path if your auth0 client is elsewhere
+import { auth0 } from "./lib/auth0"; // Adjust path if your auth0 client is elsewhere
 
 export async function middleware(request: NextRequest) {
-  const authRes = await auth0.middleware(request)
+  const authRes = await auth0.middleware(request);
 
   if (request.nextUrl.pathname.startsWith("/auth")) {
-    return authRes
+    return authRes;
   }
 
-  const session = await auth0.getSession(request)
+  const session = await auth0.getSession(request);
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(new URL("/auth/login", request.nextUrl.origin))
+    return NextResponse.redirect(
+      new URL("/auth/login", request.nextUrl.origin)
+    );
   }
 
-  const accessToken = await auth0.getAccessTokenForConnection({ connection: 'google-oauth2' }, request, authRes)
+  const accessToken = await auth0.getAccessTokenForConnection(
+    { connection: "google-oauth2" },
+    request,
+    authRes
+  );
 
   // create a new response with the updated request headers
   const resWithCombinedHeaders = NextResponse.next({
     request: {
-      headers: request.headers,
-    },
-  })
+      headers: request.headers
+    }
+  });
 
   // set the response headers (set-cookie) from the auth response
   authRes.headers.forEach((value, key) => {
-    resWithCombinedHeaders.headers.set(key, value)
-  })
+    resWithCombinedHeaders.headers.set(key, value);
+  });
 
   // the headers from the auth middleware should always be returned
-  return resWithCombinedHeaders
+  return resWithCombinedHeaders;
 }
 ```

--- a/src/client/helpers/with-page-auth-required.test.tsx
+++ b/src/client/helpers/with-page-auth-required.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { JSX } from "react";
+import { usePathname } from "next/navigation.js";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as swrModule from "swr";
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockedFunction
+} from "vitest";
+
+import { User } from "../../types/index.js";
+import { Auth0Provider } from "../providers/auth0-provider.js";
+import { withPageAuthRequired } from "./with-page-auth-required.js";
+
+const user: User = {
+  email: "foo@example.com",
+  email_verified: true,
+  name: "foo",
+  nickname: "foo",
+  picture: "foo.jpg",
+  sub: "1",
+  updated_at: null
+};
+
+const withAuth0Provider = ({
+  user
+}: { user?: User } = {}): React.ComponentType => {
+  return (props: any): React.ReactElement => (
+    <Auth0Provider {...props} user={user} />
+  );
+};
+
+const mockUseUserUnauthenticated = () => ({
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isValidating: false,
+  mutate: vi.fn()
+});
+
+vi.mock("swr", async (importActual) => {
+  const actual = await importActual<typeof swrModule>();
+  return {
+    ...actual,
+    default: vi.fn(() => ({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      isValidating: false,
+      mutate: vi.fn()
+    }))
+  };
+});
+
+vi.mock("next/navigation.js", async (importActual) => {
+  const actual = await importActual<typeof import("next/navigation.js")>();
+
+  return {
+    ...actual,
+    usePathname: vi.fn(() => "/")
+  };
+});
+
+describe("with-page-auth-required csr", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: {
+        assign: vi.fn(),
+        toString: () => "https://example.com"
+      }
+    });
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should deny access to a CSR page when not authenticated", async () => {
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledTimes(1)
+    );
+    await waitFor(() => expect(screen.queryByText("Private")).toBeNull());
+  });
+
+  it("should add user to props of CSR page when authenticated", async () => {
+    vi.mocked(swrModule.default).mockImplementation(() => ({
+      data: user,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn()
+    }));
+
+    const ProtectedPage = withPageAuthRequired(
+      ({ user }): JSX.Element => <>{user.email}</>
+    );
+
+    render(<ProtectedPage />, {
+      wrapper: withAuth0Provider({ user })
+    });
+    await waitFor(() => expect(window.location.assign).not.toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText("foo@example.com")).not.toBeNull()
+    );
+  });
+
+  it("should show an empty element when redirecting", async () => {
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    const { container } = render(<ProtectedPage />, {
+      wrapper: withAuth0Provider()
+    });
+    await waitFor(() => expect(container.innerHTML).toBe(""));
+  });
+
+  it("should show a custom element when redirecting", async () => {
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+
+    const MyPage = (): JSX.Element => <>Private</>;
+    const OnRedirecting = (): JSX.Element => <>Redirecting</>;
+    const ProtectedPage = withPageAuthRequired(MyPage, {
+      onRedirecting: OnRedirecting
+    });
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() => expect(screen.getByText("Redirecting")).not.toBeNull());
+  });
+
+  it("should show an empty fallback in case of error", async () => {
+    vi.mocked(swrModule.default).mockImplementation(() => ({
+      data: undefined,
+      error: new Error("Unauthorized"),
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn()
+    }));
+
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    const { container } = render(<ProtectedPage />, {
+      wrapper: withAuth0Provider()
+    });
+    await waitFor(() => expect(container.innerHTML).toBe(""));
+  });
+
+  it("should show a custom fallback in case of error", async () => {
+    vi.mocked(swrModule.default).mockImplementation(() => ({
+      data: undefined,
+      error: new Error("Unauthorized"),
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn()
+    }));
+
+    const MyPage = (): JSX.Element => <>Private</>;
+    const OnError = (): JSX.Element => <>Error</>;
+    const ProtectedPage = withPageAuthRequired(MyPage, { onError: OnError });
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() => expect(screen.getByText("Error")).not.toBeNull());
+  });
+
+  it("should use a custom login URL", async () => {
+    process.env.NEXT_PUBLIC_LOGIN_ROUTE = "/api/foo";
+
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining("/api/foo")
+      )
+    );
+    delete process.env.NEXT_PUBLIC_LOGIN_ROUTE;
+  });
+
+  it("should return to the root path", async () => {
+    window.location.toString = vi.fn(() => "https://example.net");
+
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    vi.mocked(usePathname).mockReturnValue("/");
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining(`?returnTo=${encodeURIComponent("/")}`)
+      )
+    );
+  });
+
+  it("should return to the current path", async () => {
+    window.location.toString = vi.fn(() => "https://example.net/foo");
+
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    vi.mocked(usePathname).mockReturnValue("/foo");
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage);
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining(`?returnTo=${encodeURIComponent("/foo")}`)
+      )
+    );
+  });
+
+  it("should accept a custom returnTo URL", async () => {
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage, { returnTo: "/foo" });
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.stringContaining(`?returnTo=${encodeURIComponent("/foo")}`)
+      )
+    );
+  });
+
+  it("should preserve multiple query params in the returnTo URL", async () => {
+    vi.mocked(swrModule.default).mockImplementation(mockUseUserUnauthenticated);
+    const MyPage = (): JSX.Element => <>Private</>;
+    const ProtectedPage = withPageAuthRequired(MyPage, {
+      returnTo: "/foo?bar=baz&qux=quux"
+    });
+
+    render(<ProtectedPage />, { wrapper: withAuth0Provider() });
+    await waitFor(() => {
+      expect(window.location.assign).toHaveBeenCalled();
+    });
+    const url = new URL(
+      (
+        window.location.assign as MockedFunction<typeof window.location.assign>
+      ).mock.calls[0][0],
+      "https://example.com"
+    );
+    expect(url.searchParams.get("returnTo")).toEqual("/foo?bar=baz&qux=quux");
+  });
+});

--- a/src/client/helpers/with-page-auth-required.tsx
+++ b/src/client/helpers/with-page-auth-required.tsx
@@ -59,7 +59,7 @@ export interface UserProps {
  * When you wrap your pages in this higher order component and an anonymous user visits your page,
  * they will be redirected to the login page and then returned to the page they were redirected from (after login).
  */
-export type WithPageAuthRequired = <P extends {}>(
+export type WithPageAuthRequired = <P extends object>(
   Component: ComponentType<P & UserProps>,
   options?: WithPageAuthRequiredOptions
 ) => React.FC<P>;

--- a/src/client/helpers/with-page-auth-required.tsx
+++ b/src/client/helpers/with-page-auth-required.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { ComponentType, JSX, useEffect } from "react";
+import { useRouter as usePagesRouter } from "next/compat/router.js";
+import { usePathname } from "next/navigation.js";
+
+import type { User } from "../../types/index.js";
+import { normalizeWithBasePath } from "../../utils/pathUtils.js";
+import { useUser } from "../hooks/use-user.js";
+
+const defaultOnRedirecting = (): JSX.Element => <></>;
+const defaultOnError = (): JSX.Element => <></>;
+
+/**
+ * Options to customize the withPageAuthRequired higher order component.
+ */
+export interface WithPageAuthRequiredOptions {
+  /**
+   * ```js
+   * withPageAuthRequired(Profile, {
+   *   returnTo: '/profile'
+   * });
+   * ```
+   *
+   * Add a path to return the user to after login.
+   */
+  returnTo?: string;
+  /**
+   * ```js
+   * withPageAuthRequired(Profile, {
+   *   onRedirecting: () => <div>Redirecting...</div>
+   * });
+   * ```
+   *
+   * Render a message to show that the user is being redirected.
+   */
+  onRedirecting?: () => JSX.Element;
+  /**
+   * ```js
+   * withPageAuthRequired(Profile, {
+   *   onError: error => <div>Error: {error.message}</div>
+   * });
+   * ```
+   *
+   * Render a fallback in case of error fetching the user from the profile API route.
+   */
+  onError?: (error: Error) => JSX.Element;
+}
+
+export interface UserProps {
+  user: User;
+}
+
+/**
+ * ```js
+ * const MyProtectedPage = withPageAuthRequired(MyPage);
+ * ```
+ *
+ * When you wrap your pages in this higher order component and an anonymous user visits your page,
+ * they will be redirected to the login page and then returned to the page they were redirected from (after login).
+ */
+export type WithPageAuthRequired = <P extends {}>(
+  Component: ComponentType<P & UserProps>,
+  options?: WithPageAuthRequiredOptions
+) => React.FC<P>;
+
+export const withPageAuthRequired: WithPageAuthRequired = (
+  Component,
+  options = {}
+) => {
+  return function WithPageAuthRequired(props): JSX.Element {
+    const {
+      returnTo,
+      onRedirecting = defaultOnRedirecting,
+      onError = defaultOnError
+    } = options;
+    const loginUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_LOGIN_ROUTE || "/auth/login"
+    );
+    const { user, error, isLoading } = useUser();
+    const pagesRouter = usePagesRouter();
+    const pathname = usePathname();
+
+    useEffect(() => {
+      if (pagesRouter && !pagesRouter.isReady) return;
+      if ((user && !error) || isLoading) return;
+
+      let returnToPath: string;
+
+      if (!returnTo) {
+        const currentLocation = window.location;
+        returnToPath = pathname + currentLocation.search + currentLocation.hash;
+      } else {
+        returnToPath = returnTo;
+      }
+
+      window.location.assign(
+        `${loginUrl}?returnTo=${encodeURIComponent(returnToPath)}`
+      );
+    }, [user, error, isLoading]);
+
+    if (error) return onError(error);
+    if (user) return <Component user={user} {...(props as any)} />;
+
+    return onRedirecting();
+  };
+};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,8 @@
 export { useUser } from "./hooks/use-user.js";
 export { getAccessToken } from "./helpers/get-access-token.js";
+export {
+  withPageAuthRequired,
+  WithPageAuthRequired,
+  WithPageAuthRequiredOptions
+} from "./helpers/with-page-auth-required.js";
 export { Auth0Provider } from "./providers/auth0-provider.js";

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -254,7 +254,7 @@ export class AuthClient {
 
     // routes
     this.routes = {
-      login: "/auth/login",
+      login: process.env.NEXT_PUBLIC_LOGIN_ROUTE || "/auth/login",
       logout: "/auth/logout",
       callback: "/auth/callback",
       backChannelLogout: "/auth/backchannel-logout",


### PR DESCRIPTION
### 📋 Changes

Adds the `withPageAuthRequired` HoC to protect pages, client side.

`withPageAuthRequired` for SSR and APIs will follow in subsequent PRs.

### 📎 References

- https://github.com/auth0/nextjs-auth0/issues/1790

### 🎯 Testing

1. Create a page, wrapped with `withPageAuthRequired` (see sample below)
2. Attempt to access that page without a session
3. Notice you will be redirected to the login page

```tsx
"use client";

import Link from "next/link";
import { withPageAuthRequired } from "@auth0/nextjs-auth0";

export default withPageAuthRequired(function Page({ user }) {
  return (
    <div>
      <div>Hello, {user.name}!</div>
      <Link href="/">Home</Link>
    </div>
  );
});
```
