### PR TITLE
Use `max-age=0` to delete cookie

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -2098,7 +2098,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // session cookie is cleared
       const cookie = response.cookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
     });
 
     it("should use the returnTo URL as the post_logout_redirect_uri if provided", async () => {
@@ -2170,7 +2170,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // session cookie is cleared
       const cookie = response.cookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
     });
 
     it("should not include the id_token_hint parameter if a session does not exist", async () => {
@@ -2258,7 +2258,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // session cookie is cleared
       const cookie = response.cookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
     });
 
     it("should fallback to the /v2/logout endpoint if the client does not have RP-Initiated Logout enabled", async () => {
@@ -2317,7 +2317,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       // session cookie is cleared
       const cookie = response.cookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
     });
 
     it("should return an error if the discovery endpoint could not be fetched", async () => {
@@ -2577,9 +2577,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const transactionCookie = response.cookies.get(`__txn_${state}`);
       expect(transactionCookie).toBeDefined();
       expect(transactionCookie!.value).toEqual("");
-      expect(transactionCookie!.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(transactionCookie!.maxAge).toEqual(0);
     });
 
     describe("when a base path is defined", async () => {
@@ -2760,9 +2758,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const transactionCookie = response.cookies.get(`__txn_${state}`);
       expect(transactionCookie).toBeDefined();
       expect(transactionCookie!.value).toEqual("");
-      expect(transactionCookie!.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(transactionCookie!.maxAge).toEqual(0);
     });
 
     it("should return an error if the state parameter is missing", async () => {

--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -141,7 +141,10 @@ describe("Chunked Cookie Utils", () => {
       setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
 
       // Should create 3 chunks (8000 / 3500 ≈ 2.3, rounded up to 3)
-      expect(resCookies.set).toHaveBeenCalledTimes(3);
+      // called 4 times:
+      // 3 calls to set the chunks
+      // 1 call to remove the non-chunked cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
       expect(reqCookies.set).toHaveBeenCalledTimes(3);
 
       // Check first chunk
@@ -164,6 +167,11 @@ describe("Chunked Cookie Utils", () => {
         largeValue.slice(7000),
         options
       );
+
+      // Check removal of non-chunked cookie
+      expect(resCookies.set).toHaveBeenCalledWith(name, "", {
+        maxAge: 0
+      });
     });
 
     it("should clear existing chunked cookies when setting a single cookie", () => {
@@ -181,8 +189,18 @@ describe("Chunked Cookie Utils", () => {
 
       setChunkedCookie(name, value, options, reqCookies, resCookies);
 
-      expect(resCookies.set).toHaveBeenCalledTimes(1);
-      expect(resCookies.set).toHaveBeenCalledWith(name, value, options);
+      // delete the 3 chunked cookies set above and then set the new cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
+      expect(resCookies.set).toHaveBeenNthCalledWith(1, name, value, options);
+      expect(resCookies.set).toHaveBeenNthCalledWith(2, `${name}__1`, "", {
+        maxAge: 0
+      });
+      expect(resCookies.set).toHaveBeenNthCalledWith(3, `${name}__0`, "", {
+        maxAge: 0
+      });
+      expect(resCookies.set).toHaveBeenNthCalledWith(4, `${name}__2`, "", {
+        maxAge: 0
+      });
       expect(reqCookies.set).toHaveBeenCalledTimes(1);
       expect(reqCookies.set).toHaveBeenCalledWith(name, value);
       expect(reqCookies.delete).toHaveBeenCalledTimes(3);
@@ -205,7 +223,29 @@ describe("Chunked Cookie Utils", () => {
 
       expect(reqCookies.delete).toHaveBeenCalledTimes(1);
       expect(reqCookies.delete).toHaveBeenCalledWith(`${name}`);
-      expect(resCookies.set).toHaveBeenCalledTimes(3);
+      // set a chunked cookie with 3 chunks and delete the existing single cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
+      expect(resCookies.set).toHaveBeenNthCalledWith(
+        1,
+        `${name}__0`,
+        largeValue.slice(0, 3500),
+        options
+      );
+      expect(resCookies.set).toHaveBeenNthCalledWith(
+        2,
+        `${name}__1`,
+        largeValue.slice(3500, 7000),
+        options
+      );
+      expect(resCookies.set).toHaveBeenNthCalledWith(
+        3,
+        `${name}__2`,
+        largeValue.slice(7000),
+        options
+      );
+      expect(resCookies.set).toHaveBeenNthCalledWith(4, name, "", {
+        maxAge: 0
+      });
       expect(reqCookies.set).toHaveBeenCalledTimes(3);
     });
 
@@ -272,7 +312,10 @@ describe("Chunked Cookie Utils", () => {
 
       setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
 
-      expect(resCookies.set).toHaveBeenCalledTimes(3); // 3 chunks
+      // called 4 times:
+      // 3 calls to set the chunks
+      // 1 call to remove the non-chunked cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
       expect(resCookies.set).toHaveBeenNthCalledWith(
         1,
         `${name}__0`,
@@ -291,6 +334,9 @@ describe("Chunked Cookie Utils", () => {
         expect.any(String),
         expect.objectContaining({ domain: "example.com" })
       );
+      expect(resCookies.set).toHaveBeenNthCalledWith(4, name, "", {
+        maxAge: 0
+      });
     });
 
     it("should omit maxAge for a single transient cookie", () => {
@@ -336,7 +382,10 @@ describe("Chunked Cookie Utils", () => {
 
       setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
 
-      expect(resCookies.set).toHaveBeenCalledTimes(3); // 3 chunks
+      // called 4 times:
+      // 3 calls to set the chunks
+      // 1 call to remove the non-chunked cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
       expect(resCookies.set).toHaveBeenNthCalledWith(
         1,
         `${name}__0`,
@@ -355,6 +404,9 @@ describe("Chunked Cookie Utils", () => {
         expect.any(String),
         expectedOptions
       );
+      expect(resCookies.set).toHaveBeenNthCalledWith(4, name, "", {
+        maxAge: 0
+      });
       expect(resCookies.set).not.toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
@@ -403,7 +455,10 @@ describe("Chunked Cookie Utils", () => {
 
       setChunkedCookie(name, largeValue, options, reqCookies, resCookies);
 
-      expect(resCookies.set).toHaveBeenCalledTimes(3); // 3 chunks
+      // called 4 times:
+      // 3 calls to set the chunks
+      // 1 call to remove the non-chunked cookie
+      expect(resCookies.set).toHaveBeenCalledTimes(4);
       expect(resCookies.set).toHaveBeenNthCalledWith(
         1,
         `${name}__0`,
@@ -422,11 +477,9 @@ describe("Chunked Cookie Utils", () => {
         expect.any(String),
         expectedOptions
       );
-      expect(resCookies.set).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.objectContaining({ maxAge: 3600 })
-      );
+      expect(resCookies.set).toHaveBeenNthCalledWith(4, name, "", {
+        maxAge: 0
+      });
     });
 
     describe("getChunkedCookie", () => {
@@ -498,7 +551,9 @@ describe("Chunked Cookie Utils", () => {
 
         deleteChunkedCookie(name, reqCookies, resCookies);
 
-        expect(resCookies.delete).toHaveBeenCalledWith(name);
+        expect(resCookies.set).toHaveBeenCalledWith(name, "", {
+          maxAge: 0
+        });
       });
 
       it("should delete all chunks of a cookie", () => {
@@ -515,13 +570,23 @@ describe("Chunked Cookie Utils", () => {
         deleteChunkedCookie(name, reqCookies, resCookies);
 
         // Should delete main cookie and 3 chunks
-        expect(resCookies.delete).toHaveBeenCalledTimes(4);
-        expect(resCookies.delete).toHaveBeenCalledWith(name);
-        expect(resCookies.delete).toHaveBeenCalledWith(`${name}__0`);
-        expect(resCookies.delete).toHaveBeenCalledWith(`${name}__1`);
-        expect(resCookies.delete).toHaveBeenCalledWith(`${name}__2`);
+        expect(resCookies.set).toHaveBeenCalledTimes(4);
+        expect(resCookies.set).toHaveBeenCalledWith(name, "", {
+          maxAge: 0
+        });
+        expect(resCookies.set).toHaveBeenCalledWith(`${name}__0`, "", {
+          maxAge: 0
+        });
+        expect(resCookies.set).toHaveBeenCalledWith(`${name}__1`, "", {
+          maxAge: 0
+        });
+        expect(resCookies.set).toHaveBeenCalledWith(`${name}__2`, "", {
+          maxAge: 0
+        });
         // Should not delete unrelated cookies
-        expect(resCookies.delete).not.toHaveBeenCalledWith("otherCookie");
+        expect(resCookies.set).not.toHaveBeenCalledWith("otherCookie", "", {
+          maxAge: 0
+        });
       });
     });
 
@@ -600,7 +665,10 @@ describe("Chunked Cookie Utils", () => {
         // Get chunks count (10000 / 3500 ≈ 2.86, so we need 3 chunks)
         const expectedChunks = Math.ceil(10000 / 3500);
 
-        expect(resCookies.set).toHaveBeenCalledTimes(expectedChunks);
+        // called 4 times:
+        // 3 calls to set the chunks
+        // 1 call to remove the non-chunked cookie
+        expect(resCookies.set).toHaveBeenCalledTimes(expectedChunks + 1);
 
         // Clear and set up cookies for retrieval test
         cookieStore.clear();

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -219,7 +219,7 @@ export function setChunkedCookie(
 
     // When we are writing a non-chunked cookie, we should remove the chunked cookies
     getAllChunkedCookies(reqCookies, name).forEach((cookieChunk) => {
-      resCookies.delete(cookieChunk.name);
+      deleteCookie(resCookies, cookieChunk.name);
       reqCookies.delete(cookieChunk.name);
     });
 
@@ -249,13 +249,13 @@ export function setChunkedCookie(
     for (let i = 0; i < chunksToRemove; i++) {
       const chunkIndexToRemove = chunkIndex + i;
       const chunkName = `${name}${CHUNK_PREFIX}${chunkIndexToRemove}`;
-      resCookies.delete(chunkName);
+      deleteCookie(resCookies, chunkName);
       reqCookies.delete(chunkName);
     }
   }
 
   // When we have written chunked cookies, we should remove the non-chunked cookie
-  resCookies.delete(name);
+  deleteCookie(resCookies, name);
   reqCookies.delete(name);
 }
 
@@ -324,10 +324,10 @@ export function deleteChunkedCookie(
   isLegacyCookie?: boolean
 ): void {
   // Delete main cookie
-  resCookies.delete(name);
+  deleteCookie(resCookies, name);
 
   getAllChunkedCookies(reqCookies, name, isLegacyCookie).forEach((cookie) => {
-    resCookies.delete(cookie.name); // Delete each filtered cookie
+    deleteCookie(resCookies, cookie.name); // Delete each filtered cookie
   });
 }
 
@@ -348,4 +348,10 @@ export function addCacheControlHeadersForSession(res: NextResponse): void {
   );
   res.headers.set("Pragma", "no-cache");
   res.headers.set("Expires", "0");
+}
+
+export function deleteCookie(resCookies: ResponseCookies, name: string) {
+  resCookies.set(name, "", {
+    maxAge: 0 // Ensure the cookie is deleted immediately
+  });
 }

--- a/src/server/session/stateful-session-store.test.ts
+++ b/src/server/session/stateful-session-store.test.ts
@@ -9,9 +9,11 @@ import {
   ResponseCookies,
   sign
 } from "../cookies.js";
-import { LEGACY_COOKIE_NAME, LegacySessionPayload } from "./normalize-session.js";
+import {
+  LEGACY_COOKIE_NAME,
+  LegacySessionPayload
+} from "./normalize-session.js";
 import { StatefulSessionStore } from "./stateful-session-store.js";
-
 
 describe("Stateful Session Store", async () => {
   describe("get", async () => {
@@ -730,11 +732,13 @@ describe("Stateful Session Store", async () => {
       });
 
       vi.spyOn(requestCookies, "has").mockReturnValue(true);
-      vi.spyOn(responseCookies, "delete");
+      vi.spyOn(responseCookies, "set");
 
       await sessionStore.set(requestCookies, responseCookies, session);
 
-      expect(responseCookies.delete).toHaveBeenCalledWith(LEGACY_COOKIE_NAME);
+      expect(responseCookies.set).toHaveBeenCalledWith(LEGACY_COOKIE_NAME, "", {
+        maxAge: 0
+      });
     });
 
     it("should not delete the legacy cookie if session cookie name matches LEGACY_COOKIE_NAME", async () => {
@@ -819,7 +823,7 @@ describe("Stateful Session Store", async () => {
       await sessionStore.delete(requestCookies, responseCookies);
       const cookie = responseCookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
       expect(store.delete).toHaveBeenCalledOnce();
       expect(store.delete).toHaveBeenCalledWith(sessionId);
     });
@@ -854,7 +858,7 @@ describe("Stateful Session Store", async () => {
       await sessionStore.delete(requestCookies, responseCookies);
       const cookie = responseCookies.get("__session");
       expect(cookie?.value).toEqual("");
-      expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+      expect(cookie?.maxAge).toEqual(0);
       expect(store.delete).not.toHaveBeenCalled();
     });
   });

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -156,7 +156,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
       this.sessionCookieName !== LEGACY_COOKIE_NAME &&
       reqCookies.has(LEGACY_COOKIE_NAME)
     ) {
-      resCookies.delete(LEGACY_COOKIE_NAME);
+      cookies.deleteCookie(resCookies, LEGACY_COOKIE_NAME);
     }
   }
 
@@ -165,7 +165,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
     resCookies: cookies.ResponseCookies
   ) {
     const cookieValue = reqCookies.get(this.sessionCookieName)?.value;
-    await resCookies.delete(this.sessionCookieName);
+    cookies.deleteCookie(resCookies, this.sessionCookieName);
 
     if (!cookieValue) {
       return;

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -1,9 +1,11 @@
-import { ConnectionTokenSet, CookieOptions, SessionData } from "../../types/index.js";
-
 import type { JWTPayload } from "jose";
 
+import {
+  ConnectionTokenSet,
+  CookieOptions,
+  SessionData
+} from "../../types/index.js";
 import * as cookies from "../cookies.js";
-
 import {
   AbstractSessionStore,
   SessionCookieOptions
@@ -138,7 +140,7 @@ export class StatelessSessionStore extends AbstractSessionStore {
     cookies.deleteChunkedCookie(this.sessionCookieName, reqCookies, resCookies);
 
     this.getConnectionTokenSetsCookies(reqCookies).forEach((cookie) =>
-      resCookies.delete(cookie.name)
+      cookies.deleteCookie(resCookies, cookie.name)
     );
   }
 

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -2,7 +2,12 @@ import * as oauth from "oauth4webapi";
 import { describe, expect, it } from "vitest";
 
 import { generateSecret } from "../test/utils.js";
-import { decrypt, encrypt, RequestCookies, ResponseCookies } from "./cookies.js";
+import {
+  decrypt,
+  encrypt,
+  RequestCookies,
+  ResponseCookies
+} from "./cookies.js";
 import { TransactionState, TransactionStore } from "./transaction-store.js";
 
 describe("Transaction Store", async () => {
@@ -315,9 +320,7 @@ describe("Transaction Store", async () => {
       await transactionStore.delete(responseCookies, state);
 
       expect(responseCookies.get(cookieName)?.value).toEqual("");
-      expect(responseCookies.get(cookieName)?.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(responseCookies.get(cookieName)?.maxAge).toEqual(0);
     });
 
     it("should not throw an error if the cookie does not exist", async () => {
@@ -357,13 +360,9 @@ describe("Transaction Store", async () => {
       await transactionStore.deleteAll(requestCookies, responseCookies);
 
       expect(responseCookies.get("__txn_state1")?.value).toEqual("");
-      expect(responseCookies.get("__txn_state1")?.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(responseCookies.get("__txn_state1")?.maxAge).toEqual(0);
       expect(responseCookies.get("__txn_state2")?.value).toEqual("");
-      expect(responseCookies.get("__txn_state2")?.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(responseCookies.get("__txn_state2")?.maxAge).toEqual(0);
       expect(responseCookies.get("other_cookie")?.value).toEqual("value3"); // Should not be deleted
     });
 
@@ -392,9 +391,7 @@ describe("Transaction Store", async () => {
       await transactionStore.deleteAll(requestCookies, responseCookies);
 
       expect(responseCookies.get(`${customPrefix}state1`)?.value).toEqual("");
-      expect(responseCookies.get(`${customPrefix}state1`)?.expires).toEqual(
-        new Date("1970-01-01T00:00:00.000Z")
-      );
+      expect(responseCookies.get(`${customPrefix}state1`)?.maxAge).toEqual(0);
       expect(responseCookies.get("__txn_state2")?.value).toEqual("value2"); // Should not be deleted
       expect(responseCookies.get("other_cookie")?.value).toEqual("value3"); // Should not be deleted
     });

--- a/src/server/transaction-store.ts
+++ b/src/server/transaction-store.ts
@@ -118,7 +118,7 @@ export class TransactionStore {
   }
 
   async delete(resCookies: cookies.ResponseCookies, state: string) {
-    await resCookies.delete(this.getTransactionCookieName(state));
+    cookies.deleteCookie(resCookies, this.getTransactionCookieName(state));
   }
 
   /**
@@ -131,7 +131,7 @@ export class TransactionStore {
     const txnPrefix = this.getCookiePrefix();
     reqCookies.getAll().forEach((cookie) => {
       if (cookie.name.startsWith(txnPrefix)) {
-        resCookies.delete(cookie.name);
+        cookies.deleteCookie(resCookies, cookie.name);
       }
     });
   }


### PR DESCRIPTION
### 📋 Changes

Currently, when a cookie is to be deleted due to logout or a transaction being completed, the underlying `delete()` method from Next's `ResponseCookies` sets the `Expires` attribute to `__session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`.

While this is quite common and widely used, it results in Azure Static Web App (SWA) deployments in completely dropping the `Set-Cookie` header. As a result, the user is not logged out.

To fix this issue, the `Max-Age` attribute is set to `0` which will have the same effect for clearing the cookie and is [supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#browser_compatibility). 

### 📎 References

Fixes: https://github.com/auth0/nextjs-auth0/issues/2074

### 🎯 Testing

1. Deploy an application to Azure SWA
2. Attempt to log out
3. Observe the `Set-Cookie` is not being returned when the `Expire` attribute is set to the Unix epoch
4. Do the same with this change set and observe the session and transaction cookies being cleared
