### PR TITLE
Pass down request when calling getSession in middleware

### DIFF
--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -111,7 +111,7 @@ export async function middleware(request) {
 
     // Any route that gets to this point will be considered a protected route, and require the user to be logged-in to be able to access it
     const { origin } = new URL(request.url)
-    const session = await auth0.getSession()
+    const session = await auth0.getSession(request)
 
     // If the user does not have a session, redirect to login
     if (!session) {


### PR DESCRIPTION
Update the migration guide to correctly show how to use getSession in middleware. Not passing request in middleware will work fine, unless when using turbopack, so the recommendation is to pass down request in middleware.