### PR TITLE
fix failing tests due to using cookie maxage 0 for deletion

### DIFF
--- a/src/server/logout-strategy.flow.test.ts
+++ b/src/server/logout-strategy.flow.test.ts
@@ -464,7 +464,7 @@ describe("Logout Strategy Flow Tests", () => {
         // Session cookie should be cleared
         const cookie = response.cookies.get("__session");
         expect(cookie?.value).toBe("");
-        expect(cookie?.expires).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+        expect(cookie?.maxAge).toBe(0);
 
         // Response should have cache control headers
         expect(response.headers.get("cache-control")).toContain("no-cache");


### PR DESCRIPTION
This PR fixes a failing test which checks if it's deleted by checking if expiry time is unix epoch 0. We use max-age=0 since #2200 so this should be checked instead.
This was not caught in #2200 bc the branch was not updated with main (github showed that there were no changed files b/w pr and main but testing strategy was changed)