### PR TITLE
feat: add support for `withApiAuthRequired` helper

### DIFF
--- a/src/server/helpers/with-api-auth-required.test.ts
+++ b/src/server/helpers/with-api-auth-required.test.ts
@@ -1,0 +1,258 @@
+import { IncomingMessage, ServerResponse } from "http";
+import { Socket } from "net";
+import { NextApiRequest, NextApiResponse } from "next";
+import { cookies } from "next/headers.js";
+import { NextRequest, NextResponse } from "next/server.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { generateSecret } from "../../test/utils.js";
+import { SessionData } from "../../types/index.js";
+import { Auth0Client } from "../client.js";
+import { encrypt, ReadonlyRequestCookies, RequestCookies } from "../cookies.js";
+import {
+  appRouteHandlerFactory,
+  pageRouteHandlerFactory
+} from "./with-api-auth-required.js";
+
+describe("with-api-auth-required", () => {
+  describe("app router", () => {
+    vi.mock("next/headers.js", async (importActual) => {
+      const actual = await importActual<typeof import("next/headers.js")>();
+
+      return {
+        ...actual,
+        cookies: vi.fn().mockImplementation(async () => {
+          return new RequestCookies(new Headers());
+        })
+      };
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should protect an API route", async () => {
+      const withApiAuthRequired = appRouteHandlerFactory(
+        new Auth0Client({
+          domain: constants.domain,
+          clientId: constants.clientId,
+          clientSecret: constants.clientSecret,
+          appBaseUrl: constants.appBaseUrl,
+          secret: constants.secret
+        })
+      );
+
+      const request = new NextRequest(
+        new URL("/custom-profile", constants.appBaseUrl),
+        {
+          method: "GET"
+        }
+      );
+      const handler = withApiAuthRequired(async () =>
+        NextResponse.json({ protected: true })
+      );
+      const response = await handler(request, {});
+      expect(response.status).toBe(401);
+    });
+
+    it("allow access to an API route with a valid session", async () => {
+      const auth0Client = new Auth0Client({
+        domain: constants.domain,
+        clientId: constants.clientId,
+        clientSecret: constants.clientSecret,
+        appBaseUrl: constants.appBaseUrl,
+        secret: constants.secret
+      });
+      const withApiAuthRequired = appRouteHandlerFactory(auth0Client);
+
+      vi.mocked(cookies).mockImplementation(async () => {
+        const session: SessionData = {
+          user: { sub: "user_123" },
+          tokenSet: {
+            idToken: "idt_123",
+            accessToken: "at_123",
+            refreshToken: "rt_123",
+            expiresAt: 123456
+          },
+          internal: {
+            sid: "auth0-sid",
+            createdAt: Math.floor(Date.now() / 1000)
+          }
+        };
+        const maxAge = 60 * 60; // 1 hour
+        const expiration = Math.floor(Date.now() / 1000 + maxAge);
+        const sessionCookie = await encrypt(
+          session,
+          constants.secret,
+          expiration
+        );
+        const headers = new Headers();
+        headers.append("cookie", `__session=${sessionCookie}`);
+
+        return new RequestCookies(headers) as unknown as ReadonlyRequestCookies;
+      });
+
+      const request = new NextRequest(
+        new URL("/custom-profile", constants.appBaseUrl),
+        {
+          method: "GET"
+        }
+      );
+      const handler = withApiAuthRequired(async () =>
+        NextResponse.json({ foo: "bar" })
+      );
+      const response = await handler(request, {});
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ foo: "bar" });
+    });
+
+    it("allow access to an API route that updates the cookies", async () => {
+      const auth0Client = new Auth0Client({
+        domain: constants.domain,
+        clientId: constants.clientId,
+        clientSecret: constants.clientSecret,
+        appBaseUrl: constants.appBaseUrl,
+        secret: constants.secret
+      });
+      const withApiAuthRequired = appRouteHandlerFactory(auth0Client);
+
+      vi.mocked(cookies).mockImplementation(async () => {
+        const session: SessionData = {
+          user: { sub: "user_123" },
+          tokenSet: {
+            idToken: "idt_123",
+            accessToken: "at_123",
+            refreshToken: "rt_123",
+            expiresAt: 123456
+          },
+          internal: {
+            sid: "auth0-sid",
+            createdAt: Math.floor(Date.now() / 1000)
+          }
+        };
+        const maxAge = 60 * 60; // 1 hour
+        const expiration = Math.floor(Date.now() / 1000 + maxAge);
+        const sessionCookie = await encrypt(
+          session,
+          constants.secret,
+          expiration
+        );
+        const headers = new Headers();
+        headers.append("cookie", `__session=${sessionCookie}`);
+
+        return new RequestCookies(headers) as unknown as ReadonlyRequestCookies;
+      });
+
+      const request = new NextRequest(
+        new URL("/custom-profile", constants.appBaseUrl),
+        {
+          method: "GET"
+        }
+      );
+      const handler = withApiAuthRequired(async () => {
+        const res = NextResponse.json({ foo: "bar" });
+        res.cookies.set("foo", "bar");
+        res.headers.set("baz", "bar");
+        return res;
+      });
+      const response = (await handler(request, {})) as NextResponse;
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ foo: "bar" });
+      expect(response.cookies.get("foo")?.value).toBe("bar");
+      expect(response.headers.get("baz")).toBe("bar");
+    });
+  });
+
+  describe("pages router", () => {
+    it("should protect an API route", async () => {
+      const withApiAuthRequired = pageRouteHandlerFactory(
+        new Auth0Client({
+          domain: constants.domain,
+          clientId: constants.clientId,
+          clientSecret: constants.clientSecret,
+          appBaseUrl: constants.appBaseUrl,
+          secret: constants.secret
+        })
+      );
+
+      const request = Object.assign(
+        new IncomingMessage(new Socket()),
+        {}
+      ) as NextApiRequest;
+      const response = new ServerResponse(
+        request
+      ) as unknown as NextApiResponse;
+      response.status = vi.fn().mockReturnValue(response);
+      response.json = vi.fn();
+      const handler = withApiAuthRequired(async () =>
+        NextResponse.json({ protected: true })
+      );
+      await handler(request, response);
+      expect(response.status).toHaveBeenCalledWith(401);
+    });
+
+    it("allow access to an API route with a valid session", async () => {
+      const withApiAuthRequired = pageRouteHandlerFactory(
+        new Auth0Client({
+          domain: constants.domain,
+          clientId: constants.clientId,
+          clientSecret: constants.clientSecret,
+          appBaseUrl: constants.appBaseUrl,
+          secret: constants.secret
+        })
+      );
+
+      const session: SessionData = {
+        user: { sub: "user_123" },
+        tokenSet: {
+          idToken: "idt_123",
+          accessToken: "at_123",
+          refreshToken: "rt_123",
+          expiresAt: 123456
+        },
+        internal: {
+          sid: "auth0-sid",
+          createdAt: Math.floor(Date.now() / 1000)
+        }
+      };
+      const maxAge = 60 * 60; // 1 hour
+      const expiration = Math.floor(Date.now() / 1000 + maxAge);
+      const sessionCookie = await encrypt(
+        session,
+        constants.secret,
+        expiration
+      );
+
+      const request = Object.assign(new IncomingMessage(new Socket()), {
+        cookies: {
+          __session: sessionCookie
+        },
+        headers: {
+          cookie: `__session=${sessionCookie}`
+        }
+      }) as unknown as NextApiRequest;
+      const response = new ServerResponse(
+        request
+      ) as unknown as NextApiResponse;
+      response.status = vi.fn().mockReturnValue(response);
+      response.json = vi.fn();
+
+      const handler = withApiAuthRequired(async (_, res) =>
+        res.status(200).json({ foo: "bar" })
+      );
+      await handler(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(200);
+      expect(response.json).toHaveBeenCalledWith({ foo: "bar" });
+    });
+  });
+});
+
+const constants = {
+  domain: "example.us.auth0.com",
+  clientId: "client_123",
+  clientSecret: "client-secret",
+  appBaseUrl: "https://example.com",
+  sub: "user_123",
+  secret: await generateSecret(32)
+};

--- a/src/server/helpers/with-api-auth-required.ts
+++ b/src/server/helpers/with-api-auth-required.ts
@@ -1,0 +1,123 @@
+import { NextApiHandler } from "next";
+import { NextRequest, NextResponse } from "next/server.js";
+
+import { Auth0Client } from "../client.js";
+
+/**
+ * This contains `param`s, which is a Promise that resolves to an object
+ * containing the dynamic route parameters for the current route.
+ *
+ * See https://nextjs.org/docs/app/api-reference/file-conventions/route#context-optional
+ */
+export type AppRouteHandlerFnContext = {
+  params?: Promise<Record<string, string | string[]>>;
+};
+
+/**
+ * Handler function for app directory api routes.
+ *
+ * See: https://nextjs.org/docs/app/api-reference/file-conventions/route
+ */
+export type AppRouteHandlerFn = (
+  /**
+   * Incoming request object.
+   */
+  req: NextRequest,
+  /**
+   * Context properties on the request (including the parameters if this was a
+   * dynamic route).
+   */
+  ctx: AppRouteHandlerFnContext
+) => Promise<Response> | Response;
+
+/**
+ * Wrap an app router API route to check that the user has a valid session. If they're not logged in the
+ * handler will return a 401 Unauthorized.
+ *
+ * ```js
+ * // app/protected-api/route.js
+ * import { auth0 } from "@/lib/auth0";
+ *
+ * export default auth0.withApiAuthRequired(function Protected(req) {
+ *   const session = auth0.getSession(req);
+ *   ...
+ * });
+ * ```
+ *
+ * If you visit `/protected-api` without a valid session cookie, you will get a 401 response.
+ */
+export type WithApiAuthRequiredAppRoute = (
+  apiRoute: AppRouteHandlerFn
+) => AppRouteHandlerFn;
+
+/**
+ * Wrap a page router API route to check that the user has a valid session. If they're not logged in the
+ * handler will return a 401 Unauthorized.
+ *
+ * ```js
+ * // pages/api/protected-route.js
+ * import { auth0 } from "@/lib/auth0";
+ *
+ * export default auth0.withApiAuthRequired(function ProtectedRoute(req, res) {
+ *   const session = auth0.getSession(req);
+ *   ...
+ * });
+ * ```
+ *
+ * If you visit `/api/protected-route` without a valid session cookie, you will get a 401 response.
+ */
+export type WithApiAuthRequiredPageRoute = (
+  apiRoute: NextApiHandler
+) => NextApiHandler;
+
+/**
+ * Protects API routes for Page router pages {@link WithApiAuthRequiredPageRoute} or
+ * App router pages {@link WithApiAuthRequiredAppRoute}
+ */
+export type WithApiAuthRequired = WithApiAuthRequiredAppRoute &
+  WithApiAuthRequiredPageRoute;
+
+export const appRouteHandlerFactory =
+  (client: Auth0Client): WithApiAuthRequiredAppRoute =>
+  (apiRoute) =>
+  async (req, params): Promise<NextResponse> => {
+    const session = await client.getSession();
+
+    if (!session || !session.user) {
+      return NextResponse.json(
+        {
+          error: "not_authenticated",
+          description:
+            "The user does not have an active session or is not authenticated"
+        },
+        { status: 401 }
+      );
+    }
+
+    const apiRes: NextResponse | Response = await apiRoute(req, params);
+    const nextApiRes: NextResponse =
+      apiRes instanceof NextResponse
+        ? apiRes
+        : new NextResponse(apiRes.body, apiRes);
+
+    return nextApiRes;
+  };
+
+export const pageRouteHandlerFactory =
+  (client: Auth0Client): WithApiAuthRequiredPageRoute =>
+  (apiRoute) =>
+  async (req, res) => {
+    const session = await client.getSession(req);
+
+    if (!session || !session.user) {
+      // If the user is not authenticated, return
+      res.status(401).json({
+        error: "not_authenticated",
+        description:
+          "The user does not have an active session or is not authenticated"
+      });
+      return;
+    }
+
+    await apiRoute(req, res);
+  };

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,0 +1,18 @@
+import type { IncomingMessage } from "http";
+import { NextApiRequest } from "next";
+import { NextRequest } from "next/server.js";
+
+type Req =
+  | IncomingMessage
+  | NextApiRequest
+  | NextRequest
+  | Request
+  | Record<string, any>;
+
+export const isRequest = (req: Req): boolean => {
+  return (
+    req instanceof Request ||
+    req.headers instanceof Headers ||
+    typeof (req as Request).bodyUsed === "boolean"
+  );
+};


### PR DESCRIPTION
### 📋 Changes

Adds support for `withApiAuthRequired` helper.

### 📎 References

Fixes: https://github.com/auth0/nextjs-auth0/issues/1790

### 🎯 Testing

Set up an API route as documented in `EXAMPLES.md` to observe the 401 when unauthenticated and the successful 200 response when a session exists.
