### PR TITLE
chore: enforce linter in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepack": "pnpm run build",
     "install:examples": "pnpm install --filter ./examples/with-next-intl --shamefully-hoist && pnpm install --filter ./examples/with-shadcn --shamefully-hoist",
     "docs": "typedoc",
-    "lint": "tsc --noEmit && eslint --fix ./src"
+    "lint": "tsc --noEmit && eslint ./src",
+    "lint:fix": "tsc --noEmit && eslint --fix ./src"
   },
   "repository": {
     "type": "git",

--- a/src/server/cookies.test.ts
+++ b/src/server/cookies.test.ts
@@ -18,7 +18,10 @@ describe("encrypt/decrypt", async () => {
     const maxAge = 60 * 60; // 1 hour in seconds
     const expiration = Math.floor(Date.now() / 1000 + maxAge);
     const encrypted = await encrypt(payload, secret, expiration);
-    const decrypted = await decrypt(encrypted, secret) as jose.JWTDecryptResult;
+    const decrypted = (await decrypt(
+      encrypted,
+      secret
+    )) as jose.JWTDecryptResult;
 
     expect(decrypted!.payload).toEqual(expect.objectContaining(payload));
   });

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -122,8 +122,10 @@ export class StatefulSessionStore extends AbstractSessionStore {
     let sessionId = null;
     const cookieValue = reqCookies.get(this.sessionCookieName)?.value;
     if (cookieValue) {
-      const sessionCookie =
-        await cookies.decrypt<SessionCookieValue>(cookieValue, this.secret);
+      const sessionCookie = await cookies.decrypt<SessionCookieValue>(
+        cookieValue,
+        this.secret
+      );
 
       if (sessionCookie) {
         sessionId = sessionCookie.payload.id;

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -67,9 +67,8 @@ export class StatelessSessionStore extends AbstractSessionStore {
 
     // As connection access tokens are stored in seperate cookies,
     // we need to get all cookies and only use those that are prefixed with `this.connectionTokenSetsCookieName`
-    const connectionTokenSetsCookies = this.getConnectionTokenSetsCookies(
-      reqCookies
-    );
+    const connectionTokenSetsCookies =
+      this.getConnectionTokenSetsCookies(reqCookies);
 
     const connectionTokenSets = [];
     for (const cookie of connectionTokenSetsCookies) {

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -1,5 +1,5 @@
-import * as oauth from "oauth4webapi";
 import * as jose from "jose";
+import * as oauth from "oauth4webapi";
 import { describe, expect, it } from "vitest";
 
 import { generateSecret } from "../test/utils.js";
@@ -106,9 +106,10 @@ describe("Transaction Store", async () => {
       const cookie = responseCookies.get(cookieName);
 
       expect(cookie).toBeDefined();
-      expect((await decrypt(cookie!.value, secret) as jose.JWTDecryptResult).payload).toEqual(
-        expect.objectContaining(transactionState)
-      );
+      expect(
+        ((await decrypt(cookie!.value, secret)) as jose.JWTDecryptResult)
+          .payload
+      ).toEqual(expect.objectContaining(transactionState));
       expect(cookie?.path).toEqual("/");
       expect(cookie?.httpOnly).toEqual(true);
       expect(cookie?.sameSite).toEqual("lax");
@@ -169,9 +170,10 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret) as jose.JWTDecryptResult).payload).toEqual(
-          expect.objectContaining(transactionState)
-        );
+        expect(
+          ((await decrypt(cookie!.value, secret)) as jose.JWTDecryptResult)
+            .payload
+        ).toEqual(expect.objectContaining(transactionState));
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");
@@ -207,9 +209,10 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret) as jose.JWTDecryptResult).payload).toEqual(
-          expect.objectContaining(transactionState)
-        );
+        expect(
+          ((await decrypt(cookie!.value, secret)) as jose.JWTDecryptResult)
+            .payload
+        ).toEqual(expect.objectContaining(transactionState));
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("strict");
@@ -245,9 +248,10 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret) as jose.JWTDecryptResult).payload).toEqual(
-          expect.objectContaining(transactionState)
-        );
+        expect(
+          ((await decrypt(cookie!.value, secret)) as jose.JWTDecryptResult)
+            .payload
+        ).toEqual(expect.objectContaining(transactionState));
         expect(cookie?.path).toEqual("/custom-path");
       });
 
@@ -279,9 +283,10 @@ describe("Transaction Store", async () => {
         const cookie = responseCookies.get(cookieName);
 
         expect(cookie).toBeDefined();
-        expect((await decrypt(cookie!.value, secret) as jose.JWTDecryptResult).payload).toEqual(expect.objectContaining(
-          transactionState
-        ));
+        expect(
+          ((await decrypt(cookie!.value, secret)) as jose.JWTDecryptResult)
+            .payload
+        ).toEqual(expect.objectContaining(transactionState));
         expect(cookie?.path).toEqual("/");
         expect(cookie?.httpOnly).toEqual(true);
         expect(cookie?.sameSite).toEqual("lax");


### PR DESCRIPTION
### 📋 Changes

Previously the linter would fail silently since it ran with the `--fix` flag in CI. This PR now ensures that the workflow will fail if the linter fails. It also fixes some inconsistencies that have been checked in.