### PR TITLE
bugfix: Fix `clientAssertionSigningKey` type mismatch

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -160,7 +160,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
     audience?: string;
     issuer?: string;
     alg?: string;
-    privateKey?: CryptoKey;
+    privateKey?: jose.CryptoKey;
   }): Promise<string> {
     return await new jose.SignJWT({
       events: {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -118,7 +118,7 @@ export interface AuthClientOptions {
   domain: string;
   clientId: string;
   clientSecret?: string;
-  clientAssertionSigningKey?: string | CryptoKey;
+  clientAssertionSigningKey?: string | jose.CryptoKey;
   clientAssertionSigningAlg?: string;
   authorizationParameters?: AuthorizationParameters;
   pushedAuthorizationRequests?: boolean;
@@ -156,7 +156,7 @@ export class AuthClient {
 
   private clientMetadata: oauth.Client;
   private clientSecret?: string;
-  private clientAssertionSigningKey?: string | CryptoKey;
+  private clientAssertionSigningKey?: string | jose.CryptoKey;
   private clientAssertionSigningAlg: string;
   private domain: string;
   private authorizationParameters: AuthorizationParameters;
@@ -1079,11 +1079,10 @@ export class AuthClient {
       );
     }
 
-    let clientPrivateKey = this.clientAssertionSigningKey as
-      | CryptoKey
-      | undefined;
+    let clientPrivateKey: jose.CryptoKey | undefined = this
+      .clientAssertionSigningKey as jose.CryptoKey | undefined;
 
-    if (clientPrivateKey && !(clientPrivateKey instanceof CryptoKey)) {
+    if (clientPrivateKey && typeof clientPrivateKey === "string") {
       clientPrivateKey = await jose.importPKCS8(
         clientPrivateKey,
         this.clientAssertionSigningAlg
@@ -1091,7 +1090,7 @@ export class AuthClient {
     }
 
     return clientPrivateKey
-      ? oauth.PrivateKeyJwt(clientPrivateKey)
+      ? oauth.PrivateKeyJwt(clientPrivateKey as CryptoKey)
       : oauth.ClientSecretPost(this.clientSecret!);
   }
 


### PR DESCRIPTION

This pull request resolves a TypeScript error by aligning the `clientAssertionSigningKey` type with the `jose` library. This ensures the key is correctly processed for client assertion signing.

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 🔍 RCA
The `clientAssertionSigningKey` property was typed as a generic `CryptoKey`, but it was being assigned a `jose.CryptoKey`. This created a type conflict because `jose.CryptoKey` is not directly assignable to the Web Crypto `CryptoKey` type.

### 📋 Changes
The changes align the type definitions and ensure the key is correctly cast when used.

- Changed `src/server/auth-client.test.ts`: Updated the test helper's `privateKey` parameter to use `jose.CryptoKey`.
- Changed `src/server/auth-client.ts`: Updated `clientAssertionSigningKey` to use `jose.CryptoKey` and cast it to `CryptoKey` when calling `oauth.PrivateKeyJwt`.

### 🎯 Testing
Automated:
The existing test suite covers the client assertion signing logic and continues to pass with these type corrections.