### PR TITLE
# bugfix: Logout fails to clear cookies when AUTH0_COOKIE_DOMAIN is set (#2237)

### DIFF
--- a/src/server/cookie-domain-deletion.test.ts
+++ b/src/server/cookie-domain-deletion.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { deleteCookie, deleteChunkedCookie } from "./cookies.js";
+import { ResponseCookies, RequestCookies } from "@edge-runtime/cookies";
+
+describe("Cookie deletion with domain", () => {
+  it("should delete cookies without domain by default", () => {
+    const headers = new Headers();
+    const resCookies = new ResponseCookies(headers);
+
+    deleteCookie(resCookies, "__session");
+
+    const setCookieHeaders = headers.getSetCookie();
+    const sessionCookieHeader = setCookieHeaders.find((header) =>
+      header.includes("__session=")
+    );
+
+    expect(sessionCookieHeader).toContain("Max-Age=0");
+    expect(sessionCookieHeader).not.toContain("Domain=");
+  });
+
+  it("should include domain when deleting cookies if domain option is provided", () => {
+    const headers = new Headers();
+    const resCookies = new ResponseCookies(headers);
+    const cookieDomain = "df.mydomain.com";
+
+    deleteCookie(resCookies, "__session", {
+      domain: cookieDomain,
+      path: "/"
+    });
+
+    const setCookieHeaders = headers.getSetCookie();
+    const sessionCookieHeader = setCookieHeaders.find((header) =>
+      header.includes("__session=")
+    );
+
+    expect(sessionCookieHeader).toContain(`Domain=${cookieDomain}`);
+    expect(sessionCookieHeader).toContain("Max-Age=0");
+  });
+
+  it("should delete chunked cookies with domain when provided", () => {
+    const headers = new Headers();
+    const reqCookies = new RequestCookies(headers);
+    const resCookies = new ResponseCookies(headers);
+
+    reqCookies.set("__session__0", "chunk0");
+    reqCookies.set("__session__1", "chunk1");
+
+    const cookieDomain = "df.mydomain.com";
+
+    deleteChunkedCookie("__session", reqCookies, resCookies, false, {
+      domain: cookieDomain,
+      path: "/"
+    });
+
+    const setCookieHeaders = headers.getSetCookie();
+
+    setCookieHeaders.forEach((header) => {
+      expect(header).toContain(`Domain=${cookieDomain}`);
+      expect(header).toContain("Max-Age=0");
+    });
+
+    expect(setCookieHeaders.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -353,6 +353,13 @@ export function addCacheControlHeadersForSession(res: NextResponse): void {
   res.headers.set("Expires", "0");
 }
 
+/**
+ * Deletes a cookie from the response with optional domain and path specifications.
+ *
+ * @param resCookies - The response cookies object to manipulate.
+ * @param name - The name of the cookie to delete.
+ * @param options - Optional domain and path settings for cookie deletion.
+ */
 export function deleteCookie(
   resCookies: ResponseCookies,
   name: string,
@@ -366,7 +373,9 @@ export function deleteCookie(
     deleteOptions.domain = options.domain;
   }
 
-
+  if (options?.path) {
+    deleteOptions.path = options.path;
+  }
 
   resCookies.set(name, "", deleteOptions);
 }

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -218,6 +218,7 @@ export function setChunkedCookie(
     reqCookies.set(name, value);
 
     // When we are writing a non-chunked cookie, we should remove the chunked cookies
+    // Remove any previously stored chunks for this cookie name
     getAllChunkedCookies(reqCookies, name).forEach((cookieChunk) => {
       deleteCookie(resCookies, cookieChunk.name);
       reqCookies.delete(cookieChunk.name);
@@ -244,7 +245,6 @@ export function setChunkedCookie(
   // clear unused chunks
   const chunks = getAllChunkedCookies(reqCookies, name);
   const chunksToRemove = chunks.length - chunkIndex;
-
   if (chunksToRemove > 0) {
     for (let i = 0; i < chunksToRemove; i++) {
       const chunkIndexToRemove = chunkIndex + i;
@@ -316,18 +316,21 @@ export function getChunkedCookie(
  * @param name - The name of the main cookie to delete.
  * @param reqCookies - The request cookies object containing all cookies from the request.
  * @param resCookies - The response cookies object to manipulate the cookies in the response.
+ * @param isLegacyCookie - Whether to handle legacy cookie format.
+ * @param options - Options for cookie deletion including domain and path.
  */
 export function deleteChunkedCookie(
   name: string,
   reqCookies: RequestCookies,
   resCookies: ResponseCookies,
-  isLegacyCookie?: boolean
+  isLegacyCookie?: boolean,
+  options?: Pick<CookieOptions, "domain" | "path">
 ): void {
   // Delete main cookie
-  deleteCookie(resCookies, name);
+  deleteCookie(resCookies, name, options);
 
   getAllChunkedCookies(reqCookies, name, isLegacyCookie).forEach((cookie) => {
-    deleteCookie(resCookies, cookie.name); // Delete each filtered cookie
+    deleteCookie(resCookies, cookie.name, options); // Delete each filtered cookie
   });
 }
 
@@ -350,8 +353,20 @@ export function addCacheControlHeadersForSession(res: NextResponse): void {
   res.headers.set("Expires", "0");
 }
 
-export function deleteCookie(resCookies: ResponseCookies, name: string) {
-  resCookies.set(name, "", {
+export function deleteCookie(
+  resCookies: ResponseCookies,
+  name: string,
+  options?: Pick<CookieOptions, "domain" | "path">
+) {
+  const deleteOptions: { maxAge: number; domain?: string; path?: string } = {
     maxAge: 0 // Ensure the cookie is deleted immediately
-  });
+  };
+
+  if (options?.domain) {
+    deleteOptions.domain = options.domain;
+  }
+
+
+
+  resCookies.set(name, "", deleteOptions);
 }

--- a/src/server/logout-cookie-domain-fix.test.ts
+++ b/src/server/logout-cookie-domain-fix.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { ResponseCookies } from "@edge-runtime/cookies";
+
+describe("Session cookie domain deletion bug", () => {
+  it("should delete session cookies with domain when AUTH0_COOKIE_DOMAIN is set", () => {
+    // Create session store with domain configured
+    const sessionStore = new StatelessSessionStore({
+      secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+      cookieOptions: {
+        domain: "df.mydomain.com", // This simulates AUTH0_COOKIE_DOMAIN 
+        path: "/",
+        secure: true,
+        sameSite: "lax"
+      }
+    });
+
+    // Mock request and response cookies
+    const headers = new Headers();
+    const reqCookies = new Headers();
+    const resCookies = new ResponseCookies(headers);
+    
+    // Add session cookie to request (simulate existing session)
+    reqCookies.set("__session", "existing-session-value");
+
+    // Mock request cookies to include the get method
+    const mockReqCookies = {
+      get: (name: string) => ({ value: reqCookies.get(name) }),
+      getAll: () => [],
+      set: (name: string, value: string) => reqCookies.set(name, value),
+      delete: (name: string) => reqCookies.delete(name),
+      has: (name: string) => reqCookies.has(name)
+    };
+
+    // Call delete method
+    sessionStore.delete(mockReqCookies as any, resCookies);
+
+    // Check that cookies are deleted with domain
+    const setCookieHeaders = headers.getSetCookie();
+    console.log("Session deletion Set-Cookie headers:", setCookieHeaders);
+
+    // Should have at least one cookie deletion header
+    expect(setCookieHeaders.length).toBeGreaterThan(0);
+
+    // Find the session cookie deletion header
+    const sessionDeletionHeader = setCookieHeaders.find((header) =>
+      header.includes("__session=") && header.includes("Max-Age=0")
+    );
+
+    expect(sessionDeletionHeader).toBeDefined();
+    
+    // This is the key assertion - cookie deletion should include domain
+    expect(sessionDeletionHeader).toContain("Domain=df.mydomain.com");
+    expect(sessionDeletionHeader).toContain("Max-Age=0");
+    expect(sessionDeletionHeader).toContain("Path=/");
+
+    console.log("✅ Session cookie is being deleted with proper domain:", sessionDeletionHeader);
+  });
+
+  it("should work without domain when AUTH0_COOKIE_DOMAIN is not set", () => {
+    // Create session store without domain (default behavior)
+    const sessionStore = new StatelessSessionStore({
+      secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+      cookieOptions: {
+        path: "/",
+        secure: true,
+        sameSite: "lax"
+        // no domain specified
+      }
+    });
+
+    const headers = new Headers();
+    const reqCookies = new Headers();  
+    const resCookies = new ResponseCookies(headers);
+    
+    reqCookies.set("__session", "existing-session-value");
+
+    const mockReqCookies = {
+      get: (name: string) => ({ value: reqCookies.get(name) }),
+      getAll: () => [],
+      set: (name: string, value: string) => reqCookies.set(name, value),
+      delete: (name: string) => reqCookies.delete(name),
+      has: (name: string) => reqCookies.has(name)
+    };
+
+    sessionStore.delete(mockReqCookies as any, resCookies);
+
+    const setCookieHeaders = headers.getSetCookie();
+    const sessionDeletionHeader = setCookieHeaders.find((header) =>
+      header.includes("__session=") && header.includes("Max-Age=0")
+    );
+
+    expect(sessionDeletionHeader).toBeDefined();
+    
+    // Should not include domain when none is configured
+    expect(sessionDeletionHeader).not.toContain("Domain=");
+    expect(sessionDeletionHeader).toContain("Max-Age=0");
+    expect(sessionDeletionHeader).toContain("Path=/");
+
+    console.log("✅ Session cookie deletion without domain:", sessionDeletionHeader);
+  });
+});

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -165,7 +165,10 @@ export class StatefulSessionStore extends AbstractSessionStore {
     resCookies: cookies.ResponseCookies
   ) {
     const cookieValue = reqCookies.get(this.sessionCookieName)?.value;
-    cookies.deleteCookie(resCookies, this.sessionCookieName);
+    cookies.deleteCookie(resCookies, this.sessionCookieName, {
+      domain: this.cookieConfig.domain,
+      path: this.cookieConfig.path
+    });
 
     if (!cookieValue) {
       return;

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -382,7 +382,8 @@ describe("Stateless Session Store", async () => {
           LEGACY_COOKIE_NAME,
           "",
           {
-            maxAge: 0
+            maxAge: 0,
+            path: "/"
           }
         );
       });
@@ -429,19 +430,19 @@ describe("Stateless Session Store", async () => {
           2,
           LEGACY_COOKIE_NAME,
           "",
-          { maxAge: 0 }
+          { maxAge: 0, path: "/" }
         );
         expect(responseCookies.set).toHaveBeenNthCalledWith(
           3,
           `${LEGACY_COOKIE_NAME}.0`,
           "",
-          { maxAge: 0 }
+          { maxAge: 0, path: "/" }
         );
         expect(responseCookies.set).toHaveBeenNthCalledWith(
           4,
           `${LEGACY_COOKIE_NAME}.1`,
           "",
-          { maxAge: 0 }
+          { maxAge: 0, path: "/" }
         );
       });
     });
@@ -721,7 +722,8 @@ describe("Stateless Session Store", async () => {
         legacyCookiesInSetup[0].name,
         "",
         {
-          maxAge: 0
+          maxAge: 0,
+          path: "/"
         }
       );
     });

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -129,7 +129,11 @@ export class StatelessSessionStore extends AbstractSessionStore {
       LEGACY_COOKIE_NAME,
       reqCookies,
       resCookies,
-      true
+      true,
+      {
+        domain: this.cookieConfig.domain,
+        path: this.cookieConfig.path
+      }
     );
   }
 
@@ -137,10 +141,21 @@ export class StatelessSessionStore extends AbstractSessionStore {
     reqCookies: cookies.RequestCookies,
     resCookies: cookies.ResponseCookies
   ) {
-    cookies.deleteChunkedCookie(this.sessionCookieName, reqCookies, resCookies);
+    const deleteOptions = {
+      domain: this.cookieConfig.domain,
+      path: this.cookieConfig.path
+    };
+
+    cookies.deleteChunkedCookie(
+      this.sessionCookieName,
+      reqCookies,
+      resCookies,
+      false,
+      deleteOptions
+    );
 
     this.getConnectionTokenSetsCookies(reqCookies).forEach((cookie) =>
-      cookies.deleteCookie(resCookies, cookie.name)
+      cookies.deleteCookie(resCookies, cookie.name, deleteOptions)
     );
   }
 

--- a/tests/logout-with-domain-config.test.ts
+++ b/tests/logout-with-domain-config.test.ts
@@ -1,0 +1,490 @@
+import { ResponseCookies } from "@edge-runtime/cookies";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { deleteChunkedCookie, deleteCookie } from "../src/server/cookies.js";
+import { StatelessSessionStore } from "../src/server/session/stateless-session-store.js";
+
+/**
+ * "Logout fails to clear cookies when AUTH0_COOKIE_DOMAIN is set"
+ *
+ * Tests the fix ensuring deleteCookie() properly handles both domain and path options
+ * to prevent cookies from persisting after logout when custom domains are configured.
+ */
+describe("logout-with-domain-config", () => {
+  let headers: Headers;
+  let resCookies: ResponseCookies;
+  let mockReqCookies: any;
+
+  beforeEach(() => {
+    headers = new Headers();
+    resCookies = new ResponseCookies(headers);
+
+    // Mock request cookies interface
+    const reqCookiesMap = new Map<string, string>();
+    mockReqCookies = {
+      get: (name: string) => {
+        const value = reqCookiesMap.get(name);
+        return value ? { value } : undefined;
+      },
+      getAll: () =>
+        Array.from(reqCookiesMap.entries()).map(([name, value]) => ({
+          name,
+          value
+        })),
+      set: (name: string, value: string) => reqCookiesMap.set(name, value),
+      delete: (name: string) => reqCookiesMap.delete(name),
+      has: (name: string) => reqCookiesMap.has(name)
+    };
+  });
+
+  afterEach(() => {
+    headers = new Headers();
+  });
+
+  describe("Happy Path: Successful cookie deletion", () => {
+    it("should delete session cookies with custom domain and path", () => {
+      // Arrange: Setup session store with custom domain (reproduces AUTH0_COOKIE_DOMAIN scenario)
+      const sessionStore = new StatelessSessionStore({
+        secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+        cookieOptions: {
+          domain: "example.com",
+          path: "/",
+          secure: true,
+          sameSite: "lax"
+        }
+      });
+
+      mockReqCookies.set("__session", "mock-session-token");
+
+      // Act: Delete session cookies
+      sessionStore.delete(mockReqCookies, resCookies);
+
+      // Assert: Cookie deletion headers include both domain and path
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBeGreaterThan(0);
+
+      const sessionDeletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("__session=") && header.includes("Max-Age=0")
+      );
+
+      expect(sessionDeletionHeader).toBeDefined();
+      expect(sessionDeletionHeader).toContain("Domain=example.com");
+      expect(sessionDeletionHeader).toContain("Path=/");
+      expect(sessionDeletionHeader).toContain("Max-Age=0");
+    });
+
+    it("should delete session cookies with path when domain not configured", () => {
+      // Arrange: Session store without custom domain but with path
+      const sessionStore = new StatelessSessionStore({
+        secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+        cookieOptions: {
+          path: "/",
+          secure: true,
+          sameSite: "lax"
+        }
+      });
+
+      mockReqCookies.set("__session", "mock-session-token");
+
+      // Act
+      sessionStore.delete(mockReqCookies, resCookies);
+
+      // Assert: Path is included even without domain
+      const setCookieHeaders = headers.getSetCookie();
+      const sessionDeletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("__session=") && header.includes("Max-Age=0")
+      );
+
+      expect(sessionDeletionHeader).toBeDefined();
+      expect(sessionDeletionHeader).not.toContain("Domain=");
+      expect(sessionDeletionHeader).toContain("Path=/");
+      expect(sessionDeletionHeader).toContain("Max-Age=0");
+    });
+
+    it("should delete chunked session cookies with domain and path", () => {
+      // Arrange: Setup large session that gets chunked
+      const sessionStore = new StatelessSessionStore({
+        secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+        cookieOptions: {
+          domain: "test.example.com",
+          path: "/app",
+          secure: true,
+          sameSite: "lax"
+        }
+      });
+
+      // Simulate chunked cookies (multiple session chunks using correct format)
+      mockReqCookies.set("__session__0", "chunk-0-data");
+      mockReqCookies.set("__session__1", "chunk-1-data");
+      mockReqCookies.set("__session__2", "chunk-2-data");
+
+      // Act
+      sessionStore.delete(mockReqCookies, resCookies);
+
+      // Assert: All chunks are deleted with proper domain/path
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBeGreaterThanOrEqual(3);
+
+      const chunkDeletionHeaders = setCookieHeaders.filter(
+        (header) =>
+          header.includes("__session__") && header.includes("Max-Age=0")
+      );
+
+      expect(chunkDeletionHeaders.length).toBeGreaterThanOrEqual(3);
+
+      chunkDeletionHeaders.forEach((header) => {
+        expect(header).toContain("Domain=test.example.com");
+        expect(header).toContain("Path=/app");
+        expect(header).toContain("Max-Age=0");
+      });
+    });
+  });
+
+  describe("Edge Cases: deleteCookie function behavior", () => {
+    it("should handle both domain and path deletion options", () => {
+      // Arrange & Act
+      deleteCookie(resCookies, "test-cookie", {
+        domain: "api.example.com",
+        path: "/v1/auth"
+      });
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("test-cookie=") && header.includes("Max-Age=0")
+      );
+
+      expect(deletionHeader).toBeDefined();
+      expect(deletionHeader).toContain("Domain=api.example.com");
+      expect(deletionHeader).toContain("Path=/v1/auth");
+      expect(deletionHeader).toContain("Max-Age=0");
+    });
+
+    it("should handle domain-only deletion options", () => {
+      // Arrange & Act
+      deleteCookie(resCookies, "test-cookie", {
+        domain: "sub.example.com",
+        path: "/"
+      });
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("test-cookie=") && header.includes("Max-Age=0")
+      );
+
+      expect(deletionHeader).toBeDefined();
+      expect(deletionHeader).toContain("Domain=sub.example.com");
+      expect(deletionHeader).toContain("Max-Age=0");
+    });
+
+    it("should handle path-only deletion options", () => {
+      // Arrange & Act
+      deleteCookie(resCookies, "test-cookie", { path: "/api" });
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("test-cookie=") && header.includes("Max-Age=0")
+      );
+
+      expect(deletionHeader).toBeDefined();
+      expect(deletionHeader).toContain("Path=/api");
+      expect(deletionHeader).not.toContain("Domain=");
+      expect(deletionHeader).toContain("Max-Age=0");
+    });
+
+    it("should handle deletion without any options", () => {
+      // Arrange & Act
+      deleteCookie(resCookies, "simple-cookie");
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("simple-cookie=") && header.includes("Max-Age=0")
+      );
+
+      expect(deletionHeader).toBeDefined();
+      expect(deletionHeader).not.toContain("Domain=");
+      // Note: Path=/ is always included by default in ResponseCookies
+      expect(deletionHeader).toContain("Path=/");
+      expect(deletionHeader).toContain("Max-Age=0");
+    });
+  });
+
+  describe("Boundary Conditions", () => {
+    it("should handle empty cookie name", () => {
+      // Arrange & Act
+      expect(() => {
+        deleteCookie(resCookies, "", { domain: "example.com", path: "/" });
+      }).not.toThrow();
+
+      // Assert: Still creates deletion header even with empty name
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBe(1);
+      expect(setCookieHeaders[0]).toContain("Max-Age=0");
+    });
+
+    it("should handle special characters in domain and path", () => {
+      // Arrange & Act
+      deleteCookie(resCookies, "special-cookie", {
+        domain: "sub-domain.example.com",
+        path: "/special/path-with-dashes"
+      });
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders[0];
+
+      expect(deletionHeader).toContain("Domain=sub-domain.example.com");
+      expect(deletionHeader).toContain("Path=/special/path-with-dashes");
+    });
+
+    it("should handle long domain and path values", () => {
+      // Arrange
+      const longDomain =
+        "very-long-subdomain-name.with-multiple-segments.example-domain.com";
+      const longPath =
+        "/very/long/path/with/multiple/segments/that/goes/deep/into/the/application";
+
+      // Act
+      deleteCookie(resCookies, "long-path-cookie", {
+        domain: longDomain,
+        path: longPath
+      });
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      const deletionHeader = setCookieHeaders[0];
+
+      expect(deletionHeader).toContain(`Domain=${longDomain}`);
+      expect(deletionHeader).toContain(`Path=${longPath}`);
+    });
+  });
+
+  describe("Chunked Cookie Deletion", () => {
+    it("should delete all chunks when deleting chunked cookies", () => {
+      // Arrange: Simulate multiple cookie chunks
+      const cookieName = "__session";
+      mockReqCookies.set(`${cookieName}__0`, "chunk-0");
+      mockReqCookies.set(`${cookieName}__1`, "chunk-1");
+      mockReqCookies.set(`${cookieName}__2`, "chunk-2");
+
+      const options = { domain: "chunks.example.com", path: "/chunks" };
+
+      // Act
+      deleteChunkedCookie(
+        cookieName,
+        mockReqCookies,
+        resCookies,
+        false,
+        options
+      );
+
+      // Assert: All chunks plus main cookie are deleted
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBeGreaterThanOrEqual(4); // 3 chunks + main cookie
+
+      // Check main cookie deletion
+      const mainDeletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes(`${cookieName}=`) && header.includes("Max-Age=0")
+      );
+      expect(mainDeletionHeader).toBeDefined();
+      expect(mainDeletionHeader).toContain("Domain=chunks.example.com");
+      expect(mainDeletionHeader).toContain("Path=/chunks");
+
+      // Check chunk deletions
+      for (let i = 0; i < 3; i++) {
+        const chunkDeletionHeader = setCookieHeaders.find(
+          (header) =>
+            header.includes(`${cookieName}__${i}=`) &&
+            header.includes("Max-Age=0")
+        );
+        expect(chunkDeletionHeader).toBeDefined();
+        expect(chunkDeletionHeader).toContain("Domain=chunks.example.com");
+        expect(chunkDeletionHeader).toContain("Path=/chunks");
+      }
+    });
+
+    it("should handle chunked deletion without domain/path options", () => {
+      // Arrange
+      const cookieName = "__session";
+      mockReqCookies.set(`${cookieName}__0`, "chunk-0");
+      mockReqCookies.set(`${cookieName}__1`, "chunk-1");
+
+      // Act
+      deleteChunkedCookie(cookieName, mockReqCookies, resCookies);
+
+      // Assert: Chunks are deleted without domain/path
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBeGreaterThanOrEqual(3); // 2 chunks + main cookie
+
+      setCookieHeaders.forEach((header) => {
+        expect(header).toContain("Max-Age=0");
+        expect(header).not.toContain("Domain=");
+        // Note: Path=/ is always included by default in ResponseCookies
+        expect(header).toContain("Path=/");
+      });
+    });
+  });
+
+  describe("Regression Tests: Issue #2237 scenarios", () => {
+    it("should reproduce and fix the original issue: logout with AUTH0_COOKIE_DOMAIN", () => {
+      // Arrange: Exact scenario from bug report
+      const sessionStore = new StatelessSessionStore({
+        secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+        cookieOptions: {
+          domain: "df.mydomain.com", // AUTH0_COOKIE_DOMAIN setting
+          path: "/",
+          secure: true,
+          sameSite: "lax"
+        }
+      });
+
+      // Simulate existing session cookie (set during login)
+      mockReqCookies.set(
+        "__session",
+        "active-session-token-that-should-be-deleted"
+      );
+
+      // Act: Logout (delete session)
+      sessionStore.delete(mockReqCookies, resCookies);
+
+      // Assert: Cookie is properly deleted with matching domain and path
+      const setCookieHeaders = headers.getSetCookie();
+      const sessionDeletionHeader = setCookieHeaders.find(
+        (header) =>
+          header.includes("__session=") && header.includes("Max-Age=0")
+      );
+
+      expect(sessionDeletionHeader).toBeDefined();
+
+      // This is the key fix: both Domain and Path must be present for successful deletion
+      expect(sessionDeletionHeader).toContain("Domain=df.mydomain.com");
+      expect(sessionDeletionHeader).toContain("Path=/");
+      expect(sessionDeletionHeader).toContain("Max-Age=0");
+
+      // Ensure cookie value is empty (standard deletion pattern)
+      expect(sessionDeletionHeader).toMatch(/__session=;|__session="";/);
+    });
+
+    it("should handle logout path mismatch scenario (the bug condition)", () => {
+      // Arrange: This test demonstrates that the bug was about explicit path handling
+      // Even though ResponseCookies includes Path=/ by default, the fix ensures that
+      // when AUTH0_COOKIE_DOMAIN is set, the SAME path and domain used during
+      // cookie creation are used during deletion.
+
+      // Test the fixed behavior: both domain and path explicitly passed
+      const headersFixed = new Headers();
+      const resCookiesFixed = new ResponseCookies(headersFixed);
+
+      deleteCookie(resCookiesFixed, "__session", {
+        domain: "df.mydomain.com",
+        path: "/"
+      });
+
+      const fixedCookieHeaders = headersFixed.getSetCookie();
+      const fixedHeader = fixedCookieHeaders[0];
+
+      // The fixed behavior: deletion header includes both Domain and Path explicitly
+      expect(fixedHeader).toContain("Domain=df.mydomain.com");
+      expect(fixedHeader).toContain("Path=/");
+      expect(fixedHeader).toContain("Max-Age=0");
+
+      // Now test without explicit path (simplified test)
+      const headersNoDomain = new Headers();
+      const resCookiesNoDomain = new ResponseCookies(headersNoDomain);
+
+      deleteCookie(resCookiesNoDomain, "__session", {
+        domain: "df.mydomain.com",
+        path: "/" // Both domain and path required by type system
+      });
+
+      const noDomainHeaders = headersNoDomain.getSetCookie();
+      const noDomainHeader = noDomainHeaders[0];
+
+      // Both should work but the fix ensures consistency with cookie creation
+      expect(noDomainHeader).toContain("Domain=df.mydomain.com");
+      expect(noDomainHeader).toContain("Path=/"); // Default path
+      expect(noDomainHeader).toContain("Max-Age=0");
+    });
+  });
+
+  describe("Error Scenarios", () => {
+    it("should handle null/undefined options gracefully", () => {
+      // Arrange & Act: Test with undefined options
+      expect(() => {
+        deleteCookie(resCookies, "test-cookie", undefined);
+      }).not.toThrow();
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBe(1);
+      expect(setCookieHeaders[0]).toContain("Max-Age=0");
+    });
+
+    it("should handle empty options object", () => {
+      // Arrange & Act - Use minimal valid options
+      expect(() => {
+        deleteCookie(resCookies, "test-cookie", { path: "/" });
+      }).not.toThrow();
+
+      // Assert
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBe(1);
+      expect(setCookieHeaders[0]).toContain("Max-Age=0");
+    });
+  });
+
+  describe("Integration: Full logout flow", () => {
+    it("should successfully complete full logout with custom domain", () => {
+      // Arrange: Setup realistic session scenario
+      const sessionStore = new StatelessSessionStore({
+        secret: "a-very-long-secret-that-is-at-least-32-characters-long",
+        cookieOptions: {
+          domain: "app.company.com",
+          path: "/",
+          secure: true,
+          sameSite: "strict"
+        }
+      });
+
+      // Simulate multiple session-related cookies
+      mockReqCookies.set("__session", "main-session-jwt-token");
+
+      // Act: Perform logout
+      sessionStore.delete(mockReqCookies, resCookies);
+
+      // Assert: All session cookies are deleted with proper attributes
+      const setCookieHeaders = headers.getSetCookie();
+      expect(setCookieHeaders.length).toBeGreaterThan(0);
+
+      // Verify session cookie deletion
+      const sessionDeletion = setCookieHeaders.find(
+        (header) =>
+          header.includes("__session=") && header.includes("Max-Age=0")
+      );
+      expect(sessionDeletion).toBeDefined();
+      expect(sessionDeletion).toContain("Domain=app.company.com");
+      expect(sessionDeletion).toContain("Path=/");
+
+      // Verify all deletion headers have consistent domain/path
+      const deletionHeaders = setCookieHeaders.filter((header) =>
+        header.includes("Max-Age=0")
+      );
+
+      deletionHeaders.forEach((header) => {
+        expect(header).toContain("Domain=app.company.com");
+        expect(header).toContain("Path=/");
+        expect(header).toContain("Max-Age=0");
+      });
+    });
+  });
+});


### PR DESCRIPTION

Fixed logout functionality when using `AUTH0_COOKIE_DOMAIN` by ensuring cookie deletion includes the correct `path` parameter. This resolves immediate re-authentication after logout when custom cookie domains are configured.

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 🔍 RCA

The `deleteCookie()` function in `src/server/cookies.ts` was ignoring the optional `path` parameter passed through `options`. During logout, session cookies are written with an explicit `path` (defaults to `/`), but deletion attempts only included `domain` without `path`, causing browsers to treat the missing path as the current request path (e.g., `/auth/logout`) which doesn't match the original cookie's `Path=/`.

### 📋 Changes

This fix ensures proper cookie cleanup when `AUTH0_COOKIE_DOMAIN` is configured, preventing users from being immediately re-authenticated after logout.

Changed `src/server/cookies.ts`: Added `path` parameter handling to `deleteCookie()` function
Added `src/server/logout-cookie-domain-fix.test.ts`: Comprehensive test for session cookie deletion with domain configuration  
Added `src/server/cookie-domain-deletion.test.ts`: Unit tests for `deleteCookie()` and `deleteChunkedCookie()` functions
Changed `src/server/session/stateless-session-store.test.ts`: Updated existing tests to expect correct `path` parameter in cookie deletion

### 📎 References

Fixes: #2237

### 🎯 Testing

**Automated:**
- Added integration test `logout-cookie-domain-fix.test.ts` that verifies session deletion includes both `Domain` and `Path` attributes
- Added unit tests in `cookie-domain-deletion.test.ts` for `deleteCookie()` and `deleteChunkedCookie()` functions  
- Updated existing tests to expect the corrected behavior with `path` parameter

**Manual:**
1. Configure `AUTH0_COOKIE_DOMAIN=".example.com"` in sample app
2. Log in and verify session cookie is set with `Domain=.example.com; Path=/`
3. Navigate to `/auth/logout`
4. Verify cookie deletion header includes both `Domain=.example.com` and `Path=/`
5. Confirm user is not immediately re-authenticated after logout