### PR TITLE
feat: add support for access token subject type to Token Vault

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -128,9 +128,19 @@ export enum AccessTokenForConnectionErrorCode {
   MISSING_REFRESH_TOKEN = "missing_refresh_token",
 
   /**
+   * The access token is missing.
+   */
+  MISSING_ACCESS_TOKEN = "missing_access_token",
+
+  /**
    * Failed to exchange the refresh token.
    */
-  FAILED_TO_EXCHANGE = "failed_to_exchange_refresh_token"
+  FAILED_TO_EXCHANGE = "failed_to_exchange_refresh_token",
+
+  /**
+   * Failed to exchange the refresh token.
+   */
+  FAILED_TO_EXCHANGE_ACCESS_TOKEN = "failed_to_exchange_access_token"
 }
 
 /**

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,0 +1,37 @@
+export enum SUBJECT_TOKEN_TYPES {
+  /**
+   * Constant representing the subject type for a refresh token.
+   * This is used in OAuth 2.0 token exchange to specify that the token being exchanged is a refresh token.
+   *
+   * @see {@link https://tools.ietf.org/html/rfc8693#section-3.1 RFC 8693 Section 3.1}
+   */
+  SUBJECT_TYPE_REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token",
+
+  /**
+   * Constant representing the subject type for a access token.
+   * This is used in OAuth 2.0 token exchange to specify that the token being exchanged is an access token.
+   *
+   * @see {@link https://tools.ietf.org/html/rfc8693#section-3.1 RFC 8693 Section 3.1}
+   */
+  SUBJECT_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+}
+
+/**
+ * A constant representing the grant type for federated connection access token exchange.
+ *
+ * This grant type is used in OAuth token exchange scenarios where a federated connection
+ * access token is required. It is specific to Auth0's implementation and follows the
+ * "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token" format.
+ */
+export const GRANT_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+  "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
+
+/**
+ * A constant representing the token type for federated connection access tokens.
+ * This is used to specify the type of token being requested from Auth0.
+ *
+ * @constant
+ * @type {string}
+ */
+export const REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
+  "http://auth0.com/oauth/token-type/federated-connection-access-token";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,3 +19,5 @@ export {
   WithPageAuthRequiredPageRouter,
   WithPageAuthRequiredAppRouter
 } from "./helpers/with-page-auth-required.js";
+
+export { SUBJECT_TOKEN_TYPES } from "./constants.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { SUBJECT_TOKEN_TYPES } from "../server/constants.js";
+
 export interface TokenSet {
   accessToken: string;
   idToken?: string;
@@ -146,6 +148,11 @@ export interface AccessTokenForConnectionOptions {
    * An optional login hint to pass to the authorization server.
    */
   login_hint?: string;
+
+  /**
+   * An optional subject token type parameter to pass to the authorization server.
+   */
+  subject_token_type?: SUBJECT_TOKEN_TYPES;
 }
 
 /**


### PR DESCRIPTION
### 📋 Changes

This PR adds support for the access token subject type to be exchanged for a connection token.

A new optional, parameter `subject_token_type` is added to the `AccessTokenForConnectionOptions` interface that defaults to the refresh token subject token type if not specified (today's default). This ensures backwards compatibility and an explicit opt-in to use the access token as the subject token type.

Additionally, an enum (`SUBJECT_TOKEN_TYPES`) containing 2 constants have been exported `SUBJECT_TYPE_REFRESH_TOKEN` and `SUBJECT_TYPE_ACCESS_TOKEN` as a convenience for the developer.

```ts
const token = await auth0.getAccessTokenForConnection({
  connection: "google-oauth2",
  subject_token_type: SUBJECT_TOKEN_TYPES.SUBJECT_TYPE_ACCESS_TOKEN
});
```
