### PR TITLE
fix: ensure to mark StartInteractiveLoginOptions as optional

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -730,7 +730,7 @@ export class Auth0Client {
   }
 
   async startInteractiveLogin(
-    options: StartInteractiveLoginOptions
+    options: StartInteractiveLoginOptions = {}
   ): Promise<NextResponse> {
     return this.authClient.startInteractiveLogin(options);
   }


### PR DESCRIPTION
### 📋 Changes

As `StartInteractiveLoginOptions` are actually optional, we should also mark them as such in the external API.

### 📎 References

https://github.com/auth0/nextjs-auth0/pull/2249

