### PR TITLE
feat: Add documentation for proactive token refresh and session-only auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Auth0 Next.js SDK is a library for implementing user authentication in Next.
 
 ## Documentation
 
-- [QuickStart](https://auth0.com/docs/quickstart/webapp/nextjs)- our guide for adding Auth0 to your Next.js app.
+- [QuickStart](https://auth0.com/docs/quickstart/webapp/nextjs) - our guide for adding Auth0 to your Next.js app.
 - [Examples](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md) - lots of examples for your different use cases.
 - [Security](https://github.com/auth0/nextjs-auth0/blob/main/SECURITY.md) - Some important security notices that you should check.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.


### PR DESCRIPTION

This PR enhances the examples to include patterns for proactive token refresh and session-only authentication. It also clarifies important considerations for refresh token rotation.

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

These changes provide developers with more advanced and robust patterns for handling tokens and sessions. The proactive refresh example helps prevent API call failures due to expired tokens in latency-sensitive applications.

- Changed `EXAMPLES.md`: Added a note on `getSession` usage, a warning about refresh token rotation, and a new example for proactive token refresh. Corrected the import path for `withPageAuthRequired`.
- Changed `README.md`: Fixed minor list formatting.

### 🎯 Testing

Manual:
1. Review the new documentation in `EXAMPLES.md`.
2. Check the new sections on `getSession`, refresh token rotation, and proactive token refresh for clarity and accuracy.
3. Verify the code examples are correct and easy to understand.