### PR TITLE
fix: parameter name of requested_expiry

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -907,10 +907,10 @@ export class AuthClient {
       })
     );
 
-    if (options.requestExpiry) {
+    if (options.requestedExpiry) {
       authorizationParams.append(
-        "request_expiry",
-        options.requestExpiry.toString()
+        "requested_expiry",
+        options.requestedExpiry.toString()
       );
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,7 +171,7 @@ export interface BackchannelAuthenticationOptions {
   /**
    * Set a custom expiry time for the CIBA flow in seconds. Defaults to 300 seconds (5 minutes) if not set.
    */
-  requestExpiry?: number;
+  requestedExpiry?: number;
   /**
    * Optional authorization details to use Rich Authorization Requests (RAR).
    * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests


### PR DESCRIPTION
### 📋 Changes

The correct parameter name is `requested_expiry` and not `request_expiry`. This was a typo in the docs that needs to be resolved.

This is a non-breaking change as a release has not yet been cut.

### 📎 References

<img width="884" height="482" alt="sh" src="https://github.com/user-attachments/assets/5cb7ebae-e447-49b0-82b5-310a2d1307a5" />

https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba#step-1-client-application-initiates-a-ciba-request

