### PR TITLE
# Fix: getSession() returns null for expired sessions (#2312)

### DIFF
--- a/src/server/helpers/with-api-auth-required.test.ts
+++ b/src/server/helpers/with-api-auth-required.test.ts
@@ -72,7 +72,7 @@ describe("with-api-auth-required", () => {
             idToken: "idt_123",
             accessToken: "at_123",
             refreshToken: "rt_123",
-            expiresAt: 123456
+            expiresAt: Math.floor(Date.now() / 1000) + 3600 // Valid for 1 hour
           },
           internal: {
             sid: "auth0-sid",
@@ -123,7 +123,7 @@ describe("with-api-auth-required", () => {
             idToken: "idt_123",
             accessToken: "at_123",
             refreshToken: "rt_123",
-            expiresAt: 123456
+            expiresAt: Math.floor(Date.now() / 1000) + 3600 // Valid for 1 hour
           },
           internal: {
             sid: "auth0-sid",
@@ -208,7 +208,7 @@ describe("with-api-auth-required", () => {
           idToken: "idt_123",
           accessToken: "at_123",
           refreshToken: "rt_123",
-          expiresAt: 123456
+          expiresAt: Math.floor(Date.now() / 1000) + 3600 // Valid for 1 hour
         },
         internal: {
           sid: "auth0-sid",


### PR DESCRIPTION
## Summary
Fixes an issue where `getSession()` method returned expired session data instead of `null`, allowing applications to operate with invalid authentication state.

Fixes: #2312 


## Changes Made

Added token expiration validation to `getSession()` method following the exact pattern used in `getTokenSet()`:

```typescript
if (session && session.tokenSet.expiresAt <= Date.now() / 1000) {
  return null;
}
```


### Core Fix
- CHANGED `client.ts`: Added expiration validation before returning session data

### Test Updates  
- UPDATED `with-api-auth-required.test.ts`: Updated hardcoded expired timestamps to valid future timestamps
- UPDATED `client.test.ts`: Added test cases for this fix. 

### Testing
UTs are PASS.