### PR TITLE
Add support for access tokens with difference audiences (MRRT)

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface TokenSet {
   scope?: string;
   refreshToken?: string;
   expiresAt: number; // the time at which the access token expires in seconds since epoch
+  audience?: string;
 }
 
 export interface ConnectionTokenSet {
@@ -14,9 +15,17 @@ export interface ConnectionTokenSet {
   [key: string]: unknown;
 }
 
+export interface AccessTokenSet {
+  accessToken: string;
+  scope?: string;
+  audience: string;
+  expiresAt: number; // the time at which the access token expires in seconds since epoch
+}
+
 export interface SessionData {
   user: User;
   tokenSet: TokenSet;
+  accessTokens?: AccessTokenSet[];
   internal: {
     // the session ID from the authorization server
     sid: string;

--- a/src/utils/token-set-helpers.test.ts
+++ b/src/utils/token-set-helpers.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import { AccessTokenSet, SessionData } from "../types/index.js";
+import {
+  accessTokenSetFromTokenSet,
+  compareScopes,
+  findAccessTokenSet
+} from "./token-set-helpers.js";
+
+function createSessionData(
+  sessionData: Partial<SessionData> = {}
+): SessionData {
+  return {
+    user: { sub: "user123", name: "Test User" },
+    internal: { sid: "session123", createdAt: Date.now() },
+    tokenSet: {
+      accessToken: "<my_access_token>",
+      expiresAt: Date.now() / 1000 + 3600
+    },
+    ...sessionData
+  };
+}
+
+describe("token-set-helpers", () => {
+  describe("accessTokenSetFromTokenSet", () => {
+    it("should create an AccessTokenSet from a TokenSet", () => {
+      const session = createSessionData();
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(accessTokenSetFromTokenSet(session.tokenSet, options)).toEqual({
+        accessToken: session.tokenSet.accessToken,
+        expiresAt: session.tokenSet.expiresAt,
+        audience: options.audience,
+        scope: options.scope
+      });
+    });
+  });
+
+  describe("findAccessTokenSet", () => {
+    it("should find the AccessTokenSet when it is the only entry", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+      const session = createSessionData({
+        accessTokens: [accessTokenSet]
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBe(accessTokenSet);
+    });
+
+    it("should find the AccessTokenSet when it is not the only entry", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      const accessTokenSet2: AccessTokenSet = {
+        accessToken: "<my_custom_access_token_2>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "c d",
+        audience: "<my_audience>"
+      };
+
+      const session = createSessionData({
+        accessTokens: [accessTokenSet2, accessTokenSet]
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBe(accessTokenSet);
+    });
+
+    it("should find the AccessTokenSet when the scope match partial", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      const accessTokenSet2: AccessTokenSet = {
+        accessToken: "<my_custom_access_token_2>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "c d",
+        audience: "<my_audience>"
+      };
+
+      const session = createSessionData({
+        accessTokens: [accessTokenSet2, accessTokenSet]
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBe(accessTokenSet);
+    });
+
+    it("should find the AccessTokenSet when the scope match exact", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      const accessTokenSet2: AccessTokenSet = {
+        accessToken: "<my_custom_access_token_2>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "c d",
+        audience: "<my_audience>"
+      };
+
+      const session = createSessionData({
+        accessTokens: [accessTokenSet2, accessTokenSet]
+      });
+      const options = {
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBe(accessTokenSet);
+    });
+
+    it("should find the AccessTokenSet with the best match", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      const accessTokenSet2: AccessTokenSet = {
+        accessToken: "<my_custom_access_token_2>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      const accessTokenSet3: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b c",
+        audience: "<my_audience>"
+      };
+
+      const session = createSessionData({
+        accessTokens: [accessTokenSet, accessTokenSet3, accessTokenSet2]
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBe(accessTokenSet2);
+    });
+
+    it("should not find the AccessTokenSet when accessTokens is undefined", () => {
+      const session = createSessionData({
+        accessTokens: undefined
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBeUndefined();
+    });
+
+    it("should not find the AccessTokenSet when accessTokens is empty array", () => {
+      const session = createSessionData({
+        accessTokens: []
+      });
+      const options = {
+        scope: "a",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBeUndefined();
+    });
+
+    it("should not find the AccessTokenSet when no match", () => {
+      const accessTokenSet: AccessTokenSet = {
+        accessToken: "<my_custom_access_token>",
+        expiresAt: Date.now() / 1000 + 3600,
+        scope: "a b",
+        audience: "<my_audience>"
+      };
+
+      const session = createSessionData({
+        accessTokens: [accessTokenSet]
+      });
+      const options = {
+        scope: "c",
+        audience: "<my_audience>"
+      };
+
+      expect(findAccessTokenSet(session, options)).toBeUndefined();
+    });
+  });
+
+  describe("compareScopes", () => {
+    it("should match scopes when more scopes are available", () => {
+      const scopes = "a b";
+      const requiredScopes = "a";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes", () => {
+      const scopes = "a b";
+      const requiredScopes = "a b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when leading whitespaces in scopes", () => {
+      const scopes = "   a b";
+      const requiredScopes = "a b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when trailing whitespaces in scopes", () => {
+      const scopes = "a b   ";
+      const requiredScopes = "a b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when additional whitespaces in scopes", () => {
+      const scopes = "a    b";
+      const requiredScopes = "a b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when leading whitespaces in requiredScopes", () => {
+      const scopes = "a b";
+      const requiredScopes = "   a b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when trailing whitespaces in requiredScopes", () => {
+      const scopes = "a b";
+      const requiredScopes = "a b  ";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes when additional whitespaces in requiredScopes", () => {
+      const scopes = "a b";
+      const requiredScopes = "a    b";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match exact scopes in reverse order", () => {
+      const scopes = "a b";
+      const requiredScopes = "b a";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should match when both empty", () => {
+      const scopes = "";
+      const requiredScopes = "";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(true);
+    });
+
+    it("should not match when scopes empty", () => {
+      const scopes = "";
+      const requiredScopes = "a b c d";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(false);
+    });
+
+    it("should not match when requiredScopes empty", () => {
+      const scopes = "a b";
+      const requiredScopes = "";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(false);
+    });
+
+    it("should not match when no scope included", () => {
+      const scopes = "a b";
+      const requiredScopes = "c d";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(false);
+    });
+
+    it("should not match when some scopes not included", () => {
+      const scopes = "a b";
+      const requiredScopes = "a b c d";
+
+      expect(compareScopes(scopes, requiredScopes)).toBe(false);
+    });
+
+    it("should not match when scopes is undefined and requiredScopes empty string", () => {
+      expect(compareScopes(undefined, "")).toBe(false);
+    });
+  });
+});

--- a/src/utils/token-set-helpers.ts
+++ b/src/utils/token-set-helpers.ts
@@ -1,0 +1,116 @@
+import { AccessTokenSet, SessionData, TokenSet } from "../types/index.js";
+
+/**
+ * Converts a TokenSet to an AccessTokenSet, including optional audience and scope.
+ * @param tokenSet the TokenSet to convert
+ * @param options object containing optional audience and scope
+ * @returns AccessTokenSet
+ */
+export function accessTokenSetFromTokenSet(
+  tokenSet: TokenSet,
+  options: { audience: string; scope?: string }
+): AccessTokenSet {
+  return {
+    accessToken: tokenSet.accessToken,
+    expiresAt: tokenSet.expiresAt,
+    audience: options.audience,
+    scope: options.scope,
+  };
+}
+
+/**
+ * Parses a scope string into an array of individual scopes, filtering out empty strings.
+ * @param scopes Space-separated scope string
+ * @returns Array of scope strings
+ */
+function parseScopesToArray(scopes: string | undefined): string[] {
+  if (!scopes) return [];
+  return scopes.trim().split(' ').filter(Boolean);
+}
+
+/**
+ * Compares two sets of scopes to determine if all required scopes are present in the provided scopes.
+ * @param scopes Scopes to compare (space-separated string)
+ * @param requiredScopes Scopes required to be present in the scopes (space-separated string)
+ * @returns True if all required scopes are present in the scopes, false otherwise
+ */
+export const compareScopes = (
+  scopes: string | undefined,
+  requiredScopes: string | undefined
+): boolean => {
+  // When the scopes and requiredScopes are exactly the same, return true
+  // This handles cases where both are empty or undefined or both are the same string
+  if (scopes === requiredScopes) {
+    return true;
+  }
+
+  if (!scopes || !requiredScopes) {
+    return false;
+  }
+
+  const scopesSet = new Set(parseScopesToArray(scopes));
+  const requiredScopesArray = parseScopesToArray(requiredScopes);
+  
+  return requiredScopesArray.every((scope) => scopesSet.has(scope));
+};
+
+/**
+ * Finds the best matching AccessTokenSet in the session by audience and scope.
+ *
+ * The function determines a "match" if an AccessTokenSet's scope property contains all the items
+ * from the `options.scope`. From the potential matches, it selects the best one
+ * based on the following criteria, in order of priority:
+ *
+ * 1. An "exact match" is preferred above all. This is where the AccessTokenSet's scope
+ *    has the exact same items as the `options.scope` (length and content are identical,
+ *    order does not matter).
+ * 2. If no exact match is found, the "best partial match" is chosen. This is the
+ *    matching AccessTokenSet whose scope has the fewest additional items.
+ *
+ * @param sessionData The session data containing accessTokens array.
+ * @param options Object containing the scope and audience to match against.
+ * @returns The best matching AccessTokenSet, or undefined if no match is found.
+ */
+export function findAccessTokenSet(
+  sessionData: SessionData | undefined,
+  options: {
+    scope?: string;
+    audience: string;
+  }
+): AccessTokenSet | undefined {
+  const accessTokenSets = sessionData?.accessTokens;
+
+  // 1. When there are no access tokens, we can exit early.
+  if (!accessTokenSets || accessTokenSets.length === 0) {
+    return;
+  }
+
+  // 2. Filter the list to find all AccessTokenSet's that are valid matches.
+  // A valid match's audience must match the provided `options.audience`, 
+  // and its scope must contain all items from `options.scope`.
+  const allMatches = accessTokenSets.filter((accessTokenSet) => {
+    return (
+      accessTokenSet.audience === options.audience &&
+      compareScopes(accessTokenSet.scope, options.scope)
+    );
+  });
+
+  // If no potential matches were found, we can exit early.
+  if (allMatches.length === 0) {
+    return;
+  }
+
+  // 3. Sort the valid matches to find the best one.
+  // The best match is the one with the smallest scope array, as it has the fewest
+  // extra permissions. An exact match will naturally be sorted first.
+  // This also works for null/undefined scopes, as they would have been matched
+  // against a null/undefined `options.scope` and will all be equally valid.
+  allMatches.sort((a, b) => {
+    const aScopeCount = parseScopesToArray(a.scope).length;
+    const bScopeCount = parseScopesToArray(b.scope).length;
+    return aScopeCount - bScopeCount;
+  });
+
+  // The first item in the sorted list is the best possible match.
+  return allMatches[0];
+}


### PR DESCRIPTION
- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR adds support to pass `audience` and `scope` to the `getAccessToken` method.

There are still some things to complete before being ready for review:

- [ ] Add support for Audience and Scope in `/auth/access-token`

### 📎 References

N/A

### 🎯 Testing

These changes require [MRRT](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token) to be configured accordingly, so that the RefreshToken can be re-used to request tokens from different audiences.
