### PR TITLE
[DO NOT MERGE] Reproduce infinite stacking cookies

### DIFF
--- a/examples/with-shadcn/app/page.tsx
+++ b/examples/with-shadcn/app/page.tsx
@@ -13,6 +13,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar"
+import Link from "next/link"
 
 export default function Page() {
   return (
@@ -40,7 +41,11 @@ export default function Page() {
         </header>
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
           <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div className="aspect-video rounded-xl bg-muted/50" />
+            <div className="aspect-video rounded-xl bg-muted/50">
+              <Link href="/test">Go to Test</Link>
+              <Link href="/test2">Go to Test2</Link>
+              <Link href="/test3">Go to Test3</Link>
+            </div>
             <div className="aspect-video rounded-xl bg-muted/50" />
             <div className="aspect-video rounded-xl bg-muted/50" />
           </div>

--- a/examples/with-shadcn/app/test/page.tsx
+++ b/examples/with-shadcn/app/test/page.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">Protected Page 1</div>
+  );
+}

--- a/examples/with-shadcn/app/test2/page.tsx
+++ b/examples/with-shadcn/app/test2/page.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">Protected Page 2</div>
+  );
+}

--- a/examples/with-shadcn/app/test3/page.tsx
+++ b/examples/with-shadcn/app/test3/page.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">Protected Page 3</div>
+  );
+}

--- a/examples/with-shadcn/middleware.ts
+++ b/examples/with-shadcn/middleware.ts
@@ -1,8 +1,19 @@
-import type { NextRequest } from "next/server"
+import { NextResponse, type NextRequest } from "next/server";
 
-import { auth0 } from "./lib/auth0"
+import { auth0 } from "./lib/auth0";
 
 export async function middleware(request: NextRequest) {
+  // Protecting all routes that start with /test
+  if (request.nextUrl.pathname.startsWith("/test")) {
+    const session = await auth0.getSession(request);
+
+    if (!session) {
+      // user is not authenticated, redirect to login page
+      return NextResponse.redirect(
+        new URL("/auth/login", request.nextUrl.origin)
+      );
+    }
+  }
   return await auth0.middleware(request);
 }
 


### PR DESCRIPTION
This PR demonstrates how to reproduce #1917.

To run this, **it is important to run in production mode:**

- `cd examples/with-shadcn`
- `pnpm install`
- `pnpm run build`
- `pnpm run start`

Additionally, ensure to configure the `.env` file.

What is this reproduction doing?

- It has 3 routes: test1, test2 and test3
- All 3 routes are protected using the middleware.
- If you don't have a session, the middleware will redirect to auth/login
- redirecting to /auth/login will set a transaction cookie

This is a very basic setup, nothing weird going on here at first sight.

However ... As we are using a Link component on the homepage for these 3 routes, the following happens:

- When the page loads, Nextjs executes 3 prefetch requests. 1 for each `Link` in the viewport.
- This results in 3 times hitting the middleware
- This results in 3 redirects to auth/login (we don't see that in the browser, it happens under the hood)
- This results in 3 transaction cookies that will never be used.

Now refresh the page, and u have 3 more. So 6.
Now refresh the page, and u have 3 more. So 9.
...

So any page-load when not being logged in, or when the middleware tries to initiate a redirect to auth/login in your own code, will end up with `n` cookies, where `n` is the amount if `Link` components in the viewport that refer to a protected route.

Once you click any of the actual buttons, it will call the middleware again (as it returned a non-200 code, it will hit the middleware again), set a cookie and go to auth0 and come back. Never using, or deleting the cookies that come from the page-load.

It seems to be very unreliable in next.js to skip the middleware on prefetch here. Currently, the solution seems to be to either:

 - Set `prefetch` to false on the `Link`. This way, prefetch does not happen anymore on page-load in production mode. On click, we still have an additional cookie, but it should not stack infinitely anymore.
 - use `<a>` instead of `<Link>`
 - or; set `enableParallelTransactions` to false, which has the consequence that logging in in different tabs simultaneously will result in `Invalid State`.
   - Open Tab 1, click Login (but don't complete logging in to Auth0)
   - Open Tab 2, click Login (but don't complete logging in to Auth0)
   - Go back to Tab 1, and complete login. You will see Invalid State on `/auth/callback`

Additionally, I find many references to detecting prefetching in the middleware is very unreliable, and I have not been able to get that working at all.

- https://github.com/vercel/next.js/issues/63728
- https://github.com/vercel/next.js/discussions/37736

Even though some have a solution, it does not seem to work for me when using Next.js 15.