### PR TITLE
fix(app-router): encode returnTo in login redirect to prevent OAuth param injection

### DIFF
--- a/src/server/helpers/with-page-auth-required.ts
+++ b/src/server/helpers/with-page-auth-required.ts
@@ -196,7 +196,7 @@ export const appRouteHandlerFactory =
           : opts.returnTo;
       const { redirect } = await import("next/navigation.js");
       redirect(
-        `${config.loginUrl}${opts.returnTo ? `?returnTo=${returnTo}` : ""}`
+        `${config.loginUrl}${opts.returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : ""}`
       );
     }
     return handler(params);


### PR DESCRIPTION
URLencode returnTo in appRouteHandlerFactory so the query params don’t break out into /auth/login and get forwarded to /authorize (e.g., scope, audience, etc).

This bug was found with ZeroPath.