### PR TITLE
fix: DPoP nonce retry on auth code callback

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -796,7 +796,7 @@ export class AuthClient {
       codeGrantResponse = await withDPoPNonceRetry(
         authorizationCodeGrantRequestCall,
         {
-          isDPoPEnabled: !!(this.useDPoP && this.dpopKeyPair),
+          isDPoPEnabled: !!dpopHandle,
           ...this.dpopOptions?.retry
         }
       );

--- a/src/server/dpop-authcode-nonce-retry.test.ts
+++ b/src/server/dpop-authcode-nonce-retry.test.ts
@@ -68,7 +68,9 @@ function createDPoPNonceRetryHandler(keyPairParam: jose.GenerateKeyPairResult) {
   };
 
   // Helper to parse DPoP JWT and extract nonce claim
-  const extractDPoPNonce = (dpopHeader: string | null): { hasNonce: boolean; nonce?: string } => {
+  const extractDPoPNonce = (
+    dpopHeader: string | null
+  ): { hasNonce: boolean; nonce?: string } => {
     if (!dpopHeader || typeof dpopHeader !== "string") {
       return { hasNonce: false };
     }
@@ -313,7 +315,9 @@ describe("AuthClient.handleCallback with DPoP Nonce Retry", () => {
       // 1. Received the DPoP-Nonce header from the 400 error response
       // 2. Extracted the nonce value ("server_nonce_value_123")
       // 3. Injected it into the DPoP JWT payload on retry
-      expect(tokenHandlerState.requests[1].nonce).toBe("server_nonce_value_123");
+      expect(tokenHandlerState.requests[1].nonce).toBe(
+        "server_nonce_value_123"
+      );
 
       // Additional validation: Decode the second request's DPoP JWT and verify
       // the payload contains the exact nonce claim


### PR DESCRIPTION
The auth code callback flow was missing the DPoP nonce retry pattern that already exists for:
- Refresh token requests (`refreshTokenGrantRequest`)
- Connection token exchanges (`genericTokenEndpointRequest`)

When a server requires a DPoP nonce, it responds with HTTP 400 + `use_dpop_nonce` error + `DPoP-Nonce` header. The client must retry with the provided nonce. Without this retry logic, the error propagates to the user and login fails.
endpoint flows.

## Changes

Wrapped the `authorizationCodeGrantRequestCall` with `withDPoPNonceRetry()` when DPoP is enabled, matching the existing patterns for other token.

- `src/server/auth-client.ts` (lines 784-789): Added conditional DPoP nonce retry wrapper in `handleCallback()` method
- `src/server/dpop-authcode-nonce-retry.test.ts`: Added MSW-based HTTP flow tests validating:
  - First request without nonce receives 400 + use_dpop_nonce error
  - Automatic retry with server-provided nonce succeeds
  - Second request returns 200 + valid tokens
- `dpopUtils.ts`: handle both type of request retries

## References
- RFC 9449

## Addendum
Replaces https://github.com/auth0/nextjs-auth0/pull/2390 with all review comments addressed