### PR TITLE
chore: avoid including test files in dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prepack": "pnpm run build",
     "install:examples": "pnpm install --filter ./examples/with-next-intl --shamefully-hoist && pnpm install --filter ./examples/with-shadcn --shamefully-hoist",
     "docs": "typedoc",
-    "lint": "tsc --noEmit && eslint ./src",
-    "lint:fix": "tsc --noEmit && eslint --fix ./src"
+    "lint": "tsc --noEmit && tsc --noEmit --project tsconfig.test.json && eslint ./src",
+    "lint:fix": "tsc --noEmit && tsc --noEmit --project tsconfig.test.json && eslint --fix ./src"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "moduleResolution": "nodenext",
+    "module": "NodeNext",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "moduleResolution": "nodenext",
-    "module": "NodeNext",
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "jsx": "react",
-    "declaration": true,
-    "resolveJsonModule": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test"
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": []
+}


### PR DESCRIPTION
Avoid including the test files in the dist directory, as they are currently included when publishing to npm.