### PR TITLE
merge sessionChanges before finalizing session after refresh

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -704,17 +704,10 @@ export class Auth0Client {
       // call beforeSessionSaved callback if present
       // if not then filter id_token claims with default rules
       const finalSession = await this.authClient.finalizeSession(
-        session,
+        { ...session, ...sessionChanges },
         tokenSet.idToken
       );
-      await this.saveToSession(
-        {
-          ...finalSession,
-          ...sessionChanges
-        },
-        req,
-        res
-      );
+      await this.saveToSession(finalSession, req, res);
     }
 
     return {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The `beforeSessionSaved` hook should be called with the updated session after the tokenSet has been refreshed. A recent change in [this PR](https://github.com/auth0/nextjs-auth0/pull/2387) fixed the behavior when requesting the access token via the token route. Thanks again for having responded to [my issue](https://github.com/auth0/nextjs-auth0/issues/2370) so promptly.

One case remains though where the old, buggy behavior remains: when `getAccessToken` is been called server side like it would be in next middleware. This PR fixes the issue in the same way the issue has been fixed elsewhere.

### 📎 References

related PR: [fix: make sure beforeSessionSaved hook gets the updated token after refresh](https://github.com/auth0/nextjs-auth0/pull/2387)
initial issue: [beforeSessionSaved behaves differently when called after login or after token refresh](https://github.com/auth0/nextjs-auth0/issues/2370)

### 🎯 Testing

Unit tests included with the PR