### PR TITLE
fix: merge sessionChanges before finalizing session after refresh (#2401)

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -695,17 +695,10 @@ export class Auth0Client {
       // call beforeSessionSaved callback if present
       // if not then filter id_token claims with default rules
       const finalSession = await this.authClient.finalizeSession(
-        session,
+        { ...session, ...sessionChanges },
         tokenSet.idToken
       );
-      await this.saveToSession(
-        {
-          ...finalSession,
-          ...sessionChanges
-        },
-        req,
-        res
-      );
+      await this.saveToSession(finalSession, req, res);
     }
 
     return {


### PR DESCRIPTION
## Description
This PR fixes an issue where the `beforeSessionSaved` hook was not receiving the refreshed token set after a token refresh operation.

### Changes
- Pass `sessionChanges` to `finalizeSession` so the `beforeSessionSaved` hook receives the refreshed tokens
- Simplify the session saving logic by merging changes before finalization
- Add comprehensive tests to verify:
  - `beforeSessionSaved` hook receives refreshed accessToken
  - Changes made in `beforeSessionSaved` hook are properly honored

### Related PRs
- Builds on community contribution from #2401 by @wgoedel
- Uses properly signed commits

### Testing
All existing tests pass, plus 2 new test cases:
```
✓ should provide the refreshed accessToken to beforeSessionSaved hook
✓ should honor changes made to the tokenSet in beforeSessionSaved hook
```

Co-authored-by: Wolfgang Goedel <wgoedel@gmail.com>