### PR TITLE
Revert "fix(app-router): encode returnTo in login redirect to prevent OAuth param injection"

### DIFF
--- a/src/server/helpers/with-page-auth-required.ts
+++ b/src/server/helpers/with-page-auth-required.ts
@@ -196,7 +196,7 @@ export const appRouteHandlerFactory =
           : opts.returnTo;
       const { redirect } = await import("next/navigation.js");
       redirect(
-        `${config.loginUrl}${returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : ""}`
+        `${config.loginUrl}${opts.returnTo ? `?returnTo=${returnTo}` : ""}`
       );
     }
     return handler(params);


### PR DESCRIPTION
Reverts auth0/nextjs-auth0#2435

This was done because the branch in https://github.com/auth0/nextjs-auth0/pull/2435 was out-of-date with `main`.