### PR TITLE
Configure cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,17 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 5
+      semver-minor-days: 5
+      semver-patch-days: 3
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 5
+      semver-major-days: 10
+      semver-minor-days: 5
+      semver-patch-days: 3


### PR DESCRIPTION
### 📋 Changes

Added cooldown settings for dependency updates to ensure we do not pick up changes as soon as they are released.

### 📎 References

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates

### 🎯 Testing

N/A
