### PR TITLE
fix: update transaction cookie deletion to clear all cookies on succe…

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -886,8 +886,8 @@ export class AuthClient {
     await this.sessionStore.set(req.cookies, res.cookies, session, true);
     addCacheControlHeadersForSession(res);
 
-    // Clean up the current transaction cookie after successful authentication
-    await this.transactionStore.delete(res.cookies, state);
+    // Clean up all transaction cookies after successful authentication
+    await this.transactionStore.deleteAll(req.cookies, res.cookies);
 
     return res;
   }


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR fixes the transaction cookie accumulation issue by calling `deleteAll` in `handleCallback` upon successful authentication.

**Problem:**
In v4, transaction cookies (`__txn_*`) accumulate over time as users navigate the app while unauthenticated. This eventually causes 431 errors due to request header size limits.

**Solution:**
- Changed `handleCallback` to call `transactionStore.deleteAll()` instead of `transactionStore.delete(state)` after successful authentication
- This ensures all accumulated transaction cookies are cleaned up when a user successfully logs in
- Complements the existing `deleteAll` call in `handleLogout`

**Changed files:**
- `src/server/auth-client.ts`: Replace `delete(state)` with `deleteAll()` in `handleCallback`
- `src/server/redundant-txn-cookie-deletion.test.ts`: Update test to verify all transaction cookies are deleted on success

### 📎 References

- Fixes #1917 - Transaction cookies accumulate infinitely causing 413 errors
- Related to PR #2077 which added `deleteAll` to `handleLogout`

### 🎯 Testing

**Unit tests:**
- Updated `redundant-txn-cookie-deletion.test.ts` to verify that all transaction cookies are deleted after successful callback
- All existing tests pass

**Manual testing (verified locally):**
1. Started the app and navigated around while unauthenticated (created multiple `__txn_*` cookies)
2. Logged in successfully
3. Verified all `__txn_*` cookies were cleared from the browser
