### PR TITLE
chore: introduce generic request to be able to handle different kind of requests

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -7956,7 +7956,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse())
+      );
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -7979,7 +7981,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        { returnTo }
+      );
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8002,7 +8007,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        { returnTo }
+      );
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8028,7 +8036,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo: unsafeReturnTo });
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        { returnTo: unsafeReturnTo }
+      );
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8050,7 +8061,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         return originalAuthorizationUrl.call(authClient, params);
       });
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { authorizationParameters });
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        { authorizationParameters }
+      );
 
       expect(authClient["authorizationUrl"]).toHaveBeenCalled();
     });
@@ -8084,7 +8098,9 @@ ca/T0LLtgmbMmxSv/MmzIg==
         fetch: mockFetch
       });
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse())
+      );
 
       // Verify that PAR was used
       expect(parRequestCalled).toBe(true);
@@ -8115,7 +8131,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        { returnTo }
+      );
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8142,12 +8161,15 @@ ca/T0LLtgmbMmxSv/MmzIg==
         return originalAuthorizationUrl.call(authClient, params);
       });
 
-      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), {
-        authorizationParameters: {
-          scope: methodScope,
-          audience: methodAudience
+      await authClient.startInteractiveLogin(
+        new Auth0NextResponse(new NextResponse()),
+        {
+          authorizationParameters: {
+            scope: methodScope,
+            audience: methodAudience
+          }
         }
-      });
+      );
 
       expect(authClient["authorizationUrl"]).toHaveBeenCalled();
     });

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -22,6 +22,7 @@ import {
 import { DEFAULT_SCOPES } from "../utils/constants.js";
 import { AuthClient } from "./auth-client.js";
 import { decrypt, encrypt } from "./cookies.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { StatefulSessionStore } from "./session/stateful-session-store.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionState, TransactionStore } from "./transaction-store.js";
@@ -443,7 +444,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/login", {
         method: "GET"
       });
-      authClient.handleLogin = vi.fn();
+      authClient.handleLogin = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleLogin).toHaveBeenCalled();
     });
@@ -474,7 +475,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/callback", {
         method: "GET"
       });
-      authClient.handleCallback = vi.fn();
+      authClient.handleCallback = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleCallback).toHaveBeenCalled();
     });
@@ -505,7 +506,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/logout", {
         method: "GET"
       });
-      authClient.handleLogout = vi.fn();
+      authClient.handleLogout = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleLogout).toHaveBeenCalled();
     });
@@ -536,7 +537,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/profile", {
         method: "GET"
       });
-      authClient.handleProfile = vi.fn();
+      authClient.handleProfile = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleProfile).toHaveBeenCalled();
     });
@@ -568,7 +569,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/access-token", {
         method: "GET"
       });
-      authClient.handleAccessToken = vi.fn();
+      authClient.handleAccessToken = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleAccessToken).toHaveBeenCalled();
     });
@@ -600,7 +601,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/access-token", {
         method: "GET"
       });
-      authClient.handleAccessToken = vi.fn();
+      authClient.handleAccessToken = vi.fn().mockResolvedValue({});
       const response = await authClient.handler(request);
       expect(authClient.handleAccessToken).not.toHaveBeenCalled();
       // When a route doesn't match, the handler returns a NextResponse.next() with status 200
@@ -634,7 +635,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       const request = new NextRequest("https://example.com/auth/access-token", {
         method: "GET"
       });
-      authClient.handleAccessToken = vi.fn();
+      authClient.handleAccessToken = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleAccessToken).toHaveBeenCalled();
     });
@@ -668,7 +669,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "POST"
         }
       );
-      authClient.handleBackChannelLogout = vi.fn();
+      authClient.handleBackChannelLogout = vi.fn().mockResolvedValue({});
       await authClient.handler(request);
       expect(authClient.handleBackChannelLogout).toHaveBeenCalled();
     });
@@ -837,7 +838,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleLogin = vi.fn();
+        authClient.handleLogin = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleLogin).toHaveBeenCalled();
       });
@@ -875,7 +876,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleLogout = vi.fn();
+        authClient.handleLogout = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleLogout).toHaveBeenCalled();
       });
@@ -913,7 +914,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleCallback = vi.fn();
+        authClient.handleCallback = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleCallback).toHaveBeenCalled();
       });
@@ -951,7 +952,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleBackChannelLogout = vi.fn();
+        authClient.handleBackChannelLogout = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleBackChannelLogout).toHaveBeenCalled();
       });
@@ -988,7 +989,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleProfile = vi.fn();
+        authClient.handleProfile = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleProfile).toHaveBeenCalled();
 
@@ -1027,7 +1028,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        authClient.handleAccessToken = vi.fn();
+        authClient.handleAccessToken = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleAccessToken).toHaveBeenCalled();
 
@@ -1121,7 +1122,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
             writable: false
           });
 
-          (authClient as any)[testCase.handler] = vi.fn();
+          (authClient as any)[testCase.handler] = vi.fn().mockResolvedValue({});
           await authClient.handler(request);
           expect((authClient as any)[testCase.handler]).toHaveBeenCalled();
         }
@@ -1151,7 +1152,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           { method: "GET" }
         );
 
-        authClient.handleLogin = vi.fn();
+        authClient.handleLogin = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleLogin).toHaveBeenCalled();
 
@@ -1189,7 +1190,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           writable: false
         });
 
-        authClient.handleMyAccount = vi.fn();
+        authClient.handleMyAccount = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleMyAccount).toHaveBeenCalled();
       });
@@ -1224,7 +1225,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
           writable: false
         });
 
-        authClient.handleMyOrg = vi.fn();
+        authClient.handleMyOrg = vi.fn().mockResolvedValue({});
         await authClient.handler(request);
         expect(authClient.handleMyOrg).toHaveBeenCalled();
       });
@@ -1262,7 +1263,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1344,7 +1351,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       const authorizationUrl = new URL(response.headers.get("Location")!);
 
       expect(authorizationUrl.searchParams.get("redirect_uri")).toEqual(
@@ -1394,7 +1407,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         const authorizationUrl = new URL(response.headers.get("Location")!);
 
         expect(authorizationUrl.searchParams.get("redirect_uri")).toEqual(
@@ -1436,7 +1455,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toContain(
         "An error occurred while trying to initiate the login request."
@@ -1474,7 +1499,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1565,7 +1596,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1635,7 +1672,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1721,7 +1764,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1791,7 +1840,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -1855,7 +1910,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         method: "GET"
       });
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       const authorizationUrl = new URL(response.headers.get("Location")!);
 
       expect(authorizationUrl.searchParams.get("max_age")).toEqual("3600");
@@ -1913,7 +1974,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         method: "GET"
       });
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       const authorizationUrl = new URL(response.headers.get("Location")!);
 
       // transaction state
@@ -1968,7 +2035,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         method: "GET"
       });
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       const authorizationUrl = new URL(response.headers.get("Location")!);
 
       // transaction state
@@ -2036,7 +2109,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
             method: "GET"
           }
         );
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
 
         expect(response.status).toEqual(500);
         expect(await response.text()).toEqual(
@@ -2089,7 +2168,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2197,7 +2282,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
             }
           );
 
-          const response = await authClient.handleLogin(request);
+          const auth0Req = new Auth0NextRequest(request);
+
+          const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+          await authClient.handleLogin(auth0Req, auth0Res);
+
+          const response = auth0Res.res;
           expect(response.status).toEqual(307);
           expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2252,7 +2343,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
             })
           });
 
-          const response = await authClient.handleLogin(request);
+          const auth0Req = new Auth0NextRequest(request);
+
+          const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+          await authClient.handleLogin(auth0Req, auth0Res);
+
+          const response = auth0Res.res;
           expect(response.status).toEqual(307);
           expect(response.headers.get("Location")).not.toBeNull();
           const authorizationUrl = new URL(response.headers.get("Location")!);
@@ -2341,7 +2438,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
             })
           });
 
-          const response = await authClient.handleLogin(request);
+          const auth0Req = new Auth0NextRequest(request);
+
+          const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+          await authClient.handleLogin(auth0Req, auth0Res);
+
+          const response = auth0Res.res;
           expect(response.status).toEqual(307);
           expect(response.headers.get("Location")).not.toBeNull();
           const authorizationUrl = new URL(response.headers.get("Location")!);
@@ -2422,7 +2525,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2477,7 +2586,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        const response = await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         const authorizationUrl = new URL(response.headers.get("Location")!);
 
         // With PAR, the authorization URL should only contain request_uri and client_id
@@ -2533,7 +2648,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
 
         // All safe parameters should be sent in the PAR request
         expect(parRequestParams!.get("screen_hint")).toEqual("signup");
@@ -2582,7 +2701,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        await authClient.handleLogin(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogin(auth0Req, auth0Res);
 
         // With simplified approach, custom parameters are forwarded to PAR
         expect(parRequestParams!.get("scope")).toEqual("read:users"); // Query param forwarded
@@ -2650,7 +2773,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2727,7 +2856,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2782,7 +2917,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2821,7 +2962,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -2887,7 +3034,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       const logoutUrl = new URL(response.headers.get("Location")!);
       expect(logoutUrl.origin).toEqual(`https://${DEFAULT.domain}`);
@@ -2937,7 +3090,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "An error occurred while trying to initiate the logout request."
@@ -2999,7 +3158,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3066,7 +3231,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3131,7 +3302,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3195,7 +3372,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3264,7 +3447,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleProfile(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleProfile(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(200);
       expect(await response.json()).toEqual({
         sub: DEFAULT.sub,
@@ -3305,7 +3494,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleProfile(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleProfile(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(401);
       expect(response.body).toBeNull();
     });
@@ -3343,7 +3538,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleProfile(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleProfile(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(204);
       expect(response.body).toBeNull();
     });
@@ -3401,7 +3602,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3503,7 +3710,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3589,7 +3802,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(307);
       expect(response.headers.get("Location")).not.toBeNull();
 
@@ -3661,7 +3880,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         method: "GET"
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual("The state parameter is missing.");
     });
@@ -3717,7 +3942,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual("The state parameter is invalid.");
     });
@@ -3773,7 +4004,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "An error occurred during the authorization flow."
@@ -3836,7 +4073,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "An error occurred while trying to exchange the authorization code."
@@ -3896,7 +4139,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         headers
       });
 
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleCallback(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "Discovery failed for the OpenID Connect configuration."
@@ -3965,7 +4214,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         const redirectUrl = new URL(response.headers.get("Location")!);
         expect(redirectUrl.pathname).toEqual("/other-path");
@@ -4048,7 +4303,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4127,7 +4388,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4206,7 +4473,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4292,7 +4565,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4377,7 +4656,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         });
 
         // validate the new response redirect
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4465,7 +4750,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
         expect(mockBeforeSessionSaved).toHaveBeenCalledWith(
           {
             user: expect.objectContaining({
@@ -4549,7 +4838,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4618,7 +4913,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
           method: "GET"
         });
 
-        await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
         expect(mockBeforeSessionSaved).not.toHaveBeenCalled();
       });
 
@@ -4687,7 +4986,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4817,7 +5122,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -4930,7 +5241,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -5036,7 +5353,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
             )
           ]);
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -5154,7 +5477,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           headers
         });
 
-        const response = await authClient.handleCallback(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleCallback(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(307);
         expect(response.headers.get("Location")).not.toBeNull();
 
@@ -5250,7 +5579,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleAccessToken(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleAccessToken(auth0Req, auth0Res);
+      const response = auth0Res.res;
       expect(response.status).toEqual(200);
       expect(await response.json()).toEqual({
         token: newAccessToken,
@@ -5299,7 +5631,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleAccessToken(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleAccessToken(auth0Req, auth0Res);
+      const response = auth0Res.res;
       expect(response.status).toEqual(401);
       expect(await response.json()).toEqual({
         error: {
@@ -5368,7 +5703,10 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleAccessToken(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleAccessToken(auth0Req, auth0Res);
+      const response = auth0Res.res;
       expect(response.status).toEqual(401);
       expect(await response.json()).toEqual({
         error: {
@@ -5426,7 +5764,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleBackChannelLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(204);
       expect(response.body).toBeNull();
 
@@ -5472,7 +5816,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleBackChannelLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "A session data store is not configured."
@@ -5519,7 +5869,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      const response = await authClient.handleBackChannelLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
       expect(response.status).toEqual(500);
       expect(await response.text()).toEqual(
         "Back-channel logout is not supported by the session data store."
@@ -5573,7 +5929,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5618,7 +5980,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5670,7 +6038,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5721,7 +6095,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5772,7 +6152,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5823,7 +6209,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5874,7 +6266,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -5928,7 +6326,13 @@ ca/T0LLtgmbMmxSv/MmzIg==
           }
         );
 
-        const response = await authClient.handleBackChannelLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+        await authClient.handleBackChannelLogout(auth0Req, auth0Res);
+
+        const response = auth0Res.res;
         expect(response.status).toEqual(400);
         expect(deleteByLogoutTokenSpy).not.toHaveBeenCalled();
       });
@@ -6274,7 +6678,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
       url.searchParams.append("scopes", "offline_access");
       url.searchParams.append("scopes", "read:messages");
 
-      authClient.handleConnectAccount = vi.fn();
+      authClient.handleConnectAccount = vi.fn().mockResolvedValue({});
       expect(authClient.handleConnectAccount).not.toHaveBeenCalled();
     });
 
@@ -7767,7 +8171,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
       );
       const req = new NextRequest(reqUrl, { method: "GET" });
 
-      await authClient.handleLogin(req);
+      const auth0Req = new Auth0NextRequest(req);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
 
       expect(authClient.startInteractiveLogin).toHaveBeenCalled();
     });
@@ -7794,7 +8202,11 @@ ca/T0LLtgmbMmxSv/MmzIg==
       );
       const req = new NextRequest(reqUrl, { method: "GET" });
 
-      await authClient.handleLogin(req);
+      const auth0Req = new Auth0NextRequest(req);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
 
       expect(authClient.startInteractiveLogin).toHaveBeenCalled();
     });

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -7956,7 +7956,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin();
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -7979,7 +7979,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin({ returnTo });
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8002,7 +8002,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin({ returnTo });
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8028,7 +8028,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin({ returnTo: unsafeReturnTo });
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo: unsafeReturnTo });
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8050,7 +8050,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         return originalAuthorizationUrl.call(authClient, params);
       });
 
-      await authClient.startInteractiveLogin({ authorizationParameters });
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { authorizationParameters });
 
       expect(authClient["authorizationUrl"]).toHaveBeenCalled();
     });
@@ -8084,7 +8084,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         fetch: mockFetch
       });
 
-      await authClient.startInteractiveLogin();
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
 
       // Verify that PAR was used
       expect(parRequestCalled).toBe(true);
@@ -8115,7 +8115,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         }
       );
 
-      await authClient.startInteractiveLogin({ returnTo });
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), { returnTo });
 
       expect(authClient["transactionStore"].save).toHaveBeenCalled();
     });
@@ -8142,7 +8142,7 @@ ca/T0LLtgmbMmxSv/MmzIg==
         return originalAuthorizationUrl.call(authClient, params);
       });
 
-      await authClient.startInteractiveLogin({
+      await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), {
         authorizationParameters: {
           scope: methodScope,
           audience: methodAudience
@@ -8158,12 +8158,12 @@ ca/T0LLtgmbMmxSv/MmzIg==
 
       // Mock startInteractiveLogin to check what options are passed to it
       const originalStartInteractiveLogin = authClient.startInteractiveLogin;
-      authClient.startInteractiveLogin = vi.fn(async (options) => {
+      authClient.startInteractiveLogin = vi.fn(async (res, options) => {
         expect(options).toEqual({
           authorizationParameters: { foo: "bar" },
           returnTo: "custom-return"
         });
-        return originalStartInteractiveLogin.call(authClient, options);
+        return originalStartInteractiveLogin.call(authClient, res, options);
       });
 
       const reqUrl = new URL(
@@ -8187,14 +8187,14 @@ ca/T0LLtgmbMmxSv/MmzIg==
 
       // Mock startInteractiveLogin to check what options are passed to it
       const originalStartInteractiveLogin = authClient.startInteractiveLogin;
-      authClient.startInteractiveLogin = vi.fn(async (options) => {
+      authClient.startInteractiveLogin = vi.fn(async (res, options) => {
         expect(options).toEqual({
           authorizationParameters: {
             foo: "bar"
           },
           returnTo: "custom-return"
         });
-        return originalStartInteractiveLogin.call(authClient, options);
+        return originalStartInteractiveLogin.call(authClient, res, options);
       });
 
       const reqUrl = new URL(

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -446,6 +446,8 @@ export class AuthClient {
       return this.#unwrapHandler(() => this.handleMyOrg(auth0Req, auth0Res));
     } else {
       // no auth handler found, simply touch the sessions
+      // TODO: this should only happen if rolling sessions are enabled. Also, we should
+      // try to avoid reading from the DB (for stateful sessions) on every request if possible.
       const session = await this.sessionStore.get(auth0Req.getCookies());
       const auth0Res = new Auth0NextResponse(NextResponse.next());
       if (session) {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -714,7 +714,6 @@ export class AuthClient {
       return this.handleCallbackError(
         new MissingStateError(),
         {},
-        auth0Req,
         auth0Res
       );
     }
@@ -745,7 +744,6 @@ export class AuthClient {
             message: "The user does not have an active session."
           }),
           onCallbackCtx,
-          auth0Req,
           auth0Res,
           state
         );
@@ -764,7 +762,6 @@ export class AuthClient {
         return this.handleCallbackError(
           tokenSetError,
           onCallbackCtx,
-          auth0Req,
           auth0Res,
           state
         );
@@ -786,7 +783,6 @@ export class AuthClient {
         return this.handleCallbackError(
           completeConnectAccountError,
           onCallbackCtx,
-          auth0Req,
           auth0Res,
           state
         );
@@ -814,7 +810,6 @@ export class AuthClient {
       return this.handleCallbackError(
         discoveryError,
         onCallbackCtx,
-        auth0Req,
         auth0Res,
         state
       );
@@ -837,7 +832,6 @@ export class AuthClient {
           })
         }),
         onCallbackCtx,
-        auth0Req,
         auth0Res,
         state
       );
@@ -893,7 +887,6 @@ export class AuthClient {
       return this.handleCallbackError(
         new AuthorizationCodeGrantRequestError(e.message),
         onCallbackCtx,
-        auth0Req,
         auth0Res,
         state
       );
@@ -922,7 +915,6 @@ export class AuthClient {
           })
         }),
         onCallbackCtx,
-        auth0Req,
         auth0Res,
         state
       );
@@ -1491,7 +1483,6 @@ export class AuthClient {
   private async handleCallbackError(
     error: SdkError,
     ctx: OnCallbackContext,
-    auth0Req: Auth0Request,
     auth0Res: Auth0Response,
     state?: string
   ): Promise<Auth0Response> {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -84,20 +84,19 @@ import {
 } from "../utils/token-set-helpers.js";
 import { toSafeRedirect } from "../utils/url-helpers.js";
 import {
-  Auth0NextRequest,
-  Auth0NextResponse,
-  Auth0Request,
-  Auth0Response,
-  Auth0ResponseCookies
-} from "./http/index.js";
-import { addCacheControlHeadersForSession } from "./cookies.js";
-import {
   AccessTokenFactory,
   Fetcher,
   FetcherConfig,
   FetcherHooks,
   FetcherMinimalConfig
 } from "./fetcher.js";
+import {
+  Auth0NextRequest,
+  Auth0NextResponse,
+  Auth0Request,
+  Auth0Response,
+  Auth0ResponseCookies
+} from "./http/index.js";
 import { AbstractSessionStore } from "./session/abstract-session-store.js";
 import { TransactionState, TransactionStore } from "./transaction-store.js";
 import { filterDefaultIdTokenClaims } from "./user.js";
@@ -426,7 +425,9 @@ export class AuthClient {
       sanitizedPathname === this.routes.accessToken &&
       this.enableAccessTokenEndpoint
     ) {
-      return this.#unwrapHandler(() => this.handleAccessToken(auth0Req, auth0Res));
+      return this.#unwrapHandler(() =>
+        this.handleAccessToken(auth0Req, auth0Res)
+      );
     } else if (
       method === "POST" &&
       sanitizedPathname === this.routes.backChannelLogout
@@ -439,9 +440,13 @@ export class AuthClient {
       sanitizedPathname === this.routes.connectAccount &&
       this.enableConnectAccountEndpoint
     ) {
-      return this.#unwrapHandler(() => this.handleConnectAccount(auth0Req, auth0Res));
+      return this.#unwrapHandler(() =>
+        this.handleConnectAccount(auth0Req, auth0Res)
+      );
     } else if (sanitizedPathname.startsWith("/me/")) {
-      return this.#unwrapHandler(() => this.handleMyAccount(auth0Req, auth0Res));
+      return this.#unwrapHandler(() =>
+        this.handleMyAccount(auth0Req, auth0Res)
+      );
     } else if (sanitizedPathname.startsWith("/my-org/")) {
       return this.#unwrapHandler(() => this.handleMyOrg(auth0Req, auth0Res));
     } else {
@@ -471,7 +476,9 @@ export class AuthClient {
    * Unwraps an Auth0Response by extracting the underlying NextResponse.
    * This utility simplifies the pattern of awaiting handler calls and accessing .res
    */
-  async #unwrapHandler(handler: () => Promise<Auth0Response>): Promise<NextResponse> {
+  async #unwrapHandler(
+    handler: () => Promise<Auth0Response>
+  ): Promise<NextResponse> {
     const auth0Response = await handler();
     return auth0Response.res;
   }
@@ -711,11 +718,7 @@ export class AuthClient {
   ): Promise<Auth0Response> {
     const state = auth0Req.getUrl().searchParams.get("state");
     if (!state) {
-      return this.handleCallbackError(
-        new MissingStateError(),
-        {},
-        auth0Res
-      );
+      return this.handleCallbackError(new MissingStateError(), {}, auth0Res);
     }
 
     const transactionStateCookie = await this.transactionStore.get(
@@ -1059,7 +1062,10 @@ export class AuthClient {
     const logoutToken = body.get("logout_token");
 
     if (!logoutToken) {
-      return auth0Res.status("Missing `logout_token` in the request body.", 400);
+      return auth0Res.status(
+        "Missing `logout_token` in the request body.",
+        400
+      );
     }
 
     const [error, logoutTokenClaims] =
@@ -1126,7 +1132,10 @@ export class AuthClient {
     }
 
     const [connectAccountError, connectAccountResponse] =
-      await this.connectAccount({ tokenSet, ...connectAccountParams }, auth0Res);
+      await this.connectAccount(
+        { tokenSet, ...connectAccountParams },
+        auth0Res
+      );
 
     if (connectAccountError) {
       return auth0Res.status(

--- a/src/server/base-path-logout-integration.test.ts
+++ b/src/server/base-path-logout-integration.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Auth0Client } from "./client.js";
 import { deleteChunkedCookie } from "./cookies.js";
+import { Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
-import { Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 
 describe("Base path and cookie configuration tests", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -56,7 +56,10 @@ describe("Base path and cookie configuration tests", () => {
       mockReqCookies.getAll = () => [];
 
       // Call delete method (this would be called during logout)
-      await sessionStore.delete(new Auth0RequestCookies(mockReqCookies), new Auth0ResponseCookies(mockResCookies));
+      await sessionStore.delete(
+        new Auth0RequestCookies(mockReqCookies),
+        new Auth0ResponseCookies(mockResCookies)
+      );
 
       // Verify that the cookie deletion header includes the correct path
       const cookieHeader = mockResCookies.toString();
@@ -91,7 +94,10 @@ describe("Base path and cookie configuration tests", () => {
       mockReqCookies.get = () => ({ value: "mock-session-value" });
       mockReqCookies.getAll = () => [];
 
-      await sessionStore.delete(new Auth0RequestCookies(mockReqCookies), new Auth0ResponseCookies(mockResCookies));
+      await sessionStore.delete(
+        new Auth0RequestCookies(mockReqCookies),
+        new Auth0ResponseCookies(mockResCookies)
+      );
 
       const cookieHeader = mockResCookies.toString();
 
@@ -294,7 +300,10 @@ describe("Base path and cookie configuration tests", () => {
         }
       });
 
-      await sessionStore.delete(new Auth0RequestCookies(mockReqCookies), new Auth0ResponseCookies(mockResCookies));
+      await sessionStore.delete(
+        new Auth0RequestCookies(mockReqCookies),
+        new Auth0ResponseCookies(mockResCookies)
+      );
 
       const cookieHeader = mockResCookies.toString();
       expect(cookieHeader).toContain("__session=");
@@ -314,7 +323,10 @@ describe("Base path and cookie configuration tests", () => {
         }
       });
 
-      await transactionStore.delete(new Auth0ResponseCookies(mockResCookies), "test-state");
+      await transactionStore.delete(
+        new Auth0ResponseCookies(mockResCookies),
+        "test-state"
+      );
 
       const cookieHeader = mockResCookies.toString();
       expect(cookieHeader).toContain("__txn_test-state=");
@@ -340,7 +352,10 @@ describe("Base path and cookie configuration tests", () => {
         }
       });
 
-      await transactionStore.deleteAll(new Auth0RequestCookies(mockReqCookies), new Auth0ResponseCookies(mockResCookies));
+      await transactionStore.deleteAll(
+        new Auth0RequestCookies(mockReqCookies),
+        new Auth0ResponseCookies(mockResCookies)
+      );
 
       const cookieHeader = mockResCookies.toString();
       expect(cookieHeader).toContain("__txn_state1=");
@@ -383,7 +398,9 @@ describe("Base path and cookie configuration tests", () => {
     });
 
     it("should handle empty path correctly", () => {
-      const auth0ResponseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+      const auth0ResponseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
       auth0ResponseCookies.delete({
         name: "test-cookie",
         path: ""

--- a/src/server/beforeSessionSaved-token-refresh-flow.test.ts
+++ b/src/server/beforeSessionSaved-token-refresh-flow.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server.js";
+import { NextRequest, NextResponse } from "next/server.js";
 import * as jose from "jose";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -8,6 +8,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
 import { SessionData } from "../types/index.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { AuthClient } from "./auth-client.js";
 import { decrypt, encrypt } from "./cookies.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
@@ -217,7 +218,13 @@ describe("AuthClient - beforeSessionSaved hook", async () => {
       headers
     });
 
-    const response = await authClient.handleAccessToken(request);
+    const auth0Req = new Auth0NextRequest(request);
+
+    const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+    await authClient.handleAccessToken(auth0Req, auth0Res);
+
+    const response = auth0Res.res;
 
     // Verify the response
     expect(response.status).toEqual(200);

--- a/src/server/beforeSessionSaved-token-refresh-flow.test.ts
+++ b/src/server/beforeSessionSaved-token-refresh-flow.test.ts
@@ -8,9 +8,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
 import { SessionData } from "../types/index.js";
-import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { AuthClient } from "./auth-client.js";
 import { decrypt, encrypt } from "./cookies.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
 

--- a/src/server/chunked-cookies.test.ts
+++ b/src/server/chunked-cookies.test.ts
@@ -97,7 +97,13 @@ const createMocks = () => {
     })
   };
 
-  return { reqCookies, auth0ReqCookies: new Auth0RequestCookies(reqCookies), resCookies, auth0ResCookies: new Auth0ResponseCookies(resCookies), cookieStore };
+  return {
+    reqCookies,
+    auth0ReqCookies: new Auth0RequestCookies(reqCookies),
+    resCookies,
+    auth0ResCookies: new Auth0ResponseCookies(resCookies),
+    cookieStore
+  };
 };
 
 describe("Chunked Cookie Utils", () => {
@@ -144,7 +150,13 @@ describe("Chunked Cookie Utils", () => {
       // Create a large string (8000 bytes)
       const largeValue = "a".repeat(8000);
 
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       // Should create 3 chunks (8000 / 3500 ≈ 2.3, rounded up to 3)
       // called 4 times:
@@ -229,7 +241,13 @@ describe("Chunked Cookie Utils", () => {
       const largeValue = "a".repeat(8000);
       const options = { path: "/" } as CookieOptions;
 
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       expect(reqCookies.delete).toHaveBeenCalledTimes(1);
       expect(reqCookies.delete).toHaveBeenCalledWith(`${name}`);
@@ -277,7 +295,13 @@ describe("Chunked Cookie Utils", () => {
       cookieStore.set(`${name}__4`, chunk4);
 
       const largeValue = "a".repeat(8000);
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       // It is called 3 times.
       // 2 times for the chunks
@@ -321,7 +345,13 @@ describe("Chunked Cookie Utils", () => {
         sameSite: "lax"
       };
 
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       // called 4 times:
       // 3 calls to set the chunks
@@ -393,7 +423,13 @@ describe("Chunked Cookie Utils", () => {
       delete expectedOptions.maxAge; // maxAge should be removed
       delete expectedOptions.transient; // transient flag itself is not part of the cookie options
 
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       // called 4 times:
       // 3 calls to set the chunks
@@ -467,7 +503,13 @@ describe("Chunked Cookie Utils", () => {
       const expectedOptions = { ...options };
       delete expectedOptions.transient; // transient flag itself is not part of the cookie options
 
-      setChunkedCookie(name, largeValue, options, auth0ReqCookies, auth0ResCookies);
+      setChunkedCookie(
+        name,
+        largeValue,
+        options,
+        auth0ReqCookies,
+        auth0ResCookies
+      );
 
       // called 4 times:
       // 3 calls to set the chunks
@@ -611,7 +653,13 @@ describe("Chunked Cookie Utils", () => {
         const value = "";
         const options = { path: "/" } as CookieOptions;
 
-        setChunkedCookie(name, value, options, auth0ReqCookies, auth0ResCookies);
+        setChunkedCookie(
+          name,
+          value,
+          options,
+          auth0ReqCookies,
+          auth0ResCookies
+        );
 
         expect(resCookies.set).toHaveBeenCalledTimes(1);
         expect(resCookies.set).toHaveBeenCalledWith(name, value, options);
@@ -622,7 +670,13 @@ describe("Chunked Cookie Utils", () => {
         const value = "a".repeat(3500); // Exactly MAX_CHUNK_SIZE
         const options = { path: "/" } as CookieOptions;
 
-        setChunkedCookie(name, value, options, auth0ReqCookies, auth0ResCookies);
+        setChunkedCookie(
+          name,
+          value,
+          options,
+          auth0ReqCookies,
+          auth0ResCookies
+        );
 
         // Should still fit in one cookie
         expect(resCookies.set).toHaveBeenCalledTimes(1);
@@ -635,7 +689,13 @@ describe("Chunked Cookie Utils", () => {
           '{"special":"characters","with":"quotation marks","and":"😀 emoji"}';
         const options = { path: "/" } as CookieOptions;
 
-        setChunkedCookie(name, value, options, auth0ReqCookies, auth0ResCookies);
+        setChunkedCookie(
+          name,
+          value,
+          options,
+          auth0ReqCookies,
+          auth0ResCookies
+        );
 
         expect(resCookies.set).toHaveBeenCalledWith(name, value, options);
 
@@ -653,7 +713,13 @@ describe("Chunked Cookie Utils", () => {
         const options = { path: "/" } as CookieOptions;
 
         // Store the cookie
-        setChunkedCookie(name, value, options, auth0ReqCookies, auth0ResCookies);
+        setChunkedCookie(
+          name,
+          value,
+          options,
+          auth0ReqCookies,
+          auth0ResCookies
+        );
 
         // For the retrieval test, manually set up the cookies
         // We're testing the retrieval functionality, not the chunking itself
@@ -675,7 +741,13 @@ describe("Chunked Cookie Utils", () => {
         const value = "a".repeat(10000); // Will create multiple chunks
         const options = { path: "/" } as CookieOptions;
 
-        setChunkedCookie(name, value, options, auth0ReqCookies, auth0ResCookies);
+        setChunkedCookie(
+          name,
+          value,
+          options,
+          auth0ReqCookies,
+          auth0ResCookies
+        );
 
         // Get chunks count (10000 / 3500 ≈ 2.86, so we need 3 chunks)
         const expectedChunks = Math.ceil(10000 / 3500);

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1081,13 +1081,13 @@ export class Auth0Client {
           scope: getMyAccountTokenOpts.scope,
           audience: accessToken.audience
         }
-      });
+      }, new Auth0NextResponse(new NextResponse()));
 
     if (error) {
       throw error;
     }
 
-    return connectAccountResponse;
+    return connectAccountResponse.res;
   }
 
   withPageAuthRequired(

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -61,6 +61,7 @@ import {
   TransactionCookieOptions,
   TransactionStore
 } from "./transaction-store.js";
+import { Auth0NextResponse } from "./http/auth0-next-response.js";
 
 export interface Auth0ClientOptions {
   // authorization server configuration
@@ -1020,7 +1021,8 @@ export class Auth0Client {
   async startInteractiveLogin(
     options: StartInteractiveLoginOptions = {}
   ): Promise<NextResponse> {
-    return this.authClient.startInteractiveLogin(options);
+    const auth0Res = await this.authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()), options);
+    return auth0Res.res;
   }
 
   /**

--- a/src/server/cookie-domain-deletion.test.ts
+++ b/src/server/cookie-domain-deletion.test.ts
@@ -1,14 +1,15 @@
 import { RequestCookies, ResponseCookies } from "@edge-runtime/cookies";
 import { describe, expect, it } from "vitest";
 
-import { deleteChunkedCookie, deleteCookie } from "./cookies.js";
+import { deleteChunkedCookie } from "./cookies.js";
+import { Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 
 describe("Cookie deletion with domain", () => {
   it("should delete cookies without domain by default", () => {
     const headers = new Headers();
-    const resCookies = new ResponseCookies(headers);
+    const resCookies = new Auth0ResponseCookies(new ResponseCookies(headers));
 
-    deleteCookie(resCookies, "__session");
+    resCookies.delete("__session");
 
     const setCookieHeaders = headers.getSetCookie();
     const sessionCookieHeader = setCookieHeaders.find((header) =>
@@ -21,10 +22,11 @@ describe("Cookie deletion with domain", () => {
 
   it("should include domain when deleting cookies if domain option is provided", () => {
     const headers = new Headers();
-    const resCookies = new ResponseCookies(headers);
+    const resCookies = new Auth0ResponseCookies(new ResponseCookies(headers));
     const cookieDomain = "df.mydomain.com";
 
-    deleteCookie(resCookies, "__session", {
+    resCookies.delete({
+      name: "__session",
       domain: cookieDomain,
       path: "/"
     });
@@ -40,8 +42,8 @@ describe("Cookie deletion with domain", () => {
 
   it("should delete chunked cookies with domain when provided", () => {
     const headers = new Headers();
-    const reqCookies = new RequestCookies(headers);
-    const resCookies = new ResponseCookies(headers);
+    const reqCookies = new Auth0RequestCookies(new RequestCookies(headers));
+    const resCookies = new Auth0ResponseCookies(new ResponseCookies(headers));
 
     reqCookies.set("__session__0", "chunk0");
     reqCookies.set("__session__1", "chunk1");

--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -1,9 +1,5 @@
 import type { NextResponse } from "next/server.js";
-import {
-  RequestCookie,
-  RequestCookies,
-  ResponseCookies
-} from "@edge-runtime/cookies";
+import { RequestCookies, ResponseCookies } from "@edge-runtime/cookies";
 import { hkdf } from "@panva/hkdf";
 import * as jose from "jose";
 

--- a/src/server/dpop-authcode-nonce-retry.test.ts
+++ b/src/server/dpop-authcode-nonce-retry.test.ts
@@ -9,9 +9,9 @@ import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
 import { RESPONSE_TYPES, TransactionState } from "../types/index.js";
 import { generateDpopKeyPair } from "../utils/dpopUtils.js";
-import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { AuthClient } from "./auth-client.js";
 import { decrypt, encrypt } from "./cookies.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
 

--- a/src/server/dpop-authcode-nonce-retry.test.ts
+++ b/src/server/dpop-authcode-nonce-retry.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server.js";
+import { NextRequest, NextResponse } from "next/server.js";
 import * as jose from "jose";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -9,6 +9,7 @@ import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
 import { RESPONSE_TYPES, TransactionState } from "../types/index.js";
 import { generateDpopKeyPair } from "../utils/dpopUtils.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { AuthClient } from "./auth-client.js";
 import { decrypt, encrypt } from "./cookies.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
@@ -239,7 +240,10 @@ describe("AuthClient.handleCallback with DPoP Nonce Retry", () => {
 
       // CALL THE ACTUAL SDK METHOD
       // This is where withDPoPNonceRetry() is applied internally
-      const response = await authClient.handleCallback(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleCallback(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       // Validate response
       expect(response.status).toBe(307); // Successful callback redirect

--- a/src/server/http/auth0-next-request.test.ts
+++ b/src/server/http/auth0-next-request.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server.js";
 import { describe, expect, it } from "vitest";
+
 import { Auth0NextRequest } from "./auth0-next-request.js";
 
 describe("Auth0NextRequest", () => {
@@ -30,9 +31,12 @@ describe("Auth0NextRequest", () => {
     });
 
     it("should include query parameters in the URL", () => {
-      const request = new NextRequest("https://example.com/auth/login?returnTo=/dashboard", {
-        method: "GET"
-      });
+      const request = new NextRequest(
+        "https://example.com/auth/login?returnTo=/dashboard",
+        {
+          method: "GET"
+        }
+      );
 
       const auth0Request = new Auth0NextRequest(request);
       const url = auth0Request.getUrl();
@@ -41,9 +45,12 @@ describe("Auth0NextRequest", () => {
     });
 
     it("should handle complex URLs with fragments and special characters", () => {
-      const request = new NextRequest("https://example.com/auth/callback?code=abc123&state=xyz789", {
-        method: "GET"
-      });
+      const request = new NextRequest(
+        "https://example.com/auth/callback?code=abc123&state=xyz789",
+        {
+          method: "GET"
+        }
+      );
 
       const auth0Request = new Auth0NextRequest(request);
       const url = auth0Request.getUrl();
@@ -62,7 +69,9 @@ describe("Auth0NextRequest", () => {
     });
 
     it("should return the HTTP method for POST requests", () => {
-      const request = new NextRequest("https://example.com", { method: "POST" });
+      const request = new NextRequest("https://example.com", {
+        method: "POST"
+      });
       const auth0Request = new Auth0NextRequest(request);
 
       expect(auth0Request.getMethod()).toBe("POST");
@@ -167,7 +176,7 @@ describe("Auth0NextRequest", () => {
       const request = new NextRequest("https://example.com", {
         headers: {
           "content-type": "application/json",
-          "authorization": "Bearer token123"
+          authorization: "Bearer token123"
         }
       });
 
@@ -194,7 +203,7 @@ describe("Auth0NextRequest", () => {
 
     it("should handle multiple header values", () => {
       const request = new NextRequest("https://example.com", {
-        headers: { "accept": "application/json, text/plain" }
+        headers: { accept: "application/json, text/plain" }
       });
 
       const auth0Request = new Auth0NextRequest(request);

--- a/src/server/http/auth0-next-request.test.ts
+++ b/src/server/http/auth0-next-request.test.ts
@@ -1,0 +1,384 @@
+import { NextRequest } from "next/server.js";
+import { describe, expect, it, beforeEach } from "vitest";
+import { Auth0NextRequest } from "./auth0-next-request.js";
+
+describe("Auth0NextRequest", () => {
+  describe("getUrl()", () => {
+    it("should return the request URL", () => {
+      const request = new NextRequest("https://example.com/auth/login", {
+        method: "GET"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const url = auth0Request.getUrl();
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.href).toContain("example.com");
+      expect(url.pathname).toBe("/auth/login");
+    });
+
+    it("should use nextUrl instead of url to support middleware rewrites", () => {
+      const request = new NextRequest("https://example.com/auth/login", {
+        method: "GET"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const url = auth0Request.getUrl();
+
+      // nextUrl is the rewritten URL in middleware context - should have same href
+      expect(url.href).toBe(request.nextUrl.href);
+    });
+
+    it("should include query parameters in the URL", () => {
+      const request = new NextRequest("https://example.com/auth/login?returnTo=/dashboard", {
+        method: "GET"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("returnTo")).toBe("/dashboard");
+    });
+
+    it("should handle complex URLs with fragments and special characters", () => {
+      const request = new NextRequest("https://example.com/auth/callback?code=abc123&state=xyz789", {
+        method: "GET"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("code")).toBe("abc123");
+      expect(url.searchParams.get("state")).toBe("xyz789");
+    });
+  });
+
+  describe("getMethod()", () => {
+    it("should return the HTTP method for GET requests", () => {
+      const request = new NextRequest("https://example.com", { method: "GET" });
+      const auth0Request = new Auth0NextRequest(request);
+
+      expect(auth0Request.getMethod()).toBe("GET");
+    });
+
+    it("should return the HTTP method for POST requests", () => {
+      const request = new NextRequest("https://example.com", { method: "POST" });
+      const auth0Request = new Auth0NextRequest(request);
+
+      expect(auth0Request.getMethod()).toBe("POST");
+    });
+
+    it("should return the HTTP method for other HTTP methods", () => {
+      const methods = ["PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"];
+
+      methods.forEach((method) => {
+        const request = new NextRequest("https://example.com", { method });
+        const auth0Request = new Auth0NextRequest(request);
+
+        expect(auth0Request.getMethod()).toBe(method);
+      });
+    });
+  });
+
+  describe("getBody()", () => {
+    it("should return the request body as text", async () => {
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: "test body content"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const body = await auth0Request.getBody();
+
+      expect(body).toBe("test body content");
+    });
+
+    it("should return the request body for JSON content", async () => {
+      const jsonBody = { key: "value" };
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: JSON.stringify(jsonBody),
+        headers: { "content-type": "application/json" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const body = await auth0Request.getBody();
+
+      expect(body).toEqual(JSON.stringify(jsonBody));
+    });
+
+    it("should return the request body for form data", async () => {
+      const formData = new URLSearchParams({
+        username: "user@example.com",
+        password: "secret"
+      }).toString();
+
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: formData,
+        headers: { "content-type": "application/x-www-form-urlencoded" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const body = await auth0Request.getBody();
+
+      expect(body).toContain("username=user%40example.com");
+      expect(body).toContain("password=secret");
+    });
+
+    it("should return empty string for requests with no body", async () => {
+      const request = new NextRequest("https://example.com", { method: "GET" });
+      const auth0Request = new Auth0NextRequest(request);
+
+      const body = await auth0Request.getBody();
+
+      expect(body).toBe("");
+    });
+
+    it("should handle large request bodies", async () => {
+      const largeBody = "x".repeat(10000);
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: largeBody
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const body = await auth0Request.getBody();
+
+      expect(body).toBe(largeBody);
+      expect(body.length).toBe(10000);
+    });
+
+    it("should return a promise", () => {
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: "test"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const bodyPromise = auth0Request.getBody();
+
+      expect(bodyPromise instanceof Promise).toBe(true);
+    });
+  });
+
+  describe("getHeaders()", () => {
+    it("should return the request headers", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer token123"
+        }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("content-type")).toBe("application/json");
+      expect(headers.get("authorization")).toBe("Bearer token123");
+    });
+
+    it("should be case-insensitive for header names", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: { "Content-Type": "text/html" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("content-type")).toBe("text/html");
+      expect(headers.get("Content-Type")).toBe("text/html");
+      expect(headers.get("CONTENT-TYPE")).toBe("text/html");
+    });
+
+    it("should handle multiple header values", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: { "accept": "application/json, text/plain" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("accept")).toContain("application/json");
+      expect(headers.get("accept")).toContain("text/plain");
+    });
+
+    it("should include custom headers", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: {
+          "x-custom-header": "custom-value",
+          "x-another-header": "another-value"
+        }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("x-custom-header")).toBe("custom-value");
+      expect(headers.get("x-another-header")).toBe("another-value");
+    });
+  });
+
+  describe("clone()", () => {
+    it("should clone the request", () => {
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: "test body"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const clonedRequest = auth0Request.clone();
+
+      expect(clonedRequest).not.toBe(request);
+      expect(clonedRequest).toBeInstanceOf(Request);
+    });
+
+    it("should allow reading body from cloned request", async () => {
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: "test body"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const clonedRequest = auth0Request.clone();
+
+      const body = await clonedRequest.text();
+      expect(body).toBe("test body");
+    });
+
+    it("should preserve request properties in cloned request", () => {
+      const request = new NextRequest("https://example.com/test", {
+        method: "POST",
+        headers: { "x-test": "value" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const clonedRequest = auth0Request.clone();
+
+      expect(clonedRequest.method).toBe("POST");
+      expect(clonedRequest.headers.get("x-test")).toBe("value");
+    });
+
+    it("should create independent clones", async () => {
+      const request = new NextRequest("https://example.com", {
+        method: "POST",
+        body: "original body"
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const cloned1 = auth0Request.clone();
+      const cloned2 = auth0Request.clone();
+
+      const body1 = await cloned1.text();
+      const body2 = await cloned2.text();
+
+      expect(body1).toBe("original body");
+      expect(body2).toBe("original body");
+      expect(cloned1).not.toBe(cloned2);
+    });
+  });
+
+  describe("getCookies()", () => {
+    it("should return Auth0RequestCookies object", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: { cookie: "session=abc123; preferences=dark" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies).toBeDefined();
+      expect(typeof cookies.get).toBe("function");
+      expect(typeof cookies.getAll).toBe("function");
+      expect(typeof cookies.has).toBe("function");
+    });
+
+    it("should provide access to cookies from request", () => {
+      const request = new NextRequest("https://example.com", {
+        headers: { cookie: "session=abc123" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.has("session")).toBe(true);
+    });
+
+    it("should handle requests with no cookies", () => {
+      const request = new NextRequest("https://example.com");
+
+      const auth0Request = new Auth0NextRequest(request);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.getAll()).toEqual([]);
+    });
+  });
+
+  describe("constructor", () => {
+    it("should store the underlying NextRequest", () => {
+      const request = new NextRequest("https://example.com");
+      const auth0Request = new Auth0NextRequest(request);
+
+      expect(auth0Request.req).toBe(request);
+    });
+
+    it("should accept NextRequest as constructor argument", () => {
+      const request = new NextRequest("https://example.com/auth/login", {
+        method: "GET"
+      });
+
+      expect(() => {
+        new Auth0NextRequest(request);
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle OAuth callback scenario", async () => {
+      const request = new NextRequest(
+        "https://example.com/auth/callback?code=auth0_code&state=random_state",
+        { method: "GET" }
+      );
+
+      const auth0Request = new Auth0NextRequest(request);
+
+      expect(auth0Request.getMethod()).toBe("GET");
+      const url = auth0Request.getUrl();
+      expect(url.searchParams.get("code")).toBe("auth0_code");
+      expect(url.searchParams.get("state")).toBe("random_state");
+    });
+
+    it("should handle login form submission scenario", async () => {
+      const formBody = new URLSearchParams({
+        email: "user@example.com",
+        password: "secret123"
+      }).toString();
+
+      const request = new NextRequest("https://example.com/auth/login", {
+        method: "POST",
+        body: formBody,
+        headers: { "content-type": "application/x-www-form-urlencoded" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+
+      expect(auth0Request.getMethod()).toBe("POST");
+      const body = await auth0Request.getBody();
+      expect(body).toContain("email=user%40example.com");
+    });
+
+    it("should handle logout with session cookie scenario", () => {
+      const request = new NextRequest("https://example.com/auth/logout", {
+        method: "GET",
+        headers: { cookie: "session=user_session_token; auth0_id=user123" }
+      });
+
+      const auth0Request = new Auth0NextRequest(request);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.has("session")).toBe(true);
+      expect(cookies.has("auth0_id")).toBe(true);
+    });
+  });
+});

--- a/src/server/http/auth0-next-request.test.ts
+++ b/src/server/http/auth0-next-request.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server.js";
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Auth0NextRequest } from "./auth0-next-request.js";
 
 describe("Auth0NextRequest", () => {

--- a/src/server/http/auth0-next-request.ts
+++ b/src/server/http/auth0-next-request.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server.js";
+
+import { Auth0RequestCookies } from "./auth0-request-cookies.js";
+import { Auth0Request } from "./auth0-request.js";
+
+/**
+ * An implementation of Auth0Request for Next.js' NextRequest.
+ *
+ * This class wraps NextRequest and provides a unified interface for accessing request
+ * properties like URL, method, headers, body, and cookies. It is used in middleware
+ * and route handlers to abstract away Next.js-specific request handling.
+ *
+ * @example
+ * ```typescript
+ * const auth0Req = new Auth0NextRequest(nextRequest);
+ * const url = auth0Req.getUrl();
+ * const body = await auth0Req.getBody();
+ * const cookies = auth0Req.getCookies();
+ * ```
+ */
+export class Auth0NextRequest extends Auth0Request<NextRequest> {
+  public constructor(req: NextRequest) {
+    /* c8 ignore next */
+    super(req);
+  }
+
+  /**
+   * Retrieves the full URL of the request.
+   *
+   * @returns The URL object representing the request URL.
+   *
+   * @example
+   * ```typescript
+   * const url = auth0Req.getUrl();
+   * const pathname = url.pathname;
+   * const searchParams = url.searchParams;
+   * ```
+   */
+  public getUrl(): URL {
+    return new URL(this.req.nextUrl.href);
+  }
+
+  /**
+   * Retrieves the HTTP method of the request.
+   *
+   * @returns The HTTP method as a string (e.g., "GET", "POST", "PUT", "DELETE").
+   *
+   * @example
+   * ```typescript
+   * const method = auth0Req.getMethod();
+   * if (method === "POST") {
+   *   // Handle POST request
+   * }
+   * ```
+   */
+  public getMethod(): string {
+    return this.req.method as string;
+  }
+
+  /**
+   * Retrieves the body of the request.
+   *
+   * This method reads the entire request body as text. The request body can only be
+   * read once, so cloning the request is necessary if multiple reads are needed.
+   *
+   * @returns A promise that resolves to the body of the request.
+   *
+   * @example
+   * ```typescript
+   * const body = await auth0Req.getBody();
+   * ```
+   */
+  public async getBody(): Promise<string> {
+    return this.req.text();
+  }
+
+  /**
+   * Retrieves the headers of the request.
+   *
+   * @returns The Headers object representing the request headers.
+   *
+   * @example
+   * ```typescript
+   * const headers = auth0Req.getHeaders();
+   * const contentType = headers.get("content-type");
+   * ```
+   */
+  public getHeaders(): Headers {
+    return this.req.headers;
+  }
+
+  /**
+   * Clones the underlying NextRequest.
+   *
+   * @returns A cloned NextRequest object.
+   *
+   * @example
+   * ```typescript
+   * const clonedReq = auth0Req.clone();
+   * ```
+   */
+  public clone(): Request {
+    return this.req.clone();
+  }
+
+  /**
+   * Retrieves the cookies from the request.
+   *
+   * @returns An Auth0RequestCookies object representing the request cookies.
+   *
+   * @example
+   * ```typescript
+   * const cookies = auth0Req.getCookies();
+   * const someCookie = cookies.get("cookieName");
+   * if (someCookie) {
+   *   // Use cookie value
+   * }
+   * ```
+   */
+  public getCookies(): Auth0RequestCookies {
+    return new Auth0RequestCookies(this.req.cookies);
+  }
+}

--- a/src/server/http/auth0-next-response.test.ts
+++ b/src/server/http/auth0-next-response.test.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server.js";
 import { describe, expect, it } from "vitest";
+
 import { Auth0NextResponse } from "./auth0-next-response.js";
 
 describe("Auth0NextResponse", () => {
@@ -40,7 +41,9 @@ describe("Auth0NextResponse", () => {
       auth0Response.redirect("https://example.com/callback");
 
       expect(auth0Response.res.status).toBe(307);
-      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/callback");
+      expect(auth0Response.res.headers.get("location")).toBe(
+        "https://example.com/callback"
+      );
     });
 
     it("should preserve headers from previous response", () => {
@@ -52,7 +55,9 @@ describe("Auth0NextResponse", () => {
       auth0Response.redirect("https://example.com/redirect");
 
       expect(auth0Response.res.headers.get("x-custom")).toBe("value");
-      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/redirect");
+      expect(auth0Response.res.headers.get("location")).toBe(
+        "https://example.com/redirect"
+      );
     });
   });
 
@@ -106,7 +111,9 @@ describe("Auth0NextResponse", () => {
       const data = { token: "abc123", user: { id: 1 } };
       auth0Response.json(data);
 
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
     });
 
     it("should set status code when provided in init", () => {
@@ -124,7 +131,9 @@ describe("Auth0NextResponse", () => {
 
       auth0Response.json({});
 
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
     });
 
     it("should handle nested objects", () => {
@@ -141,7 +150,9 @@ describe("Auth0NextResponse", () => {
       };
       auth0Response.json(data);
 
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
     });
 
     it("should preserve previous headers", () => {
@@ -153,7 +164,9 @@ describe("Auth0NextResponse", () => {
       auth0Response.json({ data: "test" });
 
       expect(auth0Response.res.headers.get("x-custom")).toBe("value");
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
     });
   });
 
@@ -249,7 +262,9 @@ describe("Auth0NextResponse", () => {
 
       auth0Response.json({ data: "test" });
 
-      expect(auth0Response.res.headers.get("content-security-policy")).toBe("default-src 'self'");
+      expect(auth0Response.res.headers.get("content-security-policy")).toBe(
+        "default-src 'self'"
+      );
       expect(auth0Response.res.headers.get("x-frame-options")).toBe("DENY");
     });
   });
@@ -280,8 +295,12 @@ describe("Auth0NextResponse", () => {
         path: "/"
       });
 
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
-      expect(auth0Response.res.headers.get("cache-control")).toContain("no-store");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
+      expect(auth0Response.res.headers.get("cache-control")).toContain(
+        "no-store"
+      );
     });
 
     it("should handle error response", () => {
@@ -294,7 +313,9 @@ describe("Auth0NextResponse", () => {
       );
 
       expect(auth0Response.res.status).toBe(401);
-      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("content-type")).toContain(
+        "application/json"
+      );
     });
 
     it("should handle redirect after login", () => {
@@ -309,7 +330,9 @@ describe("Auth0NextResponse", () => {
       });
 
       expect(auth0Response.res.status).toBe(307);
-      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/dashboard");
+      expect(auth0Response.res.headers.get("location")).toBe(
+        "https://example.com/dashboard"
+      );
     });
 
     it("should handle logout response", () => {
@@ -319,7 +342,9 @@ describe("Auth0NextResponse", () => {
       auth0Response.getCookies().delete("session");
       auth0Response.redirect("https://example.com");
 
-      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/");
+      expect(auth0Response.res.headers.get("location")).toBe(
+        "https://example.com/"
+      );
     });
   });
 });

--- a/src/server/http/auth0-next-response.test.ts
+++ b/src/server/http/auth0-next-response.test.ts
@@ -1,0 +1,325 @@
+import { NextResponse } from "next/server.js";
+import { describe, expect, it } from "vitest";
+import { Auth0NextResponse } from "./auth0-next-response.js";
+
+describe("Auth0NextResponse", () => {
+  describe("getCookies()", () => {
+    it("should return Auth0ResponseCookies object", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      const cookies = auth0Response.getCookies();
+
+      expect(cookies).toBeDefined();
+      expect(typeof cookies.get).toBe("function");
+      expect(typeof cookies.set).toBe("function");
+      expect(typeof cookies.delete).toBe("function");
+    });
+
+    it("should allow setting cookies", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      const cookies = auth0Response.getCookies();
+      expect(() => {
+        cookies.set("session", "token123", {
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          path: "/"
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("redirect()", () => {
+    it("should set redirect location header", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.redirect("https://example.com/callback");
+
+      expect(auth0Response.res.status).toBe(307);
+      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/callback");
+    });
+
+    it("should preserve headers from previous response", () => {
+      const response = new NextResponse(null, {
+        headers: { "x-custom": "value" }
+      });
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.redirect("https://example.com/redirect");
+
+      expect(auth0Response.res.headers.get("x-custom")).toBe("value");
+      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/redirect");
+    });
+  });
+
+  describe("status()", () => {
+    it("should set status code", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.status("Unauthorized", 401);
+
+      expect(auth0Response.res.status).toBe(401);
+    });
+
+    it("should set response body with status", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.status("Not Found", 404);
+
+      expect(auth0Response.res.status).toBe(404);
+    });
+
+    it("should handle null message", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.status(null, 500);
+
+      expect(auth0Response.res.status).toBe(500);
+    });
+
+    it("should support various HTTP status codes", () => {
+      const codes = [200, 201, 204, 400, 401, 403, 404, 500, 502, 503];
+
+      codes.forEach((code) => {
+        const response = NextResponse.next();
+        const auth0Response = new Auth0NextResponse(response);
+
+        auth0Response.status("message", code);
+
+        expect(auth0Response.res.status).toBe(code);
+      });
+    });
+  });
+
+  describe("json()", () => {
+    it("should create JSON response", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      const data = { token: "abc123", user: { id: 1 } };
+      auth0Response.json(data);
+
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+    });
+
+    it("should set status code when provided in init", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.json({ error: "Unauthorized" }, { status: 401 });
+
+      expect(auth0Response.res.status).toBe(401);
+    });
+
+    it("should handle empty object", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.json({});
+
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+    });
+
+    it("should handle nested objects", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      const data = {
+        user: {
+          profile: {
+            name: "John",
+            email: "john@example.com"
+          }
+        }
+      };
+      auth0Response.json(data);
+
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+    });
+
+    it("should preserve previous headers", () => {
+      const response = new NextResponse(null, {
+        headers: { "x-custom": "value" }
+      });
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.json({ data: "test" });
+
+      expect(auth0Response.res.headers.get("x-custom")).toBe("value");
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+    });
+  });
+
+  describe("setResponse()", () => {
+    it("should replace response with new response", () => {
+      const oldResponse = new NextResponse("old body");
+      const auth0Response = new Auth0NextResponse(oldResponse);
+
+      const newResponse = new NextResponse("new body", { status: 201 });
+      auth0Response.setResponse(newResponse);
+
+      expect(auth0Response.res).toBe(newResponse);
+    });
+
+    it("should preserve headers from old response", () => {
+      const oldResponse = new NextResponse("old", {
+        headers: { "x-old": "value" }
+      });
+      const auth0Response = new Auth0NextResponse(oldResponse);
+
+      const newResponse = new NextResponse("new");
+      auth0Response.setResponse(newResponse);
+
+      expect(auth0Response.res.headers.get("x-old")).toBe("value");
+    });
+  });
+
+  describe("addCacheControlHeadersForSession()", () => {
+    it("should set Cache-Control header", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      const cacheControl = auth0Response.res.headers.get("cache-control");
+      expect(cacheControl).toContain("no-cache");
+      expect(cacheControl).toContain("no-store");
+      expect(cacheControl).toContain("must-revalidate");
+      expect(cacheControl).toContain("private");
+    });
+
+    it("should set Pragma header", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      expect(auth0Response.res.headers.get("pragma")).toBe("no-cache");
+    });
+
+    it("should set Expires header", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      expect(auth0Response.res.headers.get("expires")).toBe("0");
+    });
+
+    it("should prevent all forms of caching", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      const cacheControl = auth0Response.res.headers.get("cache-control")!;
+      expect(cacheControl).toContain("max-age=0");
+      expect(cacheControl).toContain("must-revalidate");
+    });
+  });
+
+  describe("header merging", () => {
+    it("should merge custom headers when creating new response", () => {
+      const oldResponse = new NextResponse(null, {
+        headers: { "x-custom": "preserved", "x-another": "value" }
+      });
+      const auth0Response = new Auth0NextResponse(oldResponse);
+
+      auth0Response.json({ data: "test" });
+
+      expect(auth0Response.res.headers.get("x-custom")).toBe("preserved");
+      expect(auth0Response.res.headers.get("x-another")).toBe("value");
+    });
+
+    it("should handle security headers correctly", () => {
+      const oldResponse = new NextResponse(null, {
+        headers: {
+          "content-security-policy": "default-src 'self'",
+          "x-frame-options": "DENY"
+        }
+      });
+      const auth0Response = new Auth0NextResponse(oldResponse);
+
+      auth0Response.json({ data: "test" });
+
+      expect(auth0Response.res.headers.get("content-security-policy")).toBe("default-src 'self'");
+      expect(auth0Response.res.headers.get("x-frame-options")).toBe("DENY");
+    });
+  });
+
+  describe("constructor", () => {
+    it("should store the underlying NextResponse", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      expect(auth0Response.res).toBe(response);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle successful login response", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.json({
+        user: { id: "123", email: "user@example.com" },
+        token: "jwt_token"
+      });
+      auth0Response.addCacheControlHeadersForSession();
+      auth0Response.getCookies().set("session", "session_token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/"
+      });
+
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+      expect(auth0Response.res.headers.get("cache-control")).toContain("no-store");
+    });
+
+    it("should handle error response", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.json(
+        { error: "invalid_grant", error_description: "Invalid credentials" },
+        { status: 401 }
+      );
+
+      expect(auth0Response.res.status).toBe(401);
+      expect(auth0Response.res.headers.get("content-type")).toContain("application/json");
+    });
+
+    it("should handle redirect after login", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.redirect("https://example.com/dashboard");
+      auth0Response.getCookies().set("session", "token", {
+        httpOnly: true,
+        secure: true,
+        path: "/"
+      });
+
+      expect(auth0Response.res.status).toBe(307);
+      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/dashboard");
+    });
+
+    it("should handle logout response", () => {
+      const response = NextResponse.next();
+      const auth0Response = new Auth0NextResponse(response);
+
+      auth0Response.getCookies().delete("session");
+      auth0Response.redirect("https://example.com");
+
+      expect(auth0Response.res.headers.get("location")).toBe("https://example.com/");
+    });
+  });
+});

--- a/src/server/http/auth0-next-response.ts
+++ b/src/server/http/auth0-next-response.ts
@@ -1,0 +1,142 @@
+import { NextResponse } from "next/server.js";
+
+import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+import { Auth0Response } from "./auth0-response.js";
+
+/**
+ * An implementation of Auth0Response for Next.js' NextResponse.
+ *
+ * This class wraps NextResponse and provides a unified interface for setting responses,
+ * managing cookies, and handling redirects. It maintains a copy of headers from the
+ * previous response to support middleware patterns where responses are modified before
+ * being returned.
+ *
+ * @example
+ * ```typescript
+ * const res = new Auth0NextResponse(NextResponse.next());
+ * res.redirect("https://example.com/callback");
+ * ```
+ */
+export class Auth0NextResponse extends Auth0Response<NextResponse> {
+  public constructor(res: NextResponse) {
+    /* c8 ignore next */
+    super(res);
+  }
+
+  /**
+   * Retrieves the cookies from the response.
+   * @returns An Auth0ResponseCookies object representing the response cookies.
+   */
+  public getCookies(): Auth0ResponseCookies {
+    return new Auth0ResponseCookies(this.res.cookies);
+  }
+
+  /**
+   * Redirects the response to the specified URL.
+   *
+   * This method creates a redirect response and merges headers.
+   *
+   * @param url - The URL to redirect to.
+   */
+  public redirect(url: string): void {
+    this.res = this.#mergeHeaders(this.res, NextResponse.redirect(url));
+  }
+
+  /**
+   * Sets the HTTP status code of the response.
+   *
+   * This method creates a new response with the specified status code and message.
+   *
+   * @param message - The response body as a string or null.
+   * @param status - The HTTP status code (e.g., 200, 401, 500).
+   *
+   * @example
+   * ```typescript
+   * res.status("Unauthorized", 401);
+   * ```
+   */
+  public status(message: string | null, status: number): void {
+    const body = status === 204 ? null : message;
+    this.res = this.#mergeHeaders(
+      this.res,
+      new NextResponse(body, { status })
+    );
+  }
+
+  /**
+   * Sends a JSON response with the specified body.
+   *
+   * @param body - The body of the JSON response.
+   * @param init - Optional response initialization options (status, headers, etc.).
+   *
+   * @example
+   * ```typescript
+   * res.json({ error: "Invalid token" }, { status: 401 });
+   * ```
+   */
+  public json(body: any, init?: ResponseInit): void {
+    this.res = this.#mergeHeaders(this.res, NextResponse.json(body, init));
+  }
+
+  /**
+   * Sets the response to a new NextResponse instance, merging headers.
+   *
+   * @param res - The new NextResponse instance to set.
+   *
+   * @example
+   * ```typescript
+   * const newRes = NextResponse.redirect("/login");
+   * auth0Res.setResponse(newRes);
+   * ```
+   */
+  setResponse(res: NextResponse<unknown>): void {
+    this.res = this.#mergeHeaders(this.res, res);
+  }
+
+  /**
+   * Merges headers from the old response into the new response.
+   *
+   * @param oldRes - The old NextResponse instance.
+   * @param newRes - The new NextResponse instance.
+   * @returns The new NextResponse with merged headers.
+   */
+  #mergeHeaders(oldRes: NextResponse, newRes: NextResponse) {
+    // TODO: Should we allow-list here and only copy the expected headers?
+    // TODO: What breaks when we do not copy the headers here?
+    oldRes.headers.forEach((value, key) => {
+      newRes.headers.set(key, value);
+    });
+
+    return newRes;
+  }
+
+  /**
+   * Adds cache control headers to the response to prevent caching of session data.
+   *
+   * This method sets multiple cache control headers to ensure that sensitive session
+   * data (like authentication tokens or user info) is never cached by browsers,
+   * proxies, or CDNs.
+   *
+   * Headers set:
+   * - Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0
+   * - Pragma: no-cache (for HTTP/1.0 compatibility)
+   * - Expires: 0 (for older browser compatibility)
+   *
+   * This should be called for any response containing authenticated user data.
+   *
+   * @example
+   * ```typescript
+   * const res = new Auth0NextResponse(NextResponse.next());
+   * res.json(user);
+   * res.addCacheControlHeadersForSession();
+   * ```
+   */
+  addCacheControlHeadersForSession(): void {
+    this.res.headers.set(
+      "Cache-Control",
+      "private, no-cache, no-store, must-revalidate, max-age=0"
+    );
+    this.res.headers.set("Pragma", "no-cache");
+    this.res.headers.set("Expires", "0");
+  }
+}

--- a/src/server/http/auth0-next-response.ts
+++ b/src/server/http/auth0-next-response.ts
@@ -59,10 +59,7 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
    */
   public status(message: string | null, status: number) {
     const body = status === 204 ? null : message;
-    this.res = this.#mergeHeaders(
-      this.res,
-      new NextResponse(body, { status })
-    );
+    this.res = this.#mergeHeaders(this.res, new NextResponse(body, { status }));
 
     return this;
   }

--- a/src/server/http/auth0-next-response.ts
+++ b/src/server/http/auth0-next-response.ts
@@ -84,6 +84,12 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
     return this;
   }
 
+  public generic(body: any, init?: ResponseInit) {
+    this.res = this.#mergeHeaders(this.res, new NextResponse(body, init));
+
+    return this;
+  }
+
   /**
    * Sets the response to a new NextResponse instance, merging headers.
    *

--- a/src/server/http/auth0-next-response.ts
+++ b/src/server/http/auth0-next-response.ts
@@ -38,8 +38,10 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
    *
    * @param url - The URL to redirect to.
    */
-  public redirect(url: string): void {
+  public redirect(url: string) {
     this.res = this.#mergeHeaders(this.res, NextResponse.redirect(url));
+
+    return this;
   }
 
   /**
@@ -55,12 +57,14 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
    * res.status("Unauthorized", 401);
    * ```
    */
-  public status(message: string | null, status: number): void {
+  public status(message: string | null, status: number) {
     const body = status === 204 ? null : message;
     this.res = this.#mergeHeaders(
       this.res,
       new NextResponse(body, { status })
     );
+
+    return this;
   }
 
   /**
@@ -74,8 +78,10 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
    * res.json({ error: "Invalid token" }, { status: 401 });
    * ```
    */
-  public json(body: any, init?: ResponseInit): void {
+  public json(body: any, init?: ResponseInit) {
     this.res = this.#mergeHeaders(this.res, NextResponse.json(body, init));
+
+    return this;
   }
 
   /**

--- a/src/server/http/auth0-next-response.ts
+++ b/src/server/http/auth0-next-response.ts
@@ -116,7 +116,7 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
     // we ensure to copy it to the new response.
     const headers = ["Cache-Control", "Pragma", "Expires"];
 
-    headers.forEach(name => {
+    headers.forEach((name) => {
       const originalHeader = oldRes.headers.get(name);
 
       if (originalHeader) {
@@ -126,9 +126,9 @@ export class Auth0NextResponse extends Auth0Response<NextResponse> {
 
     // If we have cookies defined on the response,
     // ensure to carry them over to the new response.
-    oldRes.cookies.getAll().forEach(cookie => {
+    oldRes.cookies.getAll().forEach((cookie) => {
       newRes.cookies.set(cookie.name, cookie.value, cookie);
-    })
+    });
 
     return newRes;
   }

--- a/src/server/http/auth0-request-cookies.test.ts
+++ b/src/server/http/auth0-request-cookies.test.ts
@@ -1,0 +1,350 @@
+import { RequestCookies } from "@edge-runtime/cookies";
+import { describe, expect, it } from "vitest";
+import { Auth0RequestCookies } from "./auth0-request-cookies.js";
+
+describe("Auth0RequestCookies", () => {
+  describe("get()", () => {
+    it("should retrieve a cookie by name", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123; theme=dark" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const cookie = auth0Cookies.get("session");
+
+      expect(cookie).toEqual({ name: "session", value: "abc123" });
+    });
+
+    it("should return undefined for non-existent cookie", () => {
+      const cookies = new RequestCookies(new Headers({ cookie: "session=abc123" }));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const cookie = auth0Cookies.get("nonexistent");
+
+      expect(cookie).toBeUndefined();
+    });
+
+    it("should handle cookies with special characters in value", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc%20123%2Fdef" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const cookie = auth0Cookies.get("session");
+
+      expect(cookie?.value).toBe("abc 123/def");
+    });
+
+    it("should handle cookies with equals sign in value", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "jwt=eyJhbGc=value" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const cookie = auth0Cookies.get("jwt");
+
+      expect(cookie?.value).toContain("=");
+    });
+
+    it("should handle empty cookie string", () => {
+      const cookies = new RequestCookies(new Headers({ cookie: "" }));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const cookie = auth0Cookies.get("session");
+
+      expect(cookie).toBeUndefined();
+    });
+  });
+
+  describe("getAll()", () => {
+    it("should retrieve all cookies", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123; theme=dark; lang=en" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies).toHaveLength(3);
+      expect(allCookies).toEqual(
+        expect.arrayContaining([
+          { name: "session", value: "abc123" },
+          { name: "theme", value: "dark" },
+          { name: "lang", value: "en" }
+        ])
+      );
+    });
+
+    it("should return empty array when no cookies", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies).toEqual([]);
+    });
+
+    it("should return array of objects with name and value", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies).toHaveLength(1);
+      expect(allCookies[0]).toHaveProperty("name");
+      expect(allCookies[0]).toHaveProperty("value");
+    });
+
+    it("should handle chunked cookies from large sessions", () => {
+      const cookies = new RequestCookies(
+        new Headers({
+          cookie: "session__0=chunk1; session__1=chunk2; session__2=chunk3"
+        })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies.length).toBeGreaterThanOrEqual(3);
+      expect(allCookies.map((c) => c.name)).toContain("session__0");
+      expect(allCookies.map((c) => c.name)).toContain("session__1");
+      expect(allCookies.map((c) => c.name)).toContain("session__2");
+    });
+  });
+
+  describe("has()", () => {
+    it("should return true if cookie exists", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(auth0Cookies.has("session")).toBe(true);
+    });
+
+    it("should return false if cookie does not exist", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(auth0Cookies.has("nonexistent")).toBe(false);
+    });
+
+    it("should be case-sensitive", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "Session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(auth0Cookies.has("Session")).toBe(true);
+      expect(auth0Cookies.has("session")).toBe(false);
+    });
+
+    it("should return false for empty cookie jar", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(auth0Cookies.has("any")).toBe(false);
+    });
+  });
+
+  describe("set()", () => {
+    it("should set a cookie value", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("newcookie", "value123");
+
+      expect(auth0Cookies.has("newcookie")).toBe(true);
+      expect(auth0Cookies.get("newcookie")).toEqual({
+        name: "newcookie",
+        value: "value123"
+      });
+    });
+
+    it("should update existing cookie", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=old" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("session", "new");
+
+      expect(auth0Cookies.get("session")).toEqual({
+        name: "session",
+        value: "new"
+      });
+    });
+
+    it("should handle cookie values with special characters", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("token", "eyJhbGc=");
+
+      expect(auth0Cookies.get("token")?.value).toBe("eyJhbGc=");
+    });
+
+    it("should handle empty cookie value", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("empty", "");
+
+      expect(auth0Cookies.get("empty")).toEqual({
+        name: "empty",
+        value: ""
+      });
+    });
+
+    it("should enable read-after-write in middleware", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("session", "new_value");
+
+      // Should be able to read the value immediately
+      expect(auth0Cookies.get("session")).toEqual({
+        name: "session",
+        value: "new_value"
+      });
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a cookie", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.delete("session");
+
+      expect(auth0Cookies.has("session")).toBe(false);
+      expect(auth0Cookies.get("session")).toBeUndefined();
+    });
+
+    it("should handle deleting non-existent cookie", () => {
+      const cookies = new RequestCookies(new Headers({}));
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(() => {
+        auth0Cookies.delete("nonexistent");
+      }).not.toThrow();
+    });
+
+    it("should not affect other cookies", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123; theme=dark" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.delete("session");
+
+      expect(auth0Cookies.has("theme")).toBe(true);
+      expect(auth0Cookies.get("theme")).toEqual({
+        name: "theme",
+        value: "dark"
+      });
+    });
+
+    it("should handle deleting chunked cookies", () => {
+      const cookies = new RequestCookies(
+        new Headers({
+          cookie: "session__0=chunk1; session__1=chunk2; other=value"
+        })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.delete("session__0");
+
+      expect(auth0Cookies.has("session__0")).toBe(false);
+      expect(auth0Cookies.has("other")).toBe(true);
+    });
+  });
+
+  describe("constructor", () => {
+    it("should accept RequestCookies", () => {
+      const cookies = new RequestCookies(new Headers({}));
+
+      expect(() => {
+        new Auth0RequestCookies(cookies);
+      }).not.toThrow();
+    });
+
+    it("should store reference to cookies", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      expect(auth0Cookies.has("session")).toBe(true);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should retrieve session cookie for authentication", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "auth0_session=session_token_123" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const sessionCookie = auth0Cookies.get("auth0_session");
+
+      expect(sessionCookie).toEqual({
+        name: "auth0_session",
+        value: "session_token_123"
+      });
+    });
+
+    it("should handle multiple auth-related cookies", () => {
+      const cookies = new RequestCookies(
+        new Headers({
+          cookie:
+            "auth0_session=token1; auth0_nonce=nonce123; auth0_state=state456"
+        })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies).toHaveLength(3);
+      expect(allCookies.map((c) => c.name)).toContain("auth0_session");
+      expect(allCookies.map((c) => c.name)).toContain("auth0_nonce");
+      expect(allCookies.map((c) => c.name)).toContain("auth0_state");
+    });
+
+    it("should handle cookie update scenario", () => {
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "auth0_session=old_token" })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.set("auth0_session", "new_token");
+
+      expect(auth0Cookies.get("auth0_session")).toEqual({
+        name: "auth0_session",
+        value: "new_token"
+      });
+    });
+
+    it("should handle cookie cleanup on logout", () => {
+      const cookies = new RequestCookies(
+        new Headers({
+          cookie: "auth0_session=token; auth0_nonce=nonce; preferences=dark"
+        })
+      );
+      const auth0Cookies = new Auth0RequestCookies(cookies);
+
+      auth0Cookies.delete("auth0_session");
+      auth0Cookies.delete("auth0_nonce");
+
+      expect(auth0Cookies.has("auth0_session")).toBe(false);
+      expect(auth0Cookies.has("auth0_nonce")).toBe(false);
+      expect(auth0Cookies.has("preferences")).toBe(true);
+    });
+  });
+});

--- a/src/server/http/auth0-request-cookies.test.ts
+++ b/src/server/http/auth0-request-cookies.test.ts
@@ -1,5 +1,6 @@
 import { RequestCookies } from "@edge-runtime/cookies";
 import { describe, expect, it } from "vitest";
+
 import { Auth0RequestCookies } from "./auth0-request-cookies.js";
 
 describe("Auth0RequestCookies", () => {
@@ -16,7 +17,9 @@ describe("Auth0RequestCookies", () => {
     });
 
     it("should return undefined for non-existent cookie", () => {
-      const cookies = new RequestCookies(new Headers({ cookie: "session=abc123" }));
+      const cookies = new RequestCookies(
+        new Headers({ cookie: "session=abc123" })
+      );
       const auth0Cookies = new Auth0RequestCookies(cookies);
 
       const cookie = auth0Cookies.get("nonexistent");

--- a/src/server/http/auth0-request-cookies.ts
+++ b/src/server/http/auth0-request-cookies.ts
@@ -1,0 +1,115 @@
+import { ReadonlyRequestCookies, RequestCookies } from "../cookies.js";
+
+/**
+ * A wrapper around RequestCookies to provide a unified interface for reading and
+ * modifying cookies in request contexts.
+ *
+ * This class abstracts the @edge-runtime/cookies library and provides a simple
+ * interface for authentication logic to interact with request cookies. It supports
+ * both readonly contexts (like middleware) and writable contexts.
+ *
+ * Cookie values are parsed from the Cookie header and may be user-controlled.
+ * All cookie values should be treated as untrusted and validated before use in
+ * security decisions.
+ *
+ * Implementation notes:
+ * - Cookies are HTTP-only and cannot be modified by JavaScript on the client-side
+ * - Cookie values may contain special characters and should be URL-encoded
+ * - Large cookies are chunked (e.g., __session__0, __session__1) by the abstraction layer
+ * - Changes made via set() or delete() are propagated to the response
+ *
+ * Security considerations:
+ * - Never trust cookie values for authentication (validate signatures/tokens)
+ * - Use secure, HttpOnly, and SameSite flags when setting cookies (handled by abstraction)
+ * - Be aware of cookie size limits (typically 4KB per cookie)
+ * - Consider cookie expiration times to limit exposure of compromised cookies
+ *
+ * @example
+ * ```typescript
+ * const cookies = auth0Req.getCookies();
+ *
+ * // Get a single cookie
+ * const sessionCookie = cookies.get("auth0-session");
+ * if (sessionCookie) {
+ *   const sessionValue = sessionCookie.value;
+ * }
+ *
+ * // Get all cookies
+ * const allCookies = cookies.getAll();
+ *
+ * // Check if a cookie exists
+ * if (cookies.has("auth0-session")) {
+ *   // Cookie exists
+ * }
+ *
+ * // Modify cookies (for request context, enables read-after-write)
+ * cookies.set("new-cookie", "value");
+ * cookies.delete("old-cookie");
+ * ```
+ */
+export class Auth0RequestCookies {
+  constructor(
+    private cookies: ReadonlyRequestCookies | RequestCookies
+  ) {}
+
+  /**
+   * Retrieves a cookie by name.
+   *
+   * Returns undefined if the cookie does not exist.
+   *
+   * @param name The name of the cookie to retrieve.
+   * @returns An object containing the name and value of the cookie, or undefined if not found.
+   */
+  get(name: string): { name: string; value: string } | undefined {
+    const value = this.cookies.get(name);
+    if (value === undefined) {
+      return undefined;
+    }
+    return { name, value: value.value };
+  }
+
+  /**
+   * Retrieves all cookies.
+   *
+   * @returns An array of objects containing the names and values of all cookies.
+   */
+  getAll(): Array<{ name: string; value: string }> {
+    return this.cookies.getAll().map((cookie) => ({
+      name: cookie.name,
+      value: cookie.value
+    }));
+  }
+
+  /**
+   * Checks if a cookie exists by name.
+   *
+   * @param name The name of the cookie to check.
+   * @returns True if the cookie exists, false otherwise.
+   */
+  has(name: string): boolean {
+    return this.cookies.has(name);
+  }
+
+  /**
+   * Sets a cookie value.
+   *
+   * This method enables read-after-write in middleware contexts, allowing subsequent
+   * requests to see the cookie value that was just set. The actual cookie is set on
+   * the response via the response cookies abstraction.
+   *
+   * @param name The name of the cookie to set.
+   * @param value The value of the cookie to set. Should be URL-encoded if needed.
+   */
+  set(name: string, value: string): void {
+    this.cookies.set(name, value);
+  }
+
+  /**
+   * Deletes a cookie by name.
+   *
+   * @param name The name of the cookie to delete.
+   */
+  delete(name: string): void {
+    this.cookies.delete(name);
+  }
+}

--- a/src/server/http/auth0-request-cookies.ts
+++ b/src/server/http/auth0-request-cookies.ts
@@ -48,9 +48,7 @@ import { ReadonlyRequestCookies, RequestCookies } from "../cookies.js";
  * ```
  */
 export class Auth0RequestCookies {
-  constructor(
-    private cookies: ReadonlyRequestCookies | RequestCookies
-  ) {}
+  constructor(private cookies: ReadonlyRequestCookies | RequestCookies) {}
 
   /**
    * Retrieves a cookie by name.

--- a/src/server/http/auth0-request.ts
+++ b/src/server/http/auth0-request.ts
@@ -1,0 +1,80 @@
+import { Auth0RequestCookies } from "./auth0-request-cookies.js";
+
+/**
+ * An abstract representation of an HTTP request.
+ *
+ * This base class defines the interface for accessing request data without coupling
+ * to specific Next.js request types. Implementations provide access to URL, HTTP method,
+ * headers, body, cookies, and cloning capabilities.
+ *
+ * The abstraction enables:
+ * - Support for multiple request types (NextRequest, NextApiRequest, etc.)
+ * - Cleaner authentication logic that works with any implementation
+ * - Easier testing through mock implementations
+ *
+ * @template TRequest The underlying request type (e.g., NextRequest, NextApiRequest)
+ *
+ * @example
+ * ```typescript
+ * // Implementation for NextRequest
+ * class Auth0NextRequest extends Auth0Request<NextRequest> {
+ *   public getUrl(): URL { return this.req.nextUrl; }
+ *   // ... other methods
+ * }
+ *
+ * // Usage in authentication logic
+ * function handleAuth(req: Auth0Request): void {
+ *   const url = req.getUrl();
+ *   const method = req.getMethod();
+ *   const body = await req.getBody();
+ * }
+ * ```
+ */
+export abstract class Auth0Request<TRequest = any> {
+  protected constructor(public req: TRequest) {}
+
+  /**
+   * Retrieves the full URL of the request.
+   *
+   * @returns The URL object representing the request URL with pathname, search params, etc.
+   */
+  public abstract getUrl(): URL;
+
+  /**
+   * Retrieves the HTTP method of the request.
+   *
+   * @returns The HTTP method as a string (e.g., "GET", "POST", "PUT", "DELETE", "PATCH").
+   */
+  public abstract getMethod(): string;
+
+  /**
+   * Retrieves the body of the request.
+   *
+   * @returns Either a Promise or direct value containing the request body as text
+   */
+  public abstract getBody():
+    | Promise<Record<string, string> | string>
+    | Record<string, string>
+    | string;
+
+  /**
+   * Retrieves the headers of the request.
+   *
+   * @returns The Headers object representing the request headers.
+   */
+  public abstract getHeaders(): Headers;
+
+  /**
+   * Clones the underlying request.
+   *
+   * @returns A cloned Request object that is independent of the original.
+   */
+  public abstract clone(): Request;
+
+  /**
+   * Retrieves the cookies from the request.
+   *
+   * @returns An Auth0RequestCookies object providing a unified interface to cookies.
+   */
+  public abstract getCookies(): Auth0RequestCookies;
+}

--- a/src/server/http/auth0-response-cookies.test.ts
+++ b/src/server/http/auth0-response-cookies.test.ts
@@ -1,0 +1,429 @@
+import { NextResponse } from "next/server.js";
+import { describe, expect, it } from "vitest";
+import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+
+describe("Auth0ResponseCookies", () => {
+  describe("get()", () => {
+    it("should retrieve a cookie by name", () => {
+      const response = NextResponse.next();
+      response.cookies.set("session", "abc123", { httpOnly: true });
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+      const cookie = auth0Cookies.get("session");
+
+      expect(cookie).toBeDefined();
+      expect(cookie?.name).toBe("session");
+      expect(cookie?.value).toBe("abc123");
+    });
+
+    it("should return undefined for non-existent cookie", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const cookie = auth0Cookies.get("nonexistent");
+
+      expect(cookie).toBeUndefined();
+    });
+
+    it("should retrieve cookie attributes", () => {
+      const response = NextResponse.next();
+      response.cookies.set("session", "token123", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        maxAge: 86400
+      });
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+      const cookie = auth0Cookies.get("session");
+
+      expect(cookie?.httpOnly).toBe(true);
+      expect(cookie?.secure).toBe(true);
+      expect(cookie?.sameSite).toBe("lax");
+    });
+  });
+
+  describe("getAll()", () => {
+    it("should retrieve all cookies", () => {
+      const response = NextResponse.next();
+      response.cookies.set("session", "token1");
+      response.cookies.set("preferences", "dark");
+      response.cookies.set("theme", "modern");
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+      const allCookies = auth0Cookies.getAll();
+
+      expect(allCookies.length).toBeGreaterThanOrEqual(3);
+      expect(allCookies.map((c) => c.name)).toContain("session");
+      expect(allCookies.map((c) => c.name)).toContain("preferences");
+      expect(allCookies.map((c) => c.name)).toContain("theme");
+    });
+
+    it("should return empty array when no cookies set", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const allCookies = auth0Cookies.getAll();
+
+      expect(Array.isArray(allCookies)).toBe(true);
+    });
+
+    it("should support filtering by name pattern", () => {
+      const response = NextResponse.next();
+      response.cookies.set("session", "token1");
+      response.cookies.set("session__0", "chunk1");
+      response.cookies.set("session__1", "chunk2");
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+      const filtered = auth0Cookies.getAll("session");
+
+      expect(filtered).toBeDefined();
+    });
+  });
+
+  describe("has()", () => {
+    it("should return true if cookie exists", () => {
+      const response = NextResponse.next();
+      response.cookies.set("session", "token");
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      expect(auth0Cookies.has("session")).toBe(true);
+    });
+
+    it("should return false if cookie does not exist", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      expect(auth0Cookies.has("nonexistent")).toBe(false);
+    });
+
+    it("should be case-sensitive", () => {
+      const response = NextResponse.next();
+      response.cookies.set("Session", "token");
+
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      expect(auth0Cookies.has("Session")).toBe(true);
+      expect(auth0Cookies.has("session")).toBe(false);
+    });
+  });
+
+  describe("set()", () => {
+    it("should set a cookie with name and value", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("newcookie", "value123");
+
+      expect(auth0Cookies.has("newcookie")).toBe(true);
+      expect(auth0Cookies.get("newcookie")?.value).toBe("value123");
+    });
+
+    it("should set cookie with HttpOnly flag", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { httpOnly: true });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.httpOnly).toBe(true);
+    });
+
+    it("should set cookie with Secure flag", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { secure: true });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.secure).toBe(true);
+    });
+
+    it("should set cookie with SameSite flag", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { sameSite: "strict" });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.sameSite).toBe("strict");
+    });
+
+    it("should set cookie with maxAge", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { maxAge: 86400 });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.maxAge).toBe(86400);
+    });
+
+    it("should set cookie with path", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { path: "/auth" });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.path).toBe("/auth");
+    });
+
+    it("should set cookie with domain", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { domain: ".example.com" });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.domain).toBe(".example.com");
+    });
+
+    it("should allow method chaining", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const result = auth0Cookies.set("cookie1", "value1").set("cookie2", "value2");
+
+      expect(result).toBe(auth0Cookies);
+      expect(auth0Cookies.has("cookie1")).toBe(true);
+      expect(auth0Cookies.has("cookie2")).toBe(true);
+    });
+
+    it("should handle large cookie values", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const largeValue = "x".repeat(3000);
+      auth0Cookies.set("large", largeValue);
+
+      const cookie = auth0Cookies.get("large");
+      expect(cookie?.value).toBe(largeValue);
+    });
+
+    it("should handle cookie values with special characters", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+      auth0Cookies.set("jwt", jwtToken);
+
+      const cookie = auth0Cookies.get("jwt");
+      expect(cookie?.value).toBe(jwtToken);
+    });
+
+    it("should handle empty cookie value", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("empty", "");
+
+      const cookie = auth0Cookies.get("empty");
+      expect(cookie?.value).toBe("");
+    });
+
+    it("should update existing cookie", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "old_value");
+      auth0Cookies.set("session", "new_value");
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.value).toBe("new_value");
+    });
+
+    it("should automatically chunk very large cookies", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      // Create a value larger than the chunk size (3500 bytes)
+      const largeValue = "x".repeat(4000);
+      auth0Cookies.set("large", largeValue);
+
+      // Check if chunked cookies are created
+      const allCookies = auth0Cookies.getAll();
+      const largeRelatedCookies = allCookies.filter((c) =>
+        c.name.startsWith("large")
+      );
+
+      expect(largeRelatedCookies.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a cookie", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token");
+      auth0Cookies.delete("session");
+
+      // After deletion, the cookie should be set with an expiration date in the past
+      const setCookieHeader = response.headers.get("set-cookie");
+      expect(setCookieHeader).toContain("session=");
+    });
+
+    it("should not affect other cookies when deleting", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token1");
+      auth0Cookies.set("preferences", "dark");
+      auth0Cookies.delete("session");
+
+      expect(auth0Cookies.has("preferences")).toBe(true);
+    });
+
+    it("should handle deleting non-existent cookie", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      expect(() => {
+        auth0Cookies.delete("nonexistent");
+      }).not.toThrow();
+    });
+
+    it("should allow method chaining", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("cookie1", "value1");
+      auth0Cookies.set("cookie2", "value2");
+
+      const result = auth0Cookies.delete("cookie1").delete("cookie2");
+
+      expect(result).toBe(auth0Cookies);
+      const setCookieHeader = response.headers.get("set-cookie");
+      expect(setCookieHeader).toContain("cookie1=");
+      expect(setCookieHeader).toContain("cookie2=");
+    });
+
+    it("should handle deleting chunked cookies", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      const largeValue = "x".repeat(4000);
+      auth0Cookies.set("large", largeValue);
+      auth0Cookies.delete("large");
+
+      const setCookieHeader = response.headers.get("set-cookie");
+      expect(setCookieHeader).toContain("large");
+    });
+
+    it("should support delete options with path", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { path: "/auth" });
+
+      expect(() => {
+        auth0Cookies.delete({ name: "session", path: "/auth" });
+      }).not.toThrow();
+    });
+
+    it("should support delete options with domain", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("session", "token", { domain: ".example.com" });
+
+      expect(() => {
+        auth0Cookies.delete({ name: "session", domain: ".example.com" });
+      }).not.toThrow();
+    });
+  });
+
+  describe("constructor", () => {
+    it("should accept ResponseCookies", () => {
+      const response = NextResponse.next();
+
+      expect(() => {
+        new Auth0ResponseCookies(response.cookies);
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should set secure session cookie", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies.set("auth0_session", "session_token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 86400
+      });
+
+      const cookie = auth0Cookies.get("auth0_session");
+      expect(cookie?.httpOnly).toBe(true);
+      expect(cookie?.secure).toBe(true);
+      expect(cookie?.sameSite).toBe("lax");
+      expect(cookie?.maxAge).toBe(86400);
+    });
+
+    it("should handle login flow with multiple cookies", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      auth0Cookies
+        .set("auth0_session", "session_token", { httpOnly: true, secure: true })
+        .set("auth0_nonce", "nonce123", { httpOnly: true, secure: true })
+        .set("auth0_state", "state456", { httpOnly: true, secure: true });
+
+      expect(auth0Cookies.has("auth0_session")).toBe(true);
+      expect(auth0Cookies.has("auth0_nonce")).toBe(true);
+      expect(auth0Cookies.has("auth0_state")).toBe(true);
+    });
+
+    it("should handle logout flow by deleting cookies", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      // Set cookies
+      auth0Cookies.set("auth0_session", "token");
+      auth0Cookies.set("auth0_nonce", "nonce");
+
+      // Delete on logout
+      auth0Cookies.delete("auth0_session").delete("auth0_nonce");
+
+      const setCookieHeader = response.headers.get("set-cookie");
+      expect(setCookieHeader).toContain("auth0_session=");
+      expect(setCookieHeader).toContain("auth0_nonce=");
+    });
+
+    it("should handle large JWT tokens", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      // Simulate a large JWT token
+      const jwtToken =
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+        "x".repeat(2000) +
+        ".signature";
+
+      auth0Cookies.set("id_token", jwtToken, { httpOnly: true });
+
+      const cookie = auth0Cookies.get("id_token");
+      expect(cookie?.value).toBe(jwtToken);
+    });
+
+    it("should handle cookie renewal scenario", () => {
+      const response = NextResponse.next();
+      const auth0Cookies = new Auth0ResponseCookies(response.cookies);
+
+      // Set initial cookie
+      auth0Cookies.set("session", "old_token", { maxAge: 3600 });
+
+      // Renew cookie with new token
+      auth0Cookies.set("session", "new_token", { maxAge: 86400 });
+
+      const cookie = auth0Cookies.get("session");
+      expect(cookie?.value).toBe("new_token");
+      expect(cookie?.maxAge).toBe(86400);
+    });
+  });
+});

--- a/src/server/http/auth0-response-cookies.test.ts
+++ b/src/server/http/auth0-response-cookies.test.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server.js";
 import { describe, expect, it } from "vitest";
+
 import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
 
 describe("Auth0ResponseCookies", () => {
@@ -184,7 +185,9 @@ describe("Auth0ResponseCookies", () => {
       const response = NextResponse.next();
       const auth0Cookies = new Auth0ResponseCookies(response.cookies);
 
-      const result = auth0Cookies.set("cookie1", "value1").set("cookie2", "value2");
+      const result = auth0Cookies
+        .set("cookie1", "value1")
+        .set("cookie2", "value2");
 
       expect(result).toBe(auth0Cookies);
       expect(auth0Cookies.has("cookie1")).toBe(true);
@@ -206,7 +209,8 @@ describe("Auth0ResponseCookies", () => {
       const response = NextResponse.next();
       const auth0Cookies = new Auth0ResponseCookies(response.cookies);
 
-      const jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+      const jwtToken =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
       auth0Cookies.set("jwt", jwtToken);
 
       const cookie = auth0Cookies.get("jwt");

--- a/src/server/http/auth0-response-cookies.ts
+++ b/src/server/http/auth0-response-cookies.ts
@@ -27,13 +27,11 @@ import { ResponseCookies } from "../cookies.js";
  * ```
  */
 export class Auth0ResponseCookies {
-  constructor(
-    private responseCookies: ResponseCookies
-  ) {}
+  constructor(private responseCookies: ResponseCookies) {}
 
   /**
    * Retrieves a cookie by name.
-   * 
+   *
    * @param name The name of the cookie to retrieve.
    * @returns The cookie object if found, undefined otherwise.
    */
@@ -43,7 +41,7 @@ export class Auth0ResponseCookies {
 
   /**
    * Retrieves all cookies.
-   * 
+   *
    * @returns An array of all cookies with their attributes.
    */
   getAll(...args: Parameters<ResponseCookies["getAll"]>) {
@@ -110,14 +108,14 @@ export class Auth0ResponseCookies {
     const nameOrOptions = nameOrOptionsArgs[0];
 
     if (typeof nameOrOptions === "string") {
-      this.responseCookies.set(nameOrOptions, '', {
-        maxAge: 0,
+      this.responseCookies.set(nameOrOptions, "", {
+        maxAge: 0
       });
     } else {
       const { name, ...restOptions } = nameOrOptions;
-      this.responseCookies.set(name, '', {
+      this.responseCookies.set(name, "", {
         ...restOptions,
-        maxAge: 0,
+        maxAge: 0
       });
     }
 

--- a/src/server/http/auth0-response-cookies.ts
+++ b/src/server/http/auth0-response-cookies.ts
@@ -1,0 +1,126 @@
+import { ResponseCookies } from "../cookies.js";
+
+/**
+ * A wrapper around ResponseCookies to provide a unified interface for setting
+ * response cookies across different Next.js contexts.
+ *
+ * @example
+ * ```typescript
+ * const cookies = auth0Res.getCookies();
+ *
+ * // Set a cookie with options
+ * cookies.set("session", "token123", {
+ *   httpOnly: true,
+ *   secure: true,
+ *   sameSite: "lax",
+ *   maxAge: 86400, // 1 day
+ *   path: "/"
+ * });
+ *
+ * // Delete a cookie
+ * cookies.delete("session");
+ *
+ * // Check if a cookie exists
+ * if (cookies.has("session")) {
+ *   const cookie = cookies.get("session");
+ * }
+ * ```
+ */
+export class Auth0ResponseCookies {
+  constructor(
+    private responseCookies: ResponseCookies
+  ) {}
+
+  /**
+   * Retrieves a cookie by name.
+   * 
+   * @param name The name of the cookie to retrieve.
+   * @returns The cookie object if found, undefined otherwise.
+   */
+  get(name: string) {
+    return this.responseCookies.get(name);
+  }
+
+  /**
+   * Retrieves all cookies.
+   * 
+   * @returns An array of all cookies with their attributes.
+   */
+  getAll(...args: Parameters<ResponseCookies["getAll"]>) {
+    return this.responseCookies.getAll(...args);
+  }
+
+  /**
+   * Checks if a cookie exists by name.
+
+   * @param name The name of the cookie to check.
+   * @returns True if the cookie exists, false otherwise.
+   */
+  has(name: string): boolean {
+    return this.responseCookies.has(name);
+  }
+
+  /**
+   * Sets a cookie with the specified name, value, and options.
+   *
+   * This method supports setting cookies with full control over attributes like
+   * HttpOnly, Secure, SameSite, maxAge, path, and domain. Large cookie values
+   * are automatically chunked into multiple cookies if needed.
+   *
+   * Returns this for method chaining.
+   *
+   * @param args Arguments passed to ResponseCookies.set(). Typically:
+   *   - name: string - The cookie name
+   *   - value: string - The cookie value
+   *   - options: CookieOptions - Cookie attributes (httpOnly, secure, sameSite, etc.)
+   *
+   * @returns Returns this for method chaining (fluent API).
+   *
+   * @example
+   * ```typescript
+   * cookies
+   *   .set("session", "token", { httpOnly: true, secure: true })
+   *   .set("preferences", "dark-mode", { httpOnly: false });
+   * ```
+   */
+  set(...args: Parameters<ResponseCookies["set"]>) {
+    this.responseCookies.set(...args);
+    return this;
+  }
+
+  /**
+   * Deletes a cookie by name.
+   *
+   * This method removes a cookie from the response by setting an expiration time
+   * in the past.
+   *
+   * @param args Arguments passed to ResponseCookies.delete(). Typically:
+   *   - name: string - The cookie name
+   *   - options?: { path?: string, domain?: string } - Cookie removal options
+   *
+   * @returns Returns this for method chaining (fluent API).
+   *
+   * @example
+   * ```typescript
+   * cookies
+   *   .delete("cookieName");
+   * ```
+   */
+  delete(...nameOrOptionsArgs: Parameters<ResponseCookies["delete"]>) {
+    const nameOrOptions = nameOrOptionsArgs[0];
+
+    if (typeof nameOrOptions === "string") {
+      this.responseCookies.set(nameOrOptions, '', {
+        maxAge: 0,
+      });
+    } else {
+      const { name, ...restOptions } = nameOrOptions;
+      this.responseCookies.set(name, '', {
+        ...restOptions,
+        maxAge: 0,
+      });
+    }
+
+    return this;
+  }
+}

--- a/src/server/http/auth0-response.ts
+++ b/src/server/http/auth0-response.ts
@@ -56,7 +56,7 @@ export abstract class Auth0Response<TResponse = any> {
    *
    * @param url - The URL to redirect to. Should be validated before calling this method.
    */
-  abstract redirect(url: string): void;
+  abstract redirect(url: string): Auth0Response<TResponse>;
 
   /**
    * Sets the HTTP status code of the response.
@@ -67,7 +67,7 @@ export abstract class Auth0Response<TResponse = any> {
    * @param message - The response body as a string or null.
    * @param status - The HTTP status code (e.g., 200, 401, 500).
    */
-  abstract status(message: string | null, status: number): TResponse | void;
+  abstract status(message: string | null, status: number): Auth0Response<TResponse>;
 
   /**
    * Sends a JSON response with the specified body.
@@ -82,7 +82,7 @@ export abstract class Auth0Response<TResponse = any> {
    *   user data, or other structured data.
    * @param init - Optional response initialization options (status, headers, etc.).
    */
-  abstract json(body: any, init?: ResponseInit): void;
+  abstract json(body: any, init?: ResponseInit): Auth0Response<TResponse>;
 
   /**
    * Adds cache control headers to the response to prevent caching of sensitive data.

--- a/src/server/http/auth0-response.ts
+++ b/src/server/http/auth0-response.ts
@@ -61,11 +61,10 @@ export abstract class Auth0Response<TResponse = any> {
   /**
    * Sets the HTTP status code of the response.
    *
-   * Note: The return type may be void or the response object, but all implementations
-   * use side effects to modify internal state.
-   *
    * @param message - The response body as a string or null.
    * @param status - The HTTP status code (e.g., 200, 401, 500).
+   * 
+   * @returns This response object for method chaining.
    */
   abstract status(message: string | null, status: number): Auth0Response<TResponse>;
 
@@ -75,14 +74,24 @@ export abstract class Auth0Response<TResponse = any> {
    * This method automatically sets the Content-Type header to application/json and
    * serializes the body parameter as JSON.
    *
-   * Security: Be careful not to include sensitive data (like internal error details)
-   * in JSON responses, as this information could aid attackers.
+   * @param body - The response body to be serialized as JSON. May include error details,
+   *   user data, or other structured data.
+   * @param init - Optional response initialization options (status, headers, etc.).
+   * 
+   * @returns This response object for method chaining.
+   */
+  abstract json(body: any, init?: ResponseInit): Auth0Response<TResponse>;
+
+  /**
+   * Sends a Generic response with the specified body.
    *
    * @param body - The response body to be serialized as JSON. May include error details,
    *   user data, or other structured data.
    * @param init - Optional response initialization options (status, headers, etc.).
+   * 
+   * @returns This response object for method chaining.
    */
-  abstract json(body: any, init?: ResponseInit): Auth0Response<TResponse>;
+  abstract generic(body: any, init?: ResponseInit): Auth0Response<TResponse>;
 
   /**
    * Adds cache control headers to the response to prevent caching of sensitive data.

--- a/src/server/http/auth0-response.ts
+++ b/src/server/http/auth0-response.ts
@@ -1,0 +1,115 @@
+import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+
+/**
+ * An abstract representation of an HTTP response.
+ *
+ * This base class defines the interface for constructing and modifying HTTP responses
+ * without coupling to specific Next.js response types. Implementations provide methods
+ * for setting status codes, redirecting, sending JSON/generic content, and managing cookies.
+ *
+ * The abstraction enables:
+ * - Support for multiple response types (NextResponse, NextApiResponse, etc.)
+ * - Cleaner authentication logic that returns responses consistently
+ * - Easier testing through mock implementations
+ *
+ * Design pattern: All methods mutate internal state (the `res` property) rather than
+ * returning new instances. This allows for method chaining and middleware patterns where
+ * the same response object is modified multiple times before being returned.
+ *
+ * @template TResponse The underlying response type (e.g., NextResponse, NextApiResponse)
+ *
+ * @example
+ * ```typescript
+ * // Implementation for NextResponse
+ * class Auth0NextResponse extends Auth0Response<NextResponse> {
+ *   public redirect(url: string): void {
+ *     this.res = NextResponse.redirect(url);
+ *   }
+ *   // ... other methods
+ * }
+ *
+ * // Usage in authentication logic
+ * function handleLogin(res: Auth0Response): void {
+ *   res.json({ token: "...", user: {...} });
+ *   res.addCacheControlHeadersForSession();
+ * }
+ * ```
+ */
+export abstract class Auth0Response<TResponse = any> {
+  constructor(public res: TResponse) {}
+
+  /**
+   * Retrieves the cookies from the response.
+   *
+   * @returns An Auth0ResponseCookies object providing a unified interface to cookies.
+   */
+  abstract getCookies(): Auth0ResponseCookies;
+
+  /**
+   * Redirects the response to the specified URL.
+   *
+   * This method should validate the URL to prevent open redirect vulnerabilities.
+   * The implementation must preserve any headers set previously on this response.
+   *
+   * Security: Ensure URL validation to prevent redirecting users to attacker-controlled
+   * sites.
+   *
+   * @param url - The URL to redirect to. Should be validated before calling this method.
+   */
+  abstract redirect(url: string): void;
+
+  /**
+   * Sets the HTTP status code of the response.
+   *
+   * Note: The return type may be void or the response object, but all implementations
+   * use side effects to modify internal state.
+   *
+   * @param message - The response body as a string or null.
+   * @param status - The HTTP status code (e.g., 200, 401, 500).
+   */
+  abstract status(message: string | null, status: number): TResponse | void;
+
+  /**
+   * Sends a JSON response with the specified body.
+   *
+   * This method automatically sets the Content-Type header to application/json and
+   * serializes the body parameter as JSON.
+   *
+   * Security: Be careful not to include sensitive data (like internal error details)
+   * in JSON responses, as this information could aid attackers.
+   *
+   * @param body - The response body to be serialized as JSON. May include error details,
+   *   user data, or other structured data.
+   * @param init - Optional response initialization options (status, headers, etc.).
+   */
+  abstract json(body: any, init?: ResponseInit): void;
+
+  /**
+   * Adds cache control headers to the response to prevent caching of sensitive data.
+   *
+   * This should be called for any response containing authenticated user data,
+   * access tokens, or other session information that should not be cached.
+   *
+   * Headers added:
+   * - Cache-Control: private, no-cache, no-store, must-revalidate, max-age=0
+   * - Pragma: no-cache (HTTP/1.0 compatibility)
+   * - Expires: 0 (older browser compatibility)
+   *
+   * Security: Prevents cached authentication tokens or user information from being
+   * served to unauthorized users on shared devices.
+   */
+  abstract addCacheControlHeadersForSession(): void;
+
+  /**
+   * Sets the response to a new response instance, merging headers.
+   *
+   * This is useful when you have a complete response object from another source
+   * and want to preserve headers that were previously set on this response instance.
+   * This supports middleware patterns where multiple handlers modify the response.
+   *
+   * @param res - The new response instance to set.
+   *
+   * @internal
+   */
+  abstract setResponse(res: TResponse): void;
+}

--- a/src/server/http/auth0-response.ts
+++ b/src/server/http/auth0-response.ts
@@ -63,10 +63,13 @@ export abstract class Auth0Response<TResponse = any> {
    *
    * @param message - The response body as a string or null.
    * @param status - The HTTP status code (e.g., 200, 401, 500).
-   * 
+   *
    * @returns This response object for method chaining.
    */
-  abstract status(message: string | null, status: number): Auth0Response<TResponse>;
+  abstract status(
+    message: string | null,
+    status: number
+  ): Auth0Response<TResponse>;
 
   /**
    * Sends a JSON response with the specified body.
@@ -77,7 +80,7 @@ export abstract class Auth0Response<TResponse = any> {
    * @param body - The response body to be serialized as JSON. May include error details,
    *   user data, or other structured data.
    * @param init - Optional response initialization options (status, headers, etc.).
-   * 
+   *
    * @returns This response object for method chaining.
    */
   abstract json(body: any, init?: ResponseInit): Auth0Response<TResponse>;
@@ -88,7 +91,7 @@ export abstract class Auth0Response<TResponse = any> {
    * @param body - The response body to be serialized as JSON. May include error details,
    *   user data, or other structured data.
    * @param init - Optional response initialization options (status, headers, etc.).
-   * 
+   *
    * @returns This response object for method chaining.
    */
   abstract generic(body: any, init?: ResponseInit): Auth0Response<TResponse>;

--- a/src/server/http/index.ts
+++ b/src/server/http/index.ts
@@ -1,0 +1,6 @@
+export { Auth0Request } from "./auth0-request.js";
+export { Auth0Response } from "./auth0-response.js";
+export { Auth0RequestCookies } from "./auth0-request-cookies.js";
+export { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+export { Auth0NextRequest } from "./auth0-next-request.js";
+export { Auth0NextResponse } from "./auth0-next-response.js";

--- a/src/server/logout-cookie-domain.flow.test.ts
+++ b/src/server/logout-cookie-domain.flow.test.ts
@@ -2,6 +2,7 @@ import { ResponseCookies } from "@edge-runtime/cookies";
 import { describe, expect, it } from "vitest";
 
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 
 describe("Session cookie domain deletion bug", () => {
   it("should delete session cookies with domain when AUTH0_COOKIE_DOMAIN is set", () => {
@@ -19,7 +20,7 @@ describe("Session cookie domain deletion bug", () => {
     // Mock request and response cookies
     const headers = new Headers();
     const reqCookies = new Headers();
-    const resCookies = new ResponseCookies(headers);
+    const resCookies = new Auth0ResponseCookies(new ResponseCookies(headers));
 
     // Add session cookie to request (simulate existing session)
     reqCookies.set("__session", "existing-session-value");
@@ -38,7 +39,7 @@ describe("Session cookie domain deletion bug", () => {
     };
 
     // Call delete method
-    sessionStore.delete(mockReqCookies as any, resCookies);
+    sessionStore.delete(new Auth0RequestCookies(mockReqCookies as any), resCookies);
 
     // Check that cookies are deleted with domain
     const setCookieHeaders = headers.getSetCookie();
@@ -73,7 +74,7 @@ describe("Session cookie domain deletion bug", () => {
 
     const headers = new Headers();
     const reqCookies = new Headers();
-    const resCookies = new ResponseCookies(headers);
+    const resCookies = new Auth0ResponseCookies(new ResponseCookies(headers));
 
     reqCookies.set("__session", "existing-session-value");
 

--- a/src/server/logout-cookie-domain.flow.test.ts
+++ b/src/server/logout-cookie-domain.flow.test.ts
@@ -1,8 +1,8 @@
 import { ResponseCookies } from "@edge-runtime/cookies";
 import { describe, expect, it } from "vitest";
 
-import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
 
 describe("Session cookie domain deletion bug", () => {
   it("should delete session cookies with domain when AUTH0_COOKIE_DOMAIN is set", () => {
@@ -39,7 +39,10 @@ describe("Session cookie domain deletion bug", () => {
     };
 
     // Call delete method
-    sessionStore.delete(new Auth0RequestCookies(mockReqCookies as any), resCookies);
+    sessionStore.delete(
+      new Auth0RequestCookies(mockReqCookies as any),
+      resCookies
+    );
 
     // Check that cookies are deleted with domain
     const setCookieHeaders = headers.getSetCookie();

--- a/src/server/logout-strategy.flow.test.ts
+++ b/src/server/logout-strategy.flow.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server.js";
+import { NextRequest, NextResponse } from "next/server.js";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import {
@@ -18,6 +18,7 @@ import { AuthClient } from "./auth-client.js";
 import { encrypt } from "./cookies.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 
 // Test constants
 const DEFAULT = {
@@ -139,7 +140,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -179,7 +183,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -213,7 +220,10 @@ describe("Logout Strategy Flow Tests", () => {
         method: "GET"
       });
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -266,7 +276,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -299,7 +312,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(500);
       expect(await response.text()).toBe(
@@ -348,7 +364,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -381,7 +400,10 @@ describe("Logout Strategy Flow Tests", () => {
         method: "GET"
       });
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -412,7 +434,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -466,7 +491,10 @@ describe("Logout Strategy Flow Tests", () => {
           }
         );
 
-        const response = await authClient.handleLogout(request);
+        const auth0Req = new Auth0NextRequest(request);
+        const auth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleLogout(auth0Req, auth0Res);
+        const response = auth0Res.res;
 
         // All strategies should redirect (except oidc without endpoint, but we're testing with endpoint)
         expect(response.status).toBe(307);
@@ -501,7 +529,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -556,7 +587,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -608,7 +642,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -660,7 +697,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -714,7 +754,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -753,7 +796,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -792,7 +838,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -823,7 +872,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -857,7 +909,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -888,7 +943,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");
@@ -918,7 +976,10 @@ describe("Logout Strategy Flow Tests", () => {
         }
       );
 
-      const response = await authClient.handleLogout(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("Location");

--- a/src/server/logout-strategy.flow.test.ts
+++ b/src/server/logout-strategy.flow.test.ts
@@ -16,9 +16,9 @@ import { generateSecret } from "../test/utils.js";
 import type { SessionData } from "../types/index.js";
 import { AuthClient } from "./auth-client.js";
 import { encrypt } from "./cookies.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
-import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 
 // Test constants
 const DEFAULT = {

--- a/src/server/proxy-handler.test.ts
+++ b/src/server/proxy-handler.test.ts
@@ -24,7 +24,6 @@ import { generateDpopKeyPair } from "../utils/dpopUtils.js";
 import { AuthClient } from "./auth-client.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
-import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 
 /**
  * Comprehensive Test Suite: AuthClient Custom Proxy Handler

--- a/src/server/proxy-handler.test.ts
+++ b/src/server/proxy-handler.test.ts
@@ -24,6 +24,7 @@ import { generateDpopKeyPair } from "../utils/dpopUtils.js";
 import { AuthClient } from "./auth-client.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 
 /**
  * Comprehensive Test Suite: AuthClient Custom Proxy Handler

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -27,12 +27,17 @@ import {
   ResponseCookies
 } from "./cookies.js";
 import {
+  Auth0NextRequest,
+  Auth0NextResponse,
+  Auth0RequestCookies,
+  Auth0ResponseCookies
+} from "./http/index.js";
+import {
   AbstractSessionStore,
   SessionStoreOptions
 } from "./session/abstract-session-store.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
-import { Auth0NextRequest, Auth0NextResponse, Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 
 // Only mock specific oauth4webapi functions that need predictable values
 vi.mock("oauth4webapi", async () => {
@@ -141,9 +146,7 @@ class TestSessionStore extends AbstractSessionStore {
   constructor(config: SessionStoreOptions) {
     super(config);
   }
-  async get(
-    _reqCookies: Auth0RequestCookies
-  ): Promise<SessionData | null> {
+  async get(_reqCookies: Auth0RequestCookies): Promise<SessionData | null> {
     return null;
   }
   async set(
@@ -880,7 +883,9 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const saveSpy = vi.spyOn(mockTransactionStoreInstance, "save");
 
         // Act: Call startInteractiveLogin
-        await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
+        await authClient.startInteractiveLogin(
+          new Auth0NextResponse(new NextResponse())
+        );
 
         // Assert: Verify save was called with only 2 parameters (no reqCookies)
         expect(saveSpy).toHaveBeenCalledTimes(1);

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -12,6 +12,7 @@ import {
   describe,
   expect,
   it,
+  Mock,
   vi
 } from "vitest";
 
@@ -31,7 +32,7 @@ import {
 } from "./session/abstract-session-store.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
-import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
+import { Auth0NextRequest, Auth0NextResponse, Auth0RequestCookies, Auth0ResponseCookies } from "./http/index.js";
 
 // Only mock specific oauth4webapi functions that need predictable values
 vi.mock("oauth4webapi", async () => {
@@ -141,21 +142,21 @@ class TestSessionStore extends AbstractSessionStore {
     super(config);
   }
   async get(
-    _reqCookies: RequestCookies | ReadonlyRequestCookies
+    _reqCookies: Auth0RequestCookies
   ): Promise<SessionData | null> {
     return null;
   }
   async set(
-    _reqCookies: RequestCookies | ReadonlyRequestCookies,
-    _resCookies: ResponseCookies,
+    _reqCookies: Auth0RequestCookies,
+    _resCookies: Auth0ResponseCookies,
     _session: SessionData,
     _isNew?: boolean | undefined
   ): Promise<void> {
     // Empty implementation for testing
   }
   async delete(
-    _reqCookies: RequestCookies | ReadonlyRequestCookies,
-    _resCookies: ResponseCookies
+    _reqCookies: Auth0RequestCookies,
+    _resCookies: Auth0ResponseCookies
   ): Promise<void> {
     // Empty implementation for testing
   }
@@ -505,7 +506,7 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
 
       // Assert: Verify transaction was retrieved and processed
       expect(mockTransactionStoreInstance.get).toHaveBeenCalled();
-      const getCall = mockTransactionStoreInstance.get.mock.calls[0];
+      const getCall = (mockTransactionStoreInstance.get as Mock).mock.calls[0];
       expect(getCall[1]).toBe(state);
 
       // Check that the specific transaction cookie was deleted
@@ -552,7 +553,7 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
 
       // Assert: Verify transaction store was queried but found nothing
       expect(mockTransactionStoreInstance.get).toHaveBeenCalled();
-      const getCall = mockTransactionStoreInstance.get.mock.calls[0];
+      const getCall = (mockTransactionStoreInstance.get as Mock).mock.calls[0];
       expect(getCall[1]).toBe(state);
 
       // Check that no transaction cookies were deleted (preserve other auth flows)

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { NextRequest } from "next/server.js";
+import { NextRequest, NextResponse } from "next/server.js";
 import * as jose from "jose";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -31,6 +31,7 @@ import {
 } from "./session/abstract-session-store.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
+import { Auth0NextRequest, Auth0NextResponse } from "./http/index.js";
 
 // Only mock specific oauth4webapi functions that need predictable values
 vi.mock("oauth4webapi", async () => {
@@ -306,7 +307,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       req.cookies.set("__session", "session-value");
 
       // Act: Process the logout
-      const res = await authClient.handleLogout(req);
+      const auth0Req = new Auth0NextRequest(req);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const res = auth0Res.res;
 
       // Assert: Verify session cleanup occurred
       expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
@@ -348,7 +352,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       req.cookies.set("other_cookie", "other-value"); // Non-auth cookie should be preserved
 
       // Act: Process the logout
-      const res = await authClient.handleLogout(req);
+      const auth0Req = new Auth0NextRequest(req);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const res = auth0Res.res;
 
       // Assert: Verify all auth-related cleanup occurred
       expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
@@ -373,7 +380,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       const req = new NextRequest("http://localhost:3000/api/auth/logout");
       req.cookies.set("__txn_state1", "txn-value1");
 
-      const res = await authClient.handleLogout(req);
+      const auth0Req = new Auth0NextRequest(req);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const res = auth0Res.res;
 
       expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
 
@@ -412,7 +422,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       req.cookies.set(`${customPrefix}state1`, "txn-value1");
       req.cookies.set("__txn_state2", "default-prefix-value");
 
-      const res = await authClient.handleLogout(req);
+      const auth0Req = new Auth0NextRequest(req);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogout(auth0Req, auth0Res);
+      const res = auth0Res.res;
 
       expect(mockSessionStoreInstance.delete).toHaveBeenCalledTimes(1);
 
@@ -461,7 +474,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
 
       // Arrange: First, do a login to get proper state and transaction cookie
       const loginReq = new NextRequest("http://localhost:3000/api/auth/login");
-      const loginRes = await authClient.handleLogin(loginReq);
+      const loginAuth0Req = new Auth0NextRequest(loginReq);
+      const loginAuth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleLogin(loginAuth0Req, loginAuth0Res);
+      const loginRes = loginAuth0Res.res;
 
       // Extract the state from the redirect URL
       const redirectUrl = new URL(loginRes.headers.get("Location")!);
@@ -482,13 +498,15 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       }
 
       // Act: Process the successful callback
-      const res = await authClient.handleCallback(req);
+      const callbackAuth0Req = new Auth0NextRequest(req);
+      const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+      const res = callbackAuth0Res.res;
 
       // Assert: Verify transaction was retrieved and processed
-      expect(mockTransactionStoreInstance.get).toHaveBeenCalledWith(
-        req.cookies,
-        state
-      );
+      expect(mockTransactionStoreInstance.get).toHaveBeenCalled();
+      const getCall = mockTransactionStoreInstance.get.mock.calls[0];
+      expect(getCall[1]).toBe(state);
 
       // Check that the specific transaction cookie was deleted
       const deletedTxnCookies = res.cookies
@@ -527,13 +545,15 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       );
 
       // Act: Handle callback with invalid state
-      const res = await authClient.handleCallback(req);
+      const callbackAuth0Req = new Auth0NextRequest(req);
+      const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+      const res = callbackAuth0Res.res;
 
       // Assert: Verify transaction store was queried but found nothing
-      expect(mockTransactionStoreInstance.get).toHaveBeenCalledWith(
-        req.cookies,
-        state
-      );
+      expect(mockTransactionStoreInstance.get).toHaveBeenCalled();
+      const getCall = mockTransactionStoreInstance.get.mock.calls[0];
+      expect(getCall[1]).toBe(state);
 
       // Check that no transaction cookies were deleted (preserve other auth flows)
       const deletedTxnCookies = res.cookies
@@ -571,7 +591,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
       );
 
       // Act: Handle the malformed callback
-      const res = await authClient.handleCallback(req);
+      const callbackAuth0Req = new Auth0NextRequest(req);
+      const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+      const res = callbackAuth0Res.res;
 
       // Assert: Verify error handling behavior
       // Should not attempt to retrieve transaction since no state to look up
@@ -651,7 +674,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const loginReq = new NextRequest(
           "http://localhost:3000/api/auth/login"
         );
-        const loginRes = await authClient.handleLogin(loginReq);
+        const loginAuth0Req = new Auth0NextRequest(loginReq);
+        const loginAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleLogin(loginAuth0Req, loginAuth0Res);
+        const loginRes = loginAuth0Res.res;
 
         // Extract the state from the redirect URL
         const redirectUrl = new URL(loginRes.headers.get("Location")!);
@@ -674,7 +700,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         }
 
         // Act: Handle the callback
-        const callbackRes = await authClient.handleCallback(callbackReq);
+        const callbackAuth0Req = new Auth0NextRequest(callbackReq);
+        const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+        const callbackRes = callbackAuth0Res.res;
 
         // Assert: Verify that ALL transaction cookies are cleaned up
         expect(callbackRes.status).toBeGreaterThanOrEqual(300); // Should redirect
@@ -719,7 +748,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const loginReq = new NextRequest(
           "http://localhost:3000/api/auth/login"
         );
-        const loginRes = await authClient.handleLogin(loginReq);
+        const loginAuth0Req = new Auth0NextRequest(loginReq);
+        const loginAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleLogin(loginAuth0Req, loginAuth0Res);
+        const loginRes = loginAuth0Res.res;
 
         const redirectUrl = new URL(loginRes.headers.get("Location")!);
         const state = redirectUrl.searchParams.get("state")!;
@@ -734,7 +766,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
           callbackReq.cookies.set(`__txn_${state}`, txnCookie.value);
         }
 
-        const callbackRes = await authClient.handleCallback(callbackReq);
+        const callbackAuth0Req = new Auth0NextRequest(callbackReq);
+        const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+        const callbackRes = callbackAuth0Res.res;
 
         // Should still work normally
         expect(callbackRes.status).toBeGreaterThanOrEqual(300);
@@ -756,7 +791,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const loginReq = new NextRequest(
           "http://localhost:3000/api/auth/login"
         );
-        const loginRes = await authClient.handleLogin(loginReq);
+        const loginAuth0Req = new Auth0NextRequest(loginReq);
+        const loginAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleLogin(loginAuth0Req, loginAuth0Res);
+        const loginRes = loginAuth0Res.res;
 
         const redirectUrl = new URL(loginRes.headers.get("Location")!);
         const state = redirectUrl.searchParams.get("state")!;
@@ -773,7 +811,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         callbackReq.cookies.set("other_cookie", "should_not_be_deleted");
         callbackReq.cookies.set("user_pref", "also_should_remain");
 
-        const callbackRes = await authClient.handleCallback(callbackReq);
+        const callbackAuth0Req = new Auth0NextRequest(callbackReq);
+        const callbackAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await authClient.handleCallback(callbackAuth0Req, callbackAuth0Res);
+        const callbackRes = callbackAuth0Res.res;
 
         // Check that only transaction cookies are deleted
         const deletedCookies = callbackRes.cookies
@@ -814,7 +855,10 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const loginReq = new NextRequest(
           "http://localhost:3000/api/auth/login"
         );
-        const loginRes = await singleTxnAuthClient.handleLogin(loginReq);
+        const loginAuth0Req = new Auth0NextRequest(loginReq);
+        const loginAuth0Res = new Auth0NextResponse(NextResponse.next());
+        await singleTxnAuthClient.handleLogin(loginAuth0Req, loginAuth0Res);
+        const loginRes = loginAuth0Res.res;
 
         // Assert: Should use __txn_ without state suffix
         const txnCookies = loginRes.cookies

--- a/src/server/redundant-txn-cookie-deletion.test.ts
+++ b/src/server/redundant-txn-cookie-deletion.test.ts
@@ -879,7 +879,7 @@ describe("Ensure that redundant transaction cookies are deleted from auth-client
         const saveSpy = vi.spyOn(mockTransactionStoreInstance, "save");
 
         // Act: Call startInteractiveLogin
-        await authClient.startInteractiveLogin();
+        await authClient.startInteractiveLogin(new Auth0NextResponse(new NextResponse()));
 
         // Assert: Verify save was called with only 2 parameters (no reqCookies)
         expect(saveSpy).toHaveBeenCalledTimes(1);

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -1,10 +1,7 @@
 import type { SessionData, SessionDataStore } from "../../types/index.js";
-import {
-  CookieOptions,
-  ReadonlyRequestCookies,
-  RequestCookies,
-  ResponseCookies
-} from "../cookies.js";
+import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
+import { CookieOptions } from "../cookies.js";
 
 export interface SessionCookieOptions {
   /**
@@ -124,7 +121,7 @@ export abstract class AbstractSessionStore {
   }
 
   abstract get(
-    reqCookies: RequestCookies | ReadonlyRequestCookies
+    reqCookies: Auth0RequestCookies
   ): Promise<SessionData | null>;
 
   /**
@@ -132,15 +129,15 @@ export abstract class AbstractSessionStore {
    * is present on the session, then it will be used to compute the `maxAge` cookie value.
    */
   abstract set(
-    reqCookies: RequestCookies | ReadonlyRequestCookies,
-    resCookies: ResponseCookies,
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies,
     session: SessionData,
     isNew?: boolean
   ): Promise<void>;
 
   abstract delete(
-    reqCookies: RequestCookies | ReadonlyRequestCookies,
-    resCookies: ResponseCookies
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies
   ): Promise<void>;
 
   /**

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -1,7 +1,7 @@
 import type { SessionData, SessionDataStore } from "../../types/index.js";
+import { CookieOptions } from "../cookies.js";
 import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
 import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
-import { CookieOptions } from "../cookies.js";
 
 export interface SessionCookieOptions {
   /**
@@ -120,9 +120,7 @@ export abstract class AbstractSessionStore {
     };
   }
 
-  abstract get(
-    reqCookies: Auth0RequestCookies
-  ): Promise<SessionData | null>;
+  abstract get(reqCookies: Auth0RequestCookies): Promise<SessionData | null>;
 
   /**
    * save adds the encrypted session cookie as a `Set-Cookie` header. If the `iat` property

--- a/src/server/session/stateful-session-store.test.ts
+++ b/src/server/session/stateful-session-store.test.ts
@@ -10,12 +10,12 @@ import {
   ResponseCookies,
   sign
 } from "../cookies.js";
+import { Auth0RequestCookies, Auth0ResponseCookies } from "../http/index.js";
 import {
   LEGACY_COOKIE_NAME,
   LegacySessionPayload
 } from "./normalize-session.js";
 import { StatefulSessionStore } from "./stateful-session-store.js";
-import { Auth0RequestCookies, Auth0ResponseCookies } from "../http/index.js";
 
 describe("Stateful Session Store", async () => {
   describe("get", async () => {
@@ -51,7 +51,9 @@ describe("Stateful Session Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -67,7 +69,9 @@ describe("Stateful Session Store", async () => {
     it("should return null if no session cookie exists", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
       const store = {
         get: vi.fn(),
         set: vi.fn(),
@@ -119,7 +123,9 @@ describe("Stateful Session Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -162,7 +168,9 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${signedCookieValue}`);
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -212,7 +220,9 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${signedCookieValue}`);
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -262,7 +272,9 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `${cookieName}=${signedCookieValue}`);
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -324,8 +336,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -377,9 +393,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -434,8 +453,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -497,8 +520,12 @@ describe("Stateful Session Store", async () => {
         const headers = new Headers();
         headers.append("cookie", `__session=${encryptedCookieValue}`);
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -544,8 +571,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -597,8 +628,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -650,8 +685,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -694,8 +733,12 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -761,7 +804,11 @@ describe("Stateful Session Store", async () => {
       vi.spyOn(requestCookies, "has").mockReturnValue(true);
       vi.spyOn(responseCookies, "set");
 
-      await sessionStore.set(auth0RequestCookies, auth0ResponseCookies, session);
+      await sessionStore.set(
+        auth0RequestCookies,
+        auth0ResponseCookies,
+        session
+      );
 
       expect(responseCookies.set).toHaveBeenCalledWith(LEGACY_COOKIE_NAME, "", {
         maxAge: 0,
@@ -803,7 +850,11 @@ describe("Stateful Session Store", async () => {
         cookieOptions: { name: LEGACY_COOKIE_NAME } // 👈 simulate legacy name
       });
 
-      await sessionStore.set(auth0RequestCookies, auth0ResponseCookies, session);
+      await sessionStore.set(
+        auth0RequestCookies,
+        auth0ResponseCookies,
+        session
+      );
       expect(deleteSpy).not.toHaveBeenCalled();
     });
   });
@@ -841,8 +892,12 @@ describe("Stateful Session Store", async () => {
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
 
-      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
-      const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -878,9 +933,13 @@ describe("Stateful Session Store", async () => {
         set: vi.fn(),
         delete: vi.fn()
       };
-      
-      const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
-      const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
+
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(new Headers())
+      );
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
 
       const sessionStore = new StatefulSessionStore({
         secret,

--- a/src/server/session/stateful-session-store.test.ts
+++ b/src/server/session/stateful-session-store.test.ts
@@ -15,6 +15,7 @@ import {
   LegacySessionPayload
 } from "./normalize-session.js";
 import { StatefulSessionStore } from "./stateful-session-store.js";
+import { Auth0RequestCookies, Auth0ResponseCookies } from "../http/index.js";
 
 describe("Stateful Session Store", async () => {
   describe("get", async () => {
@@ -50,7 +51,7 @@ describe("Stateful Session Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -66,7 +67,7 @@ describe("Stateful Session Store", async () => {
     it("should return null if no session cookie exists", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
       const store = {
         get: vi.fn(),
         set: vi.fn(),
@@ -118,7 +119,7 @@ describe("Stateful Session Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -161,7 +162,7 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${signedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -211,7 +212,7 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${signedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -261,7 +262,7 @@ describe("Stateful Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `${cookieName}=${signedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -323,8 +324,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -376,8 +377,9 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -432,8 +434,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -494,8 +496,9 @@ describe("Stateful Session Store", async () => {
         );
         const headers = new Headers();
         headers.append("cookie", `__session=${encryptedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
-        const responseCookies = new ResponseCookies(new Headers());
+
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -541,8 +544,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -594,8 +597,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -647,8 +650,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -691,8 +694,8 @@ describe("Stateful Session Store", async () => {
           delete: vi.fn()
         };
 
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+        const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
         const sessionStore = new StatefulSessionStore({
           secret,
@@ -746,7 +749,9 @@ describe("Stateful Session Store", async () => {
       };
 
       const requestCookies = new RequestCookies(new Headers());
+      const auth0RequestCookies = new Auth0RequestCookies(requestCookies);
       const responseCookies = new ResponseCookies(new Headers());
+      const auth0ResponseCookies = new Auth0ResponseCookies(responseCookies);
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -756,7 +761,7 @@ describe("Stateful Session Store", async () => {
       vi.spyOn(requestCookies, "has").mockReturnValue(true);
       vi.spyOn(responseCookies, "set");
 
-      await sessionStore.set(requestCookies, responseCookies, session);
+      await sessionStore.set(auth0RequestCookies, auth0ResponseCookies, session);
 
       expect(responseCookies.set).toHaveBeenCalledWith(LEGACY_COOKIE_NAME, "", {
         maxAge: 0,
@@ -785,7 +790,9 @@ describe("Stateful Session Store", async () => {
       };
 
       const requestCookies = new RequestCookies(new Headers());
+      const auth0RequestCookies = new Auth0RequestCookies(requestCookies);
       const responseCookies = new ResponseCookies(new Headers());
+      const auth0ResponseCookies = new Auth0ResponseCookies(responseCookies);
 
       // Pretend the legacy cookie is already present
       vi.spyOn(requestCookies, "has").mockReturnValue(true);
@@ -796,7 +803,7 @@ describe("Stateful Session Store", async () => {
         cookieOptions: { name: LEGACY_COOKIE_NAME } // 👈 simulate legacy name
       });
 
-      await sessionStore.set(requestCookies, responseCookies, session);
+      await sessionStore.set(auth0RequestCookies, auth0ResponseCookies, session);
       expect(deleteSpy).not.toHaveBeenCalled();
     });
   });
@@ -833,8 +840,9 @@ describe("Stateful Session Store", async () => {
       );
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
-      const responseCookies = new ResponseCookies(new Headers());
+
+      const requestCookies = new Auth0RequestCookies(new RequestCookies(headers));
+      const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
       const sessionStore = new StatefulSessionStore({
         secret,
@@ -870,8 +878,9 @@ describe("Stateful Session Store", async () => {
         set: vi.fn(),
         delete: vi.fn()
       };
-      const requestCookies = new RequestCookies(new Headers());
-      const responseCookies = new ResponseCookies(new Headers());
+      
+      const requestCookies = new Auth0RequestCookies(new RequestCookies(new Headers()));
+      const responseCookies = new Auth0ResponseCookies(new ResponseCookies(new Headers()));
 
       const sessionStore = new StatefulSessionStore({
         secret,

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -1,4 +1,6 @@
 import { SessionData, SessionDataStore } from "../../types/index.js";
+import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
 import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
@@ -57,7 +59,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
     this.store = store;
   }
 
-  async get(reqCookies: cookies.RequestCookies) {
+  async get(reqCookies: Auth0RequestCookies) {
     const cookie =
       reqCookies.get(this.sessionCookieName) ||
       reqCookies.get(LEGACY_COOKIE_NAME);
@@ -113,8 +115,8 @@ export class StatefulSessionStore extends AbstractSessionStore {
   }
 
   async set(
-    reqCookies: cookies.RequestCookies,
-    resCookies: cookies.ResponseCookies,
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies,
     session: SessionData,
     isNew: boolean = false
   ) {
@@ -170,7 +172,8 @@ export class StatefulSessionStore extends AbstractSessionStore {
       this.sessionCookieName !== LEGACY_COOKIE_NAME &&
       reqCookies.has(LEGACY_COOKIE_NAME)
     ) {
-      cookies.deleteCookie(resCookies, LEGACY_COOKIE_NAME, {
+      resCookies.delete({
+        name: LEGACY_COOKIE_NAME,
         domain: this.cookieConfig.domain,
         path: this.cookieConfig.path
       });
@@ -178,11 +181,12 @@ export class StatefulSessionStore extends AbstractSessionStore {
   }
 
   async delete(
-    reqCookies: cookies.RequestCookies,
-    resCookies: cookies.ResponseCookies
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies
   ) {
     const cookieValue = reqCookies.get(this.sessionCookieName)?.value;
-    cookies.deleteCookie(resCookies, this.sessionCookieName, {
+    resCookies.delete({
+      name: this.sessionCookieName,
       domain: this.cookieConfig.domain,
       path: this.cookieConfig.path
     });

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -1,7 +1,7 @@
 import { SessionData, SessionDataStore } from "../../types/index.js";
+import * as cookies from "../cookies.js";
 import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
 import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
-import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
   SessionCookieOptions

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -3,8 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSecret } from "../../test/utils.js";
 import { CookieOptions, SessionData } from "../../types/index.js";
-import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
-import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
 import {
   decrypt,
   encrypt,
@@ -12,6 +10,8 @@ import {
   ResponseCookies
 } from "../cookies.js";
 import * as cookies from "../cookies.js";
+import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
 import { LEGACY_COOKIE_NAME, LegacySession } from "./normalize-session.js";
 import { StatelessSessionStore } from "./stateless-session-store.js";
 
@@ -825,7 +825,11 @@ describe("Stateless Session Store", async () => {
       const setSpy = vi.spyOn(responseCookies, "set");
       const sessionStore = new StatelessSessionStore({ secret });
 
-      await sessionStore.set(requestCookies, auth0ResponseCookies, sessionToSet);
+      await sessionStore.set(
+        requestCookies,
+        auth0ResponseCookies,
+        sessionToSet
+      );
 
       const setCookies = responseCookies.getAll();
       let reconstructedValue = "";

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateSecret } from "../../test/utils.js";
 import { CookieOptions, SessionData } from "../../types/index.js";
+import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
 import {
   decrypt,
   encrypt,
@@ -42,7 +44,9 @@ describe("Stateless Session Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__session=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatelessSessionStore({
         secret
@@ -56,7 +60,9 @@ describe("Stateless Session Store", async () => {
     it("should return null if no session cookie exists", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatelessSessionStore({
         secret
@@ -95,7 +101,9 @@ describe("Stateless Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${encryptedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret
@@ -140,7 +148,9 @@ describe("Stateless Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `appSession=${encryptedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret
@@ -191,7 +201,9 @@ describe("Stateless Session Store", async () => {
 
         const headers = new Headers();
         headers.append("cookie", `${cookieName}=${encryptedCookieValue}`);
-        const requestCookies = new RequestCookies(headers);
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(headers)
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -250,7 +262,9 @@ describe("Stateless Session Store", async () => {
         "cookie",
         `__session=${encryptedCookieValue};__FC.0=${encryptedGoogleConnectionCookieValue}`
       );
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatelessSessionStore({
         secret
@@ -308,7 +322,9 @@ describe("Stateless Session Store", async () => {
         "cookie",
         `__session=${encryptedCookieValue};__FC.0=${encryptedGoogleConnectionCookieValue};__FC.1=${encryptedGithubConnectionCookieValue}`
       );
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const sessionStore = new StatelessSessionStore({
         secret
@@ -349,8 +365,12 @@ describe("Stateless Session Store", async () => {
             createdAt
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -393,8 +413,12 @@ describe("Stateless Session Store", async () => {
             createdAt
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -431,8 +455,11 @@ describe("Stateless Session Store", async () => {
             createdAt
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
         const responseCookies = new ResponseCookies(new Headers());
+        const auth0ResponseCookies = new Auth0ResponseCookies(responseCookies);
 
         const sessionStore = new StatelessSessionStore({
           secret
@@ -448,7 +475,7 @@ describe("Stateless Session Store", async () => {
           return undefined;
         });
 
-        await sessionStore.set(requestCookies, responseCookies, session);
+        await sessionStore.set(requestCookies, auth0ResponseCookies, session);
 
         expect(responseCookies.set).toHaveBeenCalledWith(
           LEGACY_COOKIE_NAME,
@@ -476,8 +503,11 @@ describe("Stateless Session Store", async () => {
             createdAt
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
         const responseCookies = new ResponseCookies(new Headers());
+        const auth0ResponseCookies = new Auth0ResponseCookies(responseCookies);
 
         const sessionStore = new StatelessSessionStore({
           secret
@@ -498,7 +528,7 @@ describe("Stateless Session Store", async () => {
           { name: `${LEGACY_COOKIE_NAME}.1`, value: "" }
         ]);
 
-        await sessionStore.set(requestCookies, responseCookies, session);
+        await sessionStore.set(requestCookies, auth0ResponseCookies, session);
 
         expect(responseCookies.set).toHaveBeenCalledTimes(4);
         expect(responseCookies.set).toHaveBeenNthCalledWith(
@@ -543,8 +573,12 @@ describe("Stateless Session Store", async () => {
             createdAt: Math.floor(Date.now() / 1000)
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -583,8 +617,12 @@ describe("Stateless Session Store", async () => {
             createdAt: Math.floor(Date.now() / 1000)
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -624,8 +662,12 @@ describe("Stateless Session Store", async () => {
             createdAt: Math.floor(Date.now() / 1000)
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -666,8 +708,12 @@ describe("Stateless Session Store", async () => {
             createdAt: Math.floor(Date.now() / 1000)
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -701,8 +747,12 @@ describe("Stateless Session Store", async () => {
             createdAt: Math.floor(Date.now() / 1000)
           }
         };
-        const requestCookies = new RequestCookies(new Headers());
-        const responseCookies = new ResponseCookies(new Headers());
+        const requestCookies = new Auth0RequestCookies(
+          new RequestCookies(new Headers())
+        );
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(new Headers())
+        );
 
         const sessionStore = new StatelessSessionStore({
           secret,
@@ -748,12 +798,14 @@ describe("Stateless Session Store", async () => {
         expiration
       );
 
-      const tempResCookies = new ResponseCookies(new Headers());
+      const tempResCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
       cookies.setChunkedCookie(
         LEGACY_COOKIE_NAME,
         encryptedLegacyValue,
         baseCookieOptions,
-        new RequestCookies(new Headers()),
+        new Auth0RequestCookies(new RequestCookies(new Headers())),
         tempResCookies
       );
       const finalHeaders = new Headers();
@@ -764,13 +816,16 @@ describe("Stateless Session Store", async () => {
           `${cookie.name}=${encodeURIComponent(cookie.value)}`
         )
       );
-      const requestCookies = new RequestCookies(finalHeaders);
-
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(finalHeaders)
+      );
       const responseCookies = new ResponseCookies(new Headers());
+      const auth0ResponseCookies = new Auth0ResponseCookies(responseCookies);
+
       const setSpy = vi.spyOn(responseCookies, "set");
       const sessionStore = new StatelessSessionStore({ secret });
 
-      await sessionStore.set(requestCookies, responseCookies, sessionToSet);
+      await sessionStore.set(requestCookies, auth0ResponseCookies, sessionToSet);
 
       const setCookies = responseCookies.getAll();
       let reconstructedValue = "";
@@ -830,8 +885,12 @@ describe("Stateless Session Store", async () => {
           createdAt: Math.floor(Date.now() / 1000)
         }
       };
-      const requestCookies = new RequestCookies(new Headers());
-      const responseCookies = new ResponseCookies(new Headers());
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(new Headers())
+      );
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
 
       const sessionStore = new StatelessSessionStore({
         secret
@@ -847,8 +906,12 @@ describe("Stateless Session Store", async () => {
 
     it("should not throw an error if the cookie does not exist", async () => {
       const secret = await generateSecret(32);
-      const requestCookies = new RequestCookies(new Headers());
-      const responseCookies = new ResponseCookies(new Headers());
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(new Headers())
+      );
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(new Headers())
+      );
       const sessionStore = new StatelessSessionStore({
         secret
       });

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -5,9 +5,9 @@ import {
   CookieOptions,
   SessionData
 } from "../../types/index.js";
+import * as cookies from "../cookies.js";
 import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
 import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
-import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
   SessionCookieOptions

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -5,6 +5,8 @@ import {
   CookieOptions,
   SessionData
 } from "../../types/index.js";
+import { Auth0RequestCookies } from "../http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "../http/auth0-response-cookies.js";
 import * as cookies from "../cookies.js";
 import {
   AbstractSessionStore,
@@ -45,7 +47,7 @@ export class StatelessSessionStore extends AbstractSessionStore {
     });
   }
 
-  async get(reqCookies: cookies.RequestCookies) {
+  async get(reqCookies: Auth0RequestCookies) {
     const cookieValue =
       cookies.getChunkedCookie(this.sessionCookieName, reqCookies) ??
       cookies.getChunkedCookie(LEGACY_COOKIE_NAME, reqCookies, true);
@@ -97,8 +99,8 @@ export class StatelessSessionStore extends AbstractSessionStore {
    * save adds the encrypted session cookie as a `Set-Cookie` header.
    */
   async set(
-    reqCookies: cookies.RequestCookies,
-    resCookies: cookies.ResponseCookies,
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies,
     session: SessionData
   ) {
     const { connectionTokenSets, ...originalSession } = session;
@@ -154,8 +156,8 @@ export class StatelessSessionStore extends AbstractSessionStore {
   }
 
   async delete(
-    reqCookies: cookies.RequestCookies,
-    resCookies: cookies.ResponseCookies
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies
   ) {
     const deleteOptions = {
       domain: this.cookieConfig.domain,
@@ -171,13 +173,16 @@ export class StatelessSessionStore extends AbstractSessionStore {
     );
 
     this.getConnectionTokenSetsCookies(reqCookies).forEach((cookie) =>
-      cookies.deleteCookie(resCookies, cookie.name, deleteOptions)
+      resCookies.delete({
+        name: cookie.name,
+        ...deleteOptions
+      })
     );
   }
 
   private async storeInCookie(
-    reqCookies: cookies.RequestCookies,
-    resCookies: cookies.ResponseCookies,
+    reqCookies: Auth0RequestCookies,
+    resCookies: Auth0ResponseCookies,
     session: JWTPayload,
     cookieName: string,
     maxAge: number
@@ -219,7 +224,7 @@ export class StatelessSessionStore extends AbstractSessionStore {
   }
 
   private getConnectionTokenSetsCookies(
-    cookies: cookies.RequestCookies | cookies.ResponseCookies
+    cookies: Auth0RequestCookies | Auth0ResponseCookies
   ) {
     return cookies
       .getAll()

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -4,14 +4,14 @@ import { describe, expect, it } from "vitest";
 
 import { generateSecret } from "../test/utils.js";
 import { RESPONSE_TYPES } from "../types/connected-accounts.js";
-import { Auth0RequestCookies } from "./http/auth0-request-cookies.js";
-import { Auth0ResponseCookies } from "./http/auth0-response-cookies.js";
 import {
   decrypt,
   encrypt,
   RequestCookies,
   ResponseCookies
 } from "./cookies.js";
+import { Auth0RequestCookies } from "./http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "./http/auth0-response-cookies.js";
 import { TransactionState, TransactionStore } from "./transaction-store.js";
 
 describe("Transaction Store", async () => {

--- a/src/server/transaction-store.test.ts
+++ b/src/server/transaction-store.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 
 import { generateSecret } from "../test/utils.js";
 import { RESPONSE_TYPES } from "../types/connected-accounts.js";
+import { Auth0RequestCookies } from "./http/auth0-request-cookies.js";
+import { Auth0ResponseCookies } from "./http/auth0-response-cookies.js";
 import {
   decrypt,
   encrypt,
@@ -37,7 +39,9 @@ describe("Transaction Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__txn_${state}=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -71,7 +75,9 @@ describe("Transaction Store", async () => {
 
       const headers = new Headers();
       headers.append("cookie", `__txn_incorrect-state=${encryptedCookieValue}`);
-      const requestCookies = new RequestCookies(headers);
+      const requestCookies = new Auth0RequestCookies(
+        new RequestCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -96,7 +102,9 @@ describe("Transaction Store", async () => {
         returnTo: "/dashboard"
       };
       const headers = new Headers();
-      const responseCookies = new ResponseCookies(headers);
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -131,7 +139,9 @@ describe("Transaction Store", async () => {
         state: "" // missing state
       };
       const headers = new Headers();
-      const responseCookies = new ResponseCookies(headers);
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -157,7 +167,9 @@ describe("Transaction Store", async () => {
           returnTo: "/dashboard"
         };
         const headers = new Headers();
-        const responseCookies = new ResponseCookies(headers);
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(headers)
+        );
 
         const transactionStore = new TransactionStore({
           secret,
@@ -196,7 +208,9 @@ describe("Transaction Store", async () => {
           returnTo: "/dashboard"
         };
         const headers = new Headers();
-        const responseCookies = new ResponseCookies(headers);
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(headers)
+        );
 
         const transactionStore = new TransactionStore({
           secret,
@@ -235,7 +249,9 @@ describe("Transaction Store", async () => {
           returnTo: "/dashboard"
         };
         const headers = new Headers();
-        const responseCookies = new ResponseCookies(headers);
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(headers)
+        );
 
         const transactionStore = new TransactionStore({
           secret,
@@ -270,7 +286,9 @@ describe("Transaction Store", async () => {
           returnTo: "/dashboard"
         };
         const headers = new Headers();
-        const responseCookies = new ResponseCookies(headers);
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(headers)
+        );
 
         const transactionStore = new TransactionStore({
           secret,
@@ -309,7 +327,9 @@ describe("Transaction Store", async () => {
           returnTo: "/dashboard"
         };
         const headers = new Headers();
-        const responseCookies = new ResponseCookies(headers);
+        const responseCookies = new Auth0ResponseCookies(
+          new ResponseCookies(headers)
+        );
 
         const customMaxAge = 1800; // 30 minutes
         const transactionStore = new TransactionStore({
@@ -352,7 +372,9 @@ describe("Transaction Store", async () => {
         returnTo: "/dashboard"
       };
       const headers = new Headers();
-      const responseCookies = new ResponseCookies(headers);
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -373,7 +395,9 @@ describe("Transaction Store", async () => {
     it("should not throw an error if the cookie does not exist", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const responseCookies = new ResponseCookies(headers);
+      const responseCookies = new Auth0ResponseCookies(
+        new ResponseCookies(headers)
+      );
 
       const transactionStore = new TransactionStore({
         secret
@@ -389,16 +413,18 @@ describe("Transaction Store", async () => {
     it("should delete all cookies starting with the prefix", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new RequestCookies(headers);
-      const responseCookies = new ResponseCookies(headers);
+      const originalRequestCookies = new RequestCookies(headers);
+      const originalResponseCookies = new ResponseCookies(headers);
+      const requestCookies = new Auth0RequestCookies(originalRequestCookies);
+      const responseCookies = new Auth0ResponseCookies(originalResponseCookies);
 
-      // Set some cookies
-      requestCookies.set("__txn_state1", "value1");
-      requestCookies.set("__txn_state2", "value2");
-      requestCookies.set("other_cookie", "value3");
-      responseCookies.set("__txn_state1", "value1");
-      responseCookies.set("__txn_state2", "value2");
-      responseCookies.set("other_cookie", "value3");
+      // Set some cookies on the original cookies
+      originalRequestCookies.set("__txn_state1", "value1");
+      originalRequestCookies.set("__txn_state2", "value2");
+      originalRequestCookies.set("other_cookie", "value3");
+      originalResponseCookies.set("__txn_state1", "value1");
+      originalResponseCookies.set("__txn_state2", "value2");
+      originalResponseCookies.set("other_cookie", "value3");
 
       const transactionStore = new TransactionStore({
         secret
@@ -416,17 +442,19 @@ describe("Transaction Store", async () => {
     it("should respect custom prefix when deleting cookies", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new RequestCookies(headers);
-      const responseCookies = new ResponseCookies(headers);
+      const originalRequestCookies = new RequestCookies(headers);
+      const originalResponseCookies = new ResponseCookies(headers);
+      const requestCookies = new Auth0RequestCookies(originalRequestCookies);
+      const responseCookies = new Auth0ResponseCookies(originalResponseCookies);
       const customPrefix = "custom_txn_";
 
-      // Set some cookies
-      requestCookies.set(`${customPrefix}state1`, "value1");
-      requestCookies.set("__txn_state2", "value2");
-      requestCookies.set("other_cookie", "value3");
-      responseCookies.set(`${customPrefix}state1`, "value1");
-      responseCookies.set("__txn_state2", "value2");
-      responseCookies.set("other_cookie", "value3");
+      // Set some cookies on the original cookies
+      originalRequestCookies.set(`${customPrefix}state1`, "value1");
+      originalRequestCookies.set("__txn_state2", "value2");
+      originalRequestCookies.set("other_cookie", "value3");
+      originalResponseCookies.set(`${customPrefix}state1`, "value1");
+      originalResponseCookies.set("__txn_state2", "value2");
+      originalResponseCookies.set("other_cookie", "value3");
 
       const transactionStore = new TransactionStore({
         secret,
@@ -446,11 +474,13 @@ describe("Transaction Store", async () => {
     it("should not fail if no transaction cookies exist", async () => {
       const secret = await generateSecret(32);
       const headers = new Headers();
-      const requestCookies = new RequestCookies(headers);
-      const responseCookies = new ResponseCookies(headers);
+      const originalRequestCookies = new RequestCookies(headers);
+      const originalResponseCookies = new ResponseCookies(headers);
+      const requestCookies = new Auth0RequestCookies(originalRequestCookies);
+      const responseCookies = new Auth0ResponseCookies(originalResponseCookies);
 
-      requestCookies.set("other_cookie", "value3");
-      responseCookies.set("other_cookie", "value3");
+      originalRequestCookies.set("other_cookie", "value3");
+      originalResponseCookies.set("other_cookie", "value3");
 
       const transactionStore = new TransactionStore({
         secret

--- a/src/server/transaction-store.ts
+++ b/src/server/transaction-store.ts
@@ -1,9 +1,9 @@
 import type * as jose from "jose";
 
 import { RESPONSE_TYPES } from "../types/index.js";
+import * as cookies from "./cookies.js";
 import { Auth0RequestCookies } from "./http/auth0-request-cookies.js";
 import { Auth0ResponseCookies } from "./http/auth0-response-cookies.js";
-import * as cookies from "./cookies.js";
 
 const TRANSACTION_COOKIE_PREFIX = "__txn_";
 

--- a/tests/organizations.test.ts
+++ b/tests/organizations.test.ts
@@ -1,6 +1,10 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  Auth0NextRequest,
+  Auth0NextResponse
+} from "../src/server/http/index.js";
 import { AuthClient } from "../src/server/auth-client.js";
 import { StatelessSessionStore } from "../src/server/session/stateless-session-store.js";
 import { TransactionStore } from "../src/server/transaction-store.js";
@@ -116,7 +120,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307); // Redirect to Auth0
       expect(response.headers.get("location")).toContain(
@@ -132,7 +142,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
@@ -148,7 +164,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307); // Redirect to Auth0
       const location = response.headers.get("location");
@@ -163,7 +185,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307); // Redirect to Auth0
       const location = response.headers.get("location");
@@ -179,7 +207,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307); // Redirect to Auth0
       const location = response.headers.get("location");
@@ -191,7 +225,13 @@ describe("Organizations Feature", () => {
         method: "GET"
       });
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");
@@ -220,7 +260,10 @@ describe("Organizations Feature", () => {
         method: "GET"
       });
 
-      const response = await authClientWithOrg.handleLogin(request);
+      const auth0Req1 = new Auth0NextRequest(request);
+      const auth0Res1 = new Auth0NextResponse(NextResponse.next());
+      await authClientWithOrg.handleLogin(auth0Req1, auth0Res1);
+      const response = auth0Res1.res;
 
       expect(response.status).toBe(307);
       expect(response.headers.get("location")).toContain(
@@ -251,7 +294,10 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClientWithOrg.handleLogin(request);
+      const auth0Req2 = new Auth0NextRequest(request);
+      const auth0Res2 = new Auth0NextResponse(NextResponse.next());
+      await authClientWithOrg.handleLogin(auth0Req2, auth0Res2);
+      const response = auth0Res2.res;
 
       expect(response.status).toBe(307);
       // URL parameter should override static configuration
@@ -286,7 +332,10 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClientWithPAR.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+      await authClientWithPAR.handleLogin(auth0Req, auth0Res);
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       // With PAR enabled, query parameters should not be forwarded
@@ -304,7 +353,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");
@@ -321,7 +376,13 @@ describe("Organizations Feature", () => {
         }
       );
 
-      const response = await authClient.handleLogin(request);
+      const auth0Req = new Auth0NextRequest(request);
+
+      const auth0Res = new Auth0NextResponse(NextResponse.next());
+
+      await authClient.handleLogin(auth0Req, auth0Res);
+
+      const response = auth0Res.res;
 
       expect(response.status).toBe(307);
       const location = response.headers.get("location");


### PR DESCRIPTION
### 📋 Changes

Introduces an abstraction layer to decouple authentication logic from Next.js-specific `NextRequest`/`NextResponse` types. This refactor enables future support for API routes with Pages Router without duplicating authentication code.

**Impact:** No breaking changes to external APIs. This is purely an internal refactor - middleware continues to work exactly as before.

#### Motivation

The current v4 implementation is tightly coupled to Next.js middleware types (`NextRequest` / `NextResponse`). Supporting API routes or Pages Router would require duplicating all authentication logic for `NextApiRequest` / `NextApiResponse`, or adding some `if/else` brancing.

This abstraction establishes a foundation for multi-paradigm support through polymorphism rather than code duplication.

#### Overview

**New HTTP layer** (`src/server/http/`):
- `Auth0Request<TRequest>` - Abstract base class for request operations
- `Auth0Response<TResponse>` - Abstract base class for response operations
- `Auth0NextRequest` / `Auth0NextResponse` - Concrete implementations for middleware
- `Auth0RequestCookies` / `Auth0ResponseCookies` - Unified cookie interfaces

**Key design decisions:**

1. **Generic type preservation**: `Auth0Request<NextRequest>` maintains full type information through the stack
2. **Mutable response pattern**: Response methods mutate internal state.
3. **Cookie abstraction unification**: Single interface for both `RequestCookies` and `ReadonlyRequestCookies`

#### Critical Changes & Patterns

##### 1. Handler Abstraction Pattern

All authentication handlers now accept abstracted types instead of concrete Next.js types:

```typescript
// Before
async handleLogin(req: NextRequest): Promise<NextResponse>

// After
async handleLogin(req: Auth0Request, res: Auth0Response): Promise<Auth0Response>
```

This enables the same handler logic to work with any request/response implementation (middleware, API routes, route handlers).

##### 2. Response Wrapper & Header Merging

Introduced `#unwrapHandler()` helper in `auth-client.ts` that:
- Calls handlers that now return Auth0Response instead of NextResponse
- Unwraps the concrete `NextResponse` from `Auth0Response.res
- Returns the `NextResponse` instance.

The response wrapper pattern allows handlers to remain agnostic of the concrete response type while maintaining compatibility with Next.js middleware expectations in a non-breaking way.

##### 3. Session & Transaction Store Refactoring

All storage abstractions now operate on `Auth0RequestCookies` / `Auth0ResponseCookies`:

- `AbstractSessionStore` - Updated interface for get/set/delete operations
- `StatelessSessionStore` - Cookie encoding/chunking logic works with abstractions
- `StatefulSessionStore` - Database operations use abstracted cookie interfaces
- `TransactionStore` - State parameter handling via abstractions

This enables future storage implementations to work seamlessly across different Next.js contexts.

##### 4. Response 

When using NextResponse, we typically need to create a new instance and return it. However, to support Pages Router, which uses NextApiResponse, we know that it will be different in the sense that we will accept a NextApiResponse and call methods on that instance rather than return new instances. Therefore, this PR already ensures we create an Auth0Response in the beginning of all handlers, and returns the underlying `Auth0Response.res`.

This may be a bit weird looking at it purely from the  App Router perspective, but is done to support Pages Router in a follow up PR.

### 📎 References

N/A

### 🎯 Testing

- All existing middleware tests pass without modification
- New test cases covering abstraction layer behavior
