### PR TITLE
Expose default onCallback

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2197,11 +2197,12 @@ Do realize that this has an impact on the size of the cookie being issued, so it
 
 The `onCallback` hook is run once the user has been redirected back from Auth0 to your application with either an error or the authorization code which will be verified and exchanged.
 
-The `onCallback` hook receives 3 parameters:
+The `onCallback` hook receives 4 parameters:
 
 1. `error`: the error returned from Auth0 or when attempting to complete the transaction. This will be `null` if the transaction was completed successfully.
 2. `context`: provides context on the transaction that initiated the transaction.
 3. `session`: the `SessionData` that will be persisted once the transaction completes successfully. This will be `null` if there was an error.
+4. `defaultOnCallback`: the default onCallback hook that would have been called instead of the user-provided hook. This can be used if you want to take an action on callback, but keep the default callback behaviour instead of overriding it.
 
 The hook must return a Promise that resolves to a `NextResponse`.
 

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -354,7 +354,7 @@ import { NextResponse } from 'next/server';
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
 export const auth0 = new Auth0Client({
-  async onCallback(error, context, session) {
+  async onCallback(error, context, session, defaultOnCallback) {
     if (error) {
       console.error('Authentication error:', error);
       return NextResponse.redirect(

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -3993,7 +3993,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           null,
           expectedContext,
-          expectedSession
+          expectedSession,
+          expect.any(Function)
         );
 
         // validate the session cookie
@@ -4058,7 +4059,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           expect.any(Error),
           {},
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual("missing_state");
 
@@ -4137,7 +4139,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           expect.any(Error),
           {},
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual("invalid_state");
 
@@ -4219,7 +4222,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_error"
@@ -4305,7 +4309,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_code_grant_request_error"
@@ -4390,7 +4395,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_code_grant_error"
@@ -4866,7 +4872,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           null,
           expectedContext,
-          expectedSession
+          expectedSession,
+          expect.any(Function)
         );
       });
 
@@ -4940,7 +4947,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CONNECT_CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           ConnectAccountErrorCodes.MISSING_SESSION
@@ -5055,7 +5063,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CONNECT_CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           AccessTokenErrorCode.MISSING_REFRESH_TOKEN
@@ -5173,7 +5182,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             responseType: RESPONSE_TYPES.CONNECT_CODE,
             returnTo: transactionState.returnTo
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           ConnectAccountErrorCodes.FAILED_TO_COMPLETE


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [✅] All new/changed/fixed functionality is covered by tests (or N/A)
- [✅] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

We would like to define an `onCallback` hook in our code that takes an action but does not override default callback behaviour. This is currently difficult. This PR sends an extra `defaultOnCallback` parameter to `onCallback` that can be called if default callback behaviour is desired.

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Automated unit tests added.