### PR TITLE
feat: add support for mounting auth routes as api routes

### DIFF
--- a/src/server/auth-client.utils.ts
+++ b/src/server/auth-client.utils.ts
@@ -1,0 +1,66 @@
+/**
+ * This file is a first step to cleaning out auth-client.ts by moving out the
+ * utility methods into this file.
+ *
+ * This isn't a complete extraction, just a start.
+ */
+
+import { NextResponse } from "next/server.js";
+
+import {
+  Auth0NextApiResponse,
+  Auth0NextResponse,
+  Auth0Response
+} from "./http/index.js";
+
+/**
+ * Unwraps an Auth0NextResponse by extracting the underlying NextResponse.
+ *
+ * @param handler A function that returns a Promise resolving to an Auth0NextResponse.
+ * @returns A Promise that resolves to a NextResponse.
+ */
+export async function unwrapHandler(
+  handler: () => Promise<Auth0NextResponse>
+): Promise<NextResponse>;
+
+/**
+ * Unwraps an Auth0NextApiResponse by calling `.end()` on the underlying NextApiResponse if needed, and returning void.
+ * @param handler A function that returns a Promise resolving to an Auth0NextApiResponse.
+ * @returns A Promise that's void'.
+ */
+export async function unwrapHandler(
+  handler: () => Promise<Auth0NextApiResponse>
+): Promise<void>;
+
+/**
+ * Unwraps an Auth0Response by extracting the underlying NextResponse, or calling `.end()` on the underlying NextApiResponse if needed, and returning void.
+ * @param handler A function that returns a Promise resolving to an Auth0Response.
+ * @returns A Promise that resolves to a NextResponse or void (in case of Pages Router usage).
+ */
+export async function unwrapHandler(
+  handler: () => Promise<Auth0Response>
+): Promise<NextResponse | void>;
+
+/**
+ * Unwraps an Auth0Response by extracting the underlying NextResponse, or calling `.end()` on the underlying NextApiResponse.
+ * This utility simplifies the pattern of awaiting handler calls and accessing .res
+ *
+ * @param handler A function that returns a Promise resolving to an Auth0Response.
+ * @returns A Promise that resolves to a NextResponse or void (in case of Pages Router usage).
+ */
+export async function unwrapHandler(
+  handler: () => Promise<Auth0Response>
+): Promise<NextResponse | void> {
+  const auth0Response = await handler();
+  const response = auth0Response.res;
+  const canEndRequest =
+    response && "end" in response && typeof response.end === "function";
+
+  // When the underlying response supports .end(), call it to finalize the response without returning the NextApiResponse instance.
+  // NextResponse does not have .end(), instead we return the NextResponse instance.
+  if (canEndRequest && !response.headersSent) {
+    response.end();
+  } else {
+    return response as NextResponse;
+  }
+}

--- a/src/server/http/auth0-api-response-cookies.test.ts
+++ b/src/server/http/auth0-api-response-cookies.test.ts
@@ -1,0 +1,484 @@
+import { NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+
+import { Auth0ApiResponseCookies } from "./auth0-api-response-cookies.js";
+
+/**
+ * Creates a mock NextApiResponse for testing
+ */
+function createMockNextApiResponse(): NextApiResponse {
+  const headers: Record<string, string | string[]> = {};
+
+  const res = {
+    setHeader: vi.fn((name: string, value: string | string[]) => {
+      headers[name.toLowerCase()] = value;
+      return res;
+    }),
+    getHeader: vi.fn((name: string) => headers[name.toLowerCase()]),
+    getHeaders: vi.fn(() => headers),
+    removeHeader: vi.fn((name: string) => {
+      delete headers[name.toLowerCase()];
+      return res;
+    }),
+    // Add internal headers access for testing
+    _getInternalHeaders: () => headers
+  } as unknown as NextApiResponse & {
+    _getInternalHeaders: () => Record<string, string | string[]>;
+  };
+
+  return res;
+}
+
+describe("Auth0ApiResponseCookies", () => {
+  describe("constructor", () => {
+    it("should create an instance with NextApiResponse", () => {
+      const mockRes = createMockNextApiResponse();
+
+      expect(() => {
+        new Auth0ApiResponseCookies(mockRes);
+      }).not.toThrow();
+    });
+
+    it("should initialize with existing headers from response", () => {
+      const mockRes = createMockNextApiResponse();
+      mockRes.setHeader("X-Custom", "value");
+
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      expect(cookies).toBeDefined();
+    });
+  });
+
+  describe("set()", () => {
+    it("should set a cookie and sync to NextApiResponse", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "abc123");
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+      expect(setCookieCall).toBeDefined();
+    });
+
+    it("should set cookie with httpOnly flag", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token123", { httpOnly: true });
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+      expect(setCookieCall).toBeDefined();
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("session=token123");
+      expect(setCookieValue).toContain("HttpOnly");
+    });
+
+    it("should set cookie with secure flag", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", { secure: true });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("Secure");
+    });
+
+    it("should set cookie with sameSite flag", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", { sameSite: "lax" });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("SameSite=lax");
+    });
+
+    it("should set cookie with maxAge", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", { maxAge: 3600 });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("Max-Age=3600");
+    });
+
+    it("should set cookie with path", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", { path: "/api" });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("Path=/api");
+    });
+
+    it("should set cookie with multiple options", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+        maxAge: 7200,
+        path: "/"
+      });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1][0]
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("session=token");
+      expect(setCookieValue).toContain("HttpOnly");
+      expect(setCookieValue).toContain("Secure");
+      expect(setCookieValue).toContain("SameSite=strict");
+      expect(setCookieValue).toContain("Max-Age=7200");
+      expect(setCookieValue).toContain("Path=/");
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      const result = cookies.set("test", "value");
+
+      expect(result).toBe(cookies);
+    });
+
+    it("should handle multiple cookies", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("cookie1", "value1");
+      cookies.set("cookie2", "value2");
+      cookies.set("cookie3", "value3");
+
+      const setCookieCalls = (mockRes.setHeader as any).mock.calls.filter(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      expect(setCookieCalls.length).toBeGreaterThan(0);
+    });
+
+    it("should update existing cookie value", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "old-value");
+      cookies.set("session", "new-value");
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.findLast(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      const setCookieValue = Array.isArray(setCookieCall[1])
+        ? setCookieCall[1].find((v: string) => v.includes("session="))
+        : setCookieCall[1];
+      expect(setCookieValue).toContain("session=new-value");
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a cookie and sync to NextApiResponse", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token");
+      cookies.delete("session");
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+    });
+
+    it("should set expiration date in the past when deleting", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token");
+      cookies.delete("session");
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.findLast(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+
+      expect(setCookieCall).toBeDefined();
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("test", "value");
+      const result = cookies.delete("test");
+
+      expect(result).toBe(cookies);
+    });
+
+    it("should handle deleting non-existent cookie", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      expect(() => {
+        cookies.delete("nonexistent");
+      }).not.toThrow();
+    });
+
+    it("should handle deleting multiple cookies", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("cookie1", "value1");
+      cookies.set("cookie2", "value2");
+
+      cookies.delete("cookie1");
+      cookies.delete("cookie2");
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+    });
+  });
+
+  describe("get()", () => {
+    it("should retrieve a cookie that was set", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "abc123");
+      const cookie = cookies.get("session");
+
+      expect(cookie).toBeDefined();
+      expect(cookie?.name).toBe("session");
+      expect(cookie?.value).toBe("abc123");
+    });
+
+    it("should return undefined for non-existent cookie", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      const cookie = cookies.get("nonexistent");
+
+      expect(cookie).toBeUndefined();
+    });
+
+    it("should retrieve cookie with attributes", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax"
+      });
+
+      const cookie = cookies.get("session");
+
+      expect(cookie?.httpOnly).toBe(true);
+      expect(cookie?.secure).toBe(true);
+      expect(cookie?.sameSite).toBe("lax");
+    });
+  });
+
+  describe("getAll()", () => {
+    it("should retrieve all cookies", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("cookie1", "value1");
+      cookies.set("cookie2", "value2");
+      cookies.set("cookie3", "value3");
+
+      const allCookies = cookies.getAll();
+
+      expect(allCookies.length).toBe(3);
+      expect(allCookies.map((c) => c.name)).toContain("cookie1");
+      expect(allCookies.map((c) => c.name)).toContain("cookie2");
+      expect(allCookies.map((c) => c.name)).toContain("cookie3");
+    });
+
+    it("should return empty array when no cookies set", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      const allCookies = cookies.getAll();
+
+      expect(Array.isArray(allCookies)).toBe(true);
+      expect(allCookies.length).toBe(0);
+    });
+  });
+
+  describe("has()", () => {
+    it("should return true if cookie exists", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("session", "token");
+
+      expect(cookies.has("session")).toBe(true);
+    });
+
+    it("should return false if cookie does not exist", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      expect(cookies.has("nonexistent")).toBe(false);
+    });
+
+    it("should be case-sensitive", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("Session", "token");
+
+      expect(cookies.has("Session")).toBe(true);
+      expect(cookies.has("session")).toBe(false);
+    });
+  });
+
+  describe("syncToResponse()", () => {
+    it("should sync cookies to NextApiResponse headers", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("test", "value");
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        "Set-Cookie",
+        expect.anything()
+      );
+    });
+
+    it("should handle multiple cookies in sync", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("cookie1", "value1");
+
+      const firstCallCount = (mockRes.setHeader as any).mock.calls.length;
+
+      cookies.set("cookie2", "value2");
+
+      const secondCallCount = (mockRes.setHeader as any).mock.calls.length;
+
+      expect(secondCallCount).toBeGreaterThan(firstCallCount);
+    });
+
+    it("should remove Set-Cookie header when all cookies are deleted", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("cookie1", "value1");
+      cookies.delete("cookie1");
+
+      // After deleting all cookies, the implementation may call removeHeader or setHeader
+      // depending on whether there are any cookies left
+      expect(
+        (mockRes.removeHeader as any).mock.calls.some(
+          (call: any) => call[0] === "Set-Cookie"
+        ) ||
+          (mockRes.setHeader as any).mock.calls.some(
+            (call: any) => call[0] === "Set-Cookie"
+          )
+      ).toBe(true);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle session cookie lifecycle", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      // Set session cookie
+      cookies.set("session", "user-session-token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        maxAge: 86400,
+        path: "/"
+      });
+
+      expect(cookies.has("session")).toBe(true);
+
+      // Update session cookie
+      cookies.set("session", "new-session-token", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        maxAge: 86400,
+        path: "/"
+      });
+
+      const cookie = cookies.get("session");
+      expect(cookie?.value).toBe("new-session-token");
+
+      // Delete session cookie
+      cookies.delete("session");
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+    });
+
+    it("should handle multiple authentication cookies", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      cookies.set("access_token", "at_token", { httpOnly: true, maxAge: 3600 });
+      cookies.set("refresh_token", "rt_token", {
+        httpOnly: true,
+        maxAge: 604800
+      });
+      cookies.set("id_token", "id_token", { httpOnly: true, maxAge: 3600 });
+
+      expect(cookies.has("access_token")).toBe(true);
+      expect(cookies.has("refresh_token")).toBe(true);
+      expect(cookies.has("id_token")).toBe(true);
+
+      const allCookies = cookies.getAll();
+      expect(allCookies.length).toBe(3);
+    });
+
+    it("should handle cookie with special characters in value", () => {
+      const mockRes = createMockNextApiResponse();
+      const cookies = new Auth0ApiResponseCookies(mockRes);
+
+      const complexValue = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0";
+      cookies.set("jwt", complexValue, { httpOnly: true });
+
+      const cookie = cookies.get("jwt");
+      expect(cookie?.value).toBe(complexValue);
+    });
+  });
+});

--- a/src/server/http/auth0-api-response-cookies.ts
+++ b/src/server/http/auth0-api-response-cookies.ts
@@ -1,0 +1,68 @@
+import { NextApiResponse } from "next";
+
+import { ResponseCookies } from "../cookies.js";
+import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+
+/**
+ * A wrapper around Auth0ResponseCookies that syncs cookie changes
+ * back to the NextApiResponse.
+ *
+ * The problem: ResponseCookies operates on a Headers object, but changes to this
+ * Headers object don't automatically propagate to NextApiResponse's internal headers.
+ *
+ * This class solves the issue by intercepting write operations (set, delete) and
+ * syncing the changes back to the NextApiResponse after each mutation.
+ */
+export class Auth0ApiResponseCookies extends Auth0ResponseCookies {
+  private readonly headers: Headers;
+
+  constructor(private res: NextApiResponse) {
+    const headers = new Headers(res.getHeaders() as Record<string, string>);
+    const responseCookies = new ResponseCookies(headers);
+    super(responseCookies);
+
+    this.headers = headers;
+  }
+
+  /**
+   * Sets a cookie value and syncs the change to the NextApiResponse.
+   * @param args Arguments passed to ResponseCookies.set()
+   */
+  set(...args: Parameters<ResponseCookies["set"]>) {
+    super.set(...args);
+    this.syncToResponse();
+    return this;
+  }
+
+  /**
+   * Deletes a cookie and syncs the change to the NextApiResponse.
+   * @param args Arguments passed to ResponseCookies.delete()
+   */
+  delete(...args: Parameters<ResponseCookies["delete"]>) {
+    super.delete(...args);
+    this.syncToResponse();
+    return this;
+  }
+
+  /**
+   * Syncs cookie changes from the internal Headers object to the NextApiResponse.
+   *
+   * This method extracts the 'set-cookie' header from the internal Headers object
+   * and applies it to the NextApiResponse, ensuring that all cookie mutations
+   * are reflected in the actual HTTP response.
+   */
+  private syncToResponse(): void {
+    // The Headers API provides getSetCookie() to properly handle multiple set-cookie headers
+    // Each cookie must be a separate header value, not comma-separated
+    const setCookieHeaders = (this.headers as any).getSetCookie?.() || [];
+
+    if (setCookieHeaders.length > 0) {
+      // NextApiResponse's setHeader accepts either a string or an array of strings
+      // When it's an array, each element becomes a separate header value
+      this.res.setHeader("Set-Cookie", setCookieHeaders);
+    } else {
+      // If there are no set-cookie headers, clear them from the response
+      this.res.removeHeader("Set-Cookie");
+    }
+  }
+}

--- a/src/server/http/auth0-next-api-request.test.ts
+++ b/src/server/http/auth0-next-api-request.test.ts
@@ -1,0 +1,502 @@
+import { NextApiRequest } from "next";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { Auth0NextApiRequest } from "./auth0-next-api-request.js";
+
+/**
+ * Creates a mock NextApiRequest for testing
+ */
+function createMockNextApiRequest(
+  url: string,
+  options: {
+    method?: string;
+    body?: any;
+    cookies?: Record<string, string>;
+    headers?: Record<string, string>;
+  } = {}
+): NextApiRequest {
+  const urlObj = new URL(url);
+  const { method = "GET", body = {}, cookies = {}, headers = {} } = options;
+
+  return {
+    method,
+    url: urlObj.pathname + urlObj.search,
+    headers: {
+      host: urlObj.host,
+      ...headers
+    },
+    body,
+    cookies,
+    query: Object.fromEntries(urlObj.searchParams.entries())
+  } as NextApiRequest;
+}
+
+describe("Auth0NextApiRequest", () => {
+  const originalAppBaseUrl = process.env.APP_BASE_URL;
+
+  beforeEach(() => {
+    process.env.APP_BASE_URL = "https://example.com";
+  });
+
+  afterEach(() => {
+    process.env.APP_BASE_URL = originalAppBaseUrl;
+  });
+
+  describe("getUrl()", () => {
+    it("should return the request URL", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login"
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.href).toContain("example.com");
+      expect(url.pathname).toBe("/api/auth/login");
+    });
+
+    it("should construct URL using APP_BASE_URL environment variable", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/callback"
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url.href).toBe("https://example.com/api/auth/callback");
+    });
+
+    it("should include query parameters in the URL", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login?returnTo=/dashboard"
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("returnTo")).toBe("/dashboard");
+    });
+
+    it("should handle complex URLs with multiple query parameters", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/callback?code=abc123&state=xyz789"
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("code")).toBe("abc123");
+      expect(url.searchParams.get("state")).toBe("xyz789");
+    });
+
+    it("should handle URLs with encoded characters", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login?email=user%40example.com"
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("email")).toBe("user@example.com");
+    });
+  });
+
+  describe("getMethod()", () => {
+    it("should return the HTTP method for GET requests", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "GET"
+      });
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.getMethod()).toBe("GET");
+    });
+
+    it("should return the HTTP method for POST requests", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST"
+      });
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.getMethod()).toBe("POST");
+    });
+
+    it("should return the HTTP method for other HTTP methods", () => {
+      const methods = ["PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"];
+
+      methods.forEach((method) => {
+        const mockReq = createMockNextApiRequest(
+          "https://example.com/api/test",
+          { method }
+        );
+        const auth0Request = new Auth0NextApiRequest(mockReq);
+
+        expect(auth0Request.getMethod()).toBe(method);
+      });
+    });
+
+    it("should handle lowercase method names", () => {
+      const mockReq = {
+        method: "get",
+        url: "/api/test",
+        headers: {},
+        body: {},
+        cookies: {},
+        query: {}
+      } as NextApiRequest;
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.getMethod()).toBe("get");
+    });
+  });
+
+  describe("getBody()", () => {
+    it("should return the request body as an object", () => {
+      const body = { username: "test", password: "secret" };
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST",
+        body
+      });
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      const requestBody = auth0Request.getBody();
+
+      expect(requestBody).toEqual(body);
+    });
+
+    it("should return the request body for JSON content", () => {
+      const jsonBody = { key: "value", nested: { prop: "data" } };
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST",
+        body: jsonBody,
+        headers: { "content-type": "application/json" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const body = auth0Request.getBody();
+
+      expect(body).toEqual(jsonBody);
+    });
+
+    it("should return the request body for form data", () => {
+      const formData = {
+        username: "user@example.com",
+        password: "secret"
+      };
+
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST",
+        body: formData,
+        headers: { "content-type": "application/x-www-form-urlencoded" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const body = auth0Request.getBody();
+
+      expect(body).toEqual(formData);
+    });
+
+    it("should return empty object for requests with no body", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "GET"
+      });
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      const body = auth0Request.getBody();
+
+      expect(body).toEqual({});
+    });
+
+    it("should handle complex nested objects in body", () => {
+      const complexBody = {
+        user: {
+          name: "John Doe",
+          email: "john@example.com",
+          preferences: {
+            theme: "dark",
+            notifications: true
+          }
+        },
+        metadata: {
+          timestamp: "2024-01-01",
+          source: "web"
+        }
+      };
+
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST",
+        body: complexBody
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const body = auth0Request.getBody();
+
+      expect(body).toEqual(complexBody);
+    });
+  });
+
+  describe("getHeaders()", () => {
+    it("should return the request headers", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer token123"
+        }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("content-type")).toBe("application/json");
+      expect(headers.get("authorization")).toBe("Bearer token123");
+    });
+
+    it("should be case-insensitive for header names", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        headers: { "Content-Type": "text/html" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("content-type")).toBe("text/html");
+      expect(headers.get("Content-Type")).toBe("text/html");
+      expect(headers.get("CONTENT-TYPE")).toBe("text/html");
+    });
+
+    it("should include custom headers", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        headers: {
+          "x-custom-header": "custom-value",
+          "x-another-header": "another-value"
+        }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("x-custom-header")).toBe("custom-value");
+      expect(headers.get("x-another-header")).toBe("another-value");
+    });
+
+    it("should include host header from request", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test");
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers.get("host")).toBe("example.com");
+    });
+
+    it("should handle empty headers", () => {
+      const mockReq = {
+        method: "GET",
+        url: "/api/test",
+        headers: {},
+        body: {},
+        cookies: {},
+        query: {}
+      } as NextApiRequest;
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const headers = auth0Request.getHeaders();
+
+      expect(headers).toBeInstanceOf(Headers);
+    });
+  });
+
+  describe("clone()", () => {
+    it("should return the original request", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        method: "POST",
+        body: { test: "data" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const clonedRequest = auth0Request.clone();
+
+      expect(clonedRequest).toBe(mockReq);
+    });
+
+    it("should preserve request properties", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/test",
+        {
+          method: "POST",
+          headers: { "x-test": "value" },
+          body: { key: "value" }
+        }
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const clonedRequest = auth0Request.clone();
+
+      expect(clonedRequest.method).toBe("POST");
+      expect(clonedRequest.headers["x-test"]).toBe("value");
+      expect(clonedRequest.body).toEqual({ key: "value" });
+    });
+  });
+
+  describe("getCookies()", () => {
+    it("should return Auth0RequestCookies object", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        cookies: { session: "abc123", preferences: "dark" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies).toBeDefined();
+      expect(typeof cookies.get).toBe("function");
+      expect(typeof cookies.getAll).toBe("function");
+      expect(typeof cookies.has).toBe("function");
+    });
+
+    it("should provide access to cookies from request", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        cookies: { session: "abc123", "auth-token": "xyz789" }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.get("session")?.value).toBe("abc123");
+      expect(cookies.get("auth-token")?.value).toBe("xyz789");
+      expect(cookies.has("session")).toBe(true);
+      expect(cookies.has("auth-token")).toBe(true);
+    });
+
+    it("should handle requests with no cookies", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        cookies: {}
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.getAll()).toEqual([]);
+      expect(cookies.has("nonexistent")).toBe(false);
+    });
+
+    it("should handle cookies with special characters", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        cookies: {
+          "session-token": "abc123",
+          user_id: "12345"
+        }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.get("session-token")?.value).toBe("abc123");
+      expect(cookies.get("user_id")?.value).toBe("12345");
+    });
+
+    it("should handle multiple cookies", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test", {
+        cookies: {
+          cookie1: "value1",
+          cookie2: "value2",
+          cookie3: "value3"
+        }
+      });
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      const allCookies = cookies.getAll();
+      expect(allCookies.length).toBe(3);
+    });
+  });
+
+  describe("constructor", () => {
+    it("should store the underlying NextApiRequest", () => {
+      const mockReq = createMockNextApiRequest("https://example.com/api/test");
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.req).toBe(mockReq);
+    });
+
+    it("should accept NextApiRequest as constructor argument", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login",
+        {
+          method: "GET"
+        }
+      );
+
+      expect(() => {
+        new Auth0NextApiRequest(mockReq);
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle OAuth callback scenario", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/callback?code=auth0_code&state=random_state",
+        { method: "GET" }
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.getMethod()).toBe("GET");
+      const url = auth0Request.getUrl();
+      expect(url.searchParams.get("code")).toBe("auth0_code");
+      expect(url.searchParams.get("state")).toBe("random_state");
+    });
+
+    it("should handle login form submission scenario", () => {
+      const formBody = {
+        email: "user@example.com",
+        password: "secret123"
+      };
+
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login",
+        {
+          method: "POST",
+          body: formBody,
+          headers: { "content-type": "application/x-www-form-urlencoded" }
+        }
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+
+      expect(auth0Request.getMethod()).toBe("POST");
+      const body = auth0Request.getBody();
+      expect(body).toEqual(formBody);
+    });
+
+    it("should handle logout with session cookie scenario", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/logout",
+        {
+          method: "GET",
+          cookies: { session: "user_session_token", auth0_id: "user123" }
+        }
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const cookies = auth0Request.getCookies();
+
+      expect(cookies.has("session")).toBe(true);
+      expect(cookies.has("auth0_id")).toBe(true);
+    });
+
+    it("should handle API route with organization parameter", () => {
+      const mockReq = createMockNextApiRequest(
+        "https://example.com/api/auth/login?organization=org_123",
+        { method: "GET" }
+      );
+
+      const auth0Request = new Auth0NextApiRequest(mockReq);
+      const url = auth0Request.getUrl();
+
+      expect(url.searchParams.get("organization")).toBe("org_123");
+    });
+  });
+});

--- a/src/server/http/auth0-next-api-request.ts
+++ b/src/server/http/auth0-next-api-request.ts
@@ -1,0 +1,75 @@
+import { NextApiRequest } from "next";
+import { RequestCookies } from "@edge-runtime/cookies";
+import { Auth0RequestCookies } from "./auth0-request-cookies.js";
+import { Auth0Request } from "./auth0-request.js";
+
+/**
+ * An implementation of Auth0Request for Next.js' NextApiRequest.
+ */
+export class Auth0NextApiRequest extends Auth0Request<NextApiRequest> {
+  public constructor(req: NextApiRequest) {
+    /* c8 ignore next */
+    super(req);
+  }
+
+  /**
+   * Retrieves the full URL of the request.
+   * @returns The URL object representing the request URL.
+   */
+  public getUrl(): URL {
+    return new URL(`${process.env.APP_BASE_URL}${this.req.url}`);
+  }
+
+  /**
+   * Retrieves the HTTP method of the request.
+   * @returns The HTTP method as a string.
+   */
+  public getMethod(): string {
+    return this.req.method as string;
+  }
+
+  /**
+   * Retrieves the body of the request.
+   * @returns The body of the request, either as a string or an object.
+   */
+  public getBody(): Record<string, string> {
+    return this.req.body;
+  }
+
+  /**
+   * Retrieves the headers of the request.
+   * @returns The Headers object representing the request headers.
+   */
+  public getHeaders(): Headers {
+    return new Headers(this.req.headers as Record<string, string>);
+  }
+
+  /**
+   * Clones the underlying NextApiRequest.
+   * @returns A cloned NextApiRequest object.
+   */
+  public clone(): NextApiRequest {
+    // This isn't cloning in the traditional sense, as NextApiRequest cannot be truly cloned.
+    // However, we return the original request here for compatibility.
+
+    // TODO: Test if this works as expected when using DPoP, which is when `request.clone()` is called in `#handleProxy`.
+    // However, perhaps we may keep the `handleProxy` inside a proxy (undecided)? In that case, `clone()` shouldn't ever even be called on `Auth0NextApiRequest`.
+    return this.req;
+  }
+
+  /**
+   * Retrieves the cookies from the request.
+   * @returns An Auth0RequestCookies object representing the request cookies.
+   */
+  public getCookies(): Auth0RequestCookies {
+    // Convert plain object cookies to RequestCookies
+    const headers = new Headers();
+    const cookieString = Object.entries(this.req.cookies || {})
+      .map(([name, value]) => `${name}=${value}`)
+      .join("; ");
+    if (cookieString) {
+      headers.set("cookie", cookieString);
+    }
+    return new Auth0RequestCookies(new RequestCookies(headers));
+  }
+}

--- a/src/server/http/auth0-next-api-response.test.ts
+++ b/src/server/http/auth0-next-api-response.test.ts
@@ -1,0 +1,471 @@
+import { NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+
+import { Auth0NextApiResponse } from "./auth0-next-api-response.js";
+
+/**
+ * Creates a mock NextApiResponse for testing
+ */
+function createMockNextApiResponse(): NextApiResponse {
+  const headers: Record<string, string | string[]> = {};
+  let statusCode = 200;
+  let statusMessage = "OK";
+  const writtenData: any[] = [];
+
+  const res = {
+    statusCode,
+    statusMessage,
+    setHeader: vi.fn((name: string, value: string | string[]) => {
+      headers[name.toLowerCase()] = value;
+      return res;
+    }),
+    getHeader: vi.fn((name: string) => headers[name.toLowerCase()]),
+    getHeaders: vi.fn(() => headers),
+    removeHeader: vi.fn((name: string) => {
+      delete headers[name.toLowerCase()];
+      return res;
+    }),
+    status: vi.fn((code: number) => {
+      statusCode = code;
+      res.statusCode = code;
+      return res;
+    }),
+    redirect: vi.fn((url: string) => {
+      res.setHeader("Location", url);
+      res.status(302);
+      return res;
+    }),
+    json: vi.fn((data: any) => {
+      res.setHeader("Content-Type", "application/json");
+      writtenData.push(JSON.stringify(data));
+      return res;
+    }),
+    send: vi.fn((data: any) => {
+      writtenData.push(data);
+      return res;
+    }),
+    end: vi.fn(() => res),
+    // Add a getter to access written data for testing
+    _getWrittenData: () => writtenData
+  } as unknown as NextApiResponse & { _getWrittenData: () => any[] };
+
+  return res;
+}
+
+describe("Auth0NextApiResponse", () => {
+  describe("getCookies()", () => {
+    it("should return Auth0ApiResponseCookies object", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const cookies = auth0Response.getCookies();
+
+      expect(cookies).toBeDefined();
+      expect(typeof cookies.get).toBe("function");
+      expect(typeof cookies.set).toBe("function");
+      expect(typeof cookies.delete).toBe("function");
+    });
+
+    it("should allow setting cookies", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const cookies = auth0Response.getCookies();
+      expect(() => {
+        cookies.set("session", "token123", {
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          path: "/"
+        });
+      }).not.toThrow();
+
+      expect(mockRes.setHeader).toHaveBeenCalled();
+    });
+
+    it("should sync cookie changes to NextApiResponse", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const cookies = auth0Response.getCookies();
+      cookies.set("test-cookie", "test-value", {
+        maxAge: 3600,
+        httpOnly: true
+      });
+
+      const setCookieCall = (mockRes.setHeader as any).mock.calls.find(
+        (call: any) => call[0] === "Set-Cookie"
+      );
+      expect(setCookieCall).toBeDefined();
+    });
+  });
+
+  describe("redirect()", () => {
+    it("should set redirect location header", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.redirect("https://example.com/callback");
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        "https://example.com/callback"
+      );
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        "Location",
+        "https://example.com/callback"
+      );
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const result = auth0Response.redirect("https://example.com/redirect");
+
+      expect(result).toBe(auth0Response);
+    });
+
+    it("should handle Auth0 authorization URLs", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const authUrl =
+        "https://test.auth0.com/authorize?client_id=test&redirect_uri=http://localhost/callback";
+      auth0Response.redirect(authUrl);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(authUrl);
+    });
+
+    it("should handle relative URLs", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.redirect("/dashboard");
+
+      expect(mockRes.redirect).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  describe("status()", () => {
+    it("should set status code and send message", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.status("Unauthorized", 401);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.send).toHaveBeenCalledWith("Unauthorized");
+    });
+
+    it("should handle null message", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.status(null, 500);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith(null);
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const result = auth0Response.status("OK", 200);
+
+      expect(result).toBe(auth0Response);
+    });
+
+    it("should support various HTTP status codes", () => {
+      const codes = [200, 201, 204, 400, 401, 403, 404, 500, 502, 503];
+
+      codes.forEach((code) => {
+        const mockRes = createMockNextApiResponse();
+        const auth0Response = new Auth0NextApiResponse(mockRes);
+
+        auth0Response.status("message", code);
+
+        expect(mockRes.status).toHaveBeenCalledWith(code);
+      });
+    });
+
+    it("should send error messages", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.status("Internal Server Error", 500);
+
+      expect(mockRes.send).toHaveBeenCalledWith("Internal Server Error");
+    });
+  });
+
+  describe("json()", () => {
+    it("should send JSON response", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const data = { token: "abc123", user: { id: 1 } };
+      auth0Response.json(data);
+
+      expect(mockRes.json).toHaveBeenCalledWith(data);
+    });
+
+    it("should set status code when provided in init", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.json({ error: "Unauthorized" }, { status: 401 });
+
+      expect(mockRes.statusCode).toBe(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+    });
+
+    it("should set custom headers when provided in init", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.json(
+        { data: "test" },
+        {
+          headers: { "X-Custom-Header": "test-value" }
+        }
+      );
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        "X-Custom-Header",
+        "test-value"
+      );
+    });
+
+    it("should handle empty object", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.json({});
+
+      expect(mockRes.json).toHaveBeenCalledWith({});
+    });
+
+    it("should handle nested objects", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const data = {
+        user: {
+          profile: {
+            name: "John",
+            email: "john@example.com"
+          }
+        }
+      };
+      auth0Response.json(data);
+
+      expect(mockRes.json).toHaveBeenCalledWith(data);
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const result = auth0Response.json({ test: "data" });
+
+      expect(result).toBe(auth0Response);
+    });
+
+    it("should handle arrays", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const data = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      auth0Response.json(data);
+
+      expect(mockRes.json).toHaveBeenCalledWith(data);
+    });
+  });
+
+  describe("addCacheControlHeadersForSession()", () => {
+    it("should add cache control headers", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        "Cache-Control",
+        expect.any(String)
+      );
+      expect(mockRes.setHeader).toHaveBeenCalledWith("Pragma", "no-cache");
+      expect(mockRes.setHeader).toHaveBeenCalledWith("Expires", "0");
+    });
+
+    it("should prevent caching with appropriate headers", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.addCacheControlHeadersForSession();
+
+      const calls = (mockRes.setHeader as any).mock.calls;
+      const cacheControlCalls = calls.filter(
+        (call: any) => call[0] === "Cache-Control"
+      );
+
+      expect(cacheControlCalls.length).toBeGreaterThan(0);
+      expect(cacheControlCalls.some((call: any) => call[1] === "no-store")).toBe(
+        true
+      );
+    });
+  });
+
+  describe("setResponse()", () => {
+    it("should update the internal response object", () => {
+      const mockRes1 = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes1);
+
+      const mockRes2 = createMockNextApiResponse();
+      auth0Response.setResponse(mockRes2);
+
+      expect(auth0Response.res).toBe(mockRes2);
+    });
+
+    it("should allow changing response mid-processing", () => {
+      const mockRes1 = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes1);
+
+      const mockRes2 = createMockNextApiResponse();
+      auth0Response.setResponse(mockRes2);
+
+      auth0Response.status("OK", 200);
+
+      expect(mockRes2.status).toHaveBeenCalledWith(200);
+      expect(mockRes1.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generic()", () => {
+    it("should send generic response with body and init", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.generic("Response body", {
+        status: 201,
+        statusText: "Created",
+        headers: { "Content-Type": "text/plain" }
+      });
+
+      expect(mockRes.statusCode).toBe(201);
+      expect(mockRes.statusMessage).toBe("Created");
+      expect(mockRes.setHeader).toHaveBeenCalledWith("Content-Type", "text/plain");
+      expect(mockRes.send).toHaveBeenCalledWith("Response body");
+    });
+
+    it("should handle null body", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.generic(null, {
+        status: 204
+      });
+
+      expect(mockRes.statusCode).toBe(204);
+      expect(mockRes.send).toHaveBeenCalledWith(null);
+    });
+
+    it("should apply multiple headers", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.generic("body", {
+        status: 200,
+        headers: {
+          "X-Custom-1": "value1",
+          "X-Custom-2": "value2"
+        }
+      });
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith("X-Custom-1", "value1");
+      expect(mockRes.setHeader).toHaveBeenCalledWith("X-Custom-2", "value2");
+    });
+
+    it("should return this for method chaining", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const result = auth0Response.generic("test", { status: 200 });
+
+      expect(result).toBe(auth0Response);
+    });
+  });
+
+  describe("constructor", () => {
+    it("should store the underlying NextApiResponse", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      expect(auth0Response.res).toBe(mockRes);
+    });
+
+    it("should accept NextApiResponse as constructor argument", () => {
+      const mockRes = createMockNextApiResponse();
+
+      expect(() => {
+        new Auth0NextApiResponse(mockRes);
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle OAuth callback success", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.redirect("/dashboard");
+
+      expect(mockRes.redirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("should handle authentication error", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      auth0Response.json(
+        { error: "invalid_grant", error_description: "Invalid credentials" },
+        { status: 401 }
+      );
+
+      expect(mockRes.statusCode).toBe(401);
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    it("should handle logout flow", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const cookies = auth0Response.getCookies();
+      cookies.delete("session");
+
+      auth0Response.redirect("https://auth0.com/v2/logout");
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+    });
+
+    it("should handle user info response", () => {
+      const mockRes = createMockNextApiResponse();
+      const auth0Response = new Auth0NextApiResponse(mockRes);
+
+      const userInfo = {
+        sub: "auth0|123",
+        name: "John Doe",
+        email: "john@example.com"
+      };
+
+      auth0Response.json(userInfo);
+      auth0Response.addCacheControlHeadersForSession();
+
+      expect(mockRes.json).toHaveBeenCalledWith(userInfo);
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        "Cache-Control",
+        expect.any(String)
+      );
+    });
+  });
+});

--- a/src/server/http/auth0-next-api-response.ts
+++ b/src/server/http/auth0-next-api-response.ts
@@ -1,0 +1,108 @@
+import { NextApiResponse } from "next";
+
+import { Auth0ApiResponseCookies } from "./auth0-api-response-cookies.js";
+import { Auth0ResponseCookies } from "./auth0-response-cookies.js";
+import { Auth0Response } from "./auth0-response.js";
+
+/**
+ * An implementation of Auth0Response for Next.js' NextApiResponse.
+ */
+export class Auth0NextApiResponse extends Auth0Response<NextApiResponse> {
+  public constructor(res: NextApiResponse) {
+    /* c8 ignore next */
+    super(res);
+  }
+
+  /**
+   * Retrieves the cookies from the response.
+   * @returns An Auth0ResponseCookies object representing the response cookies.
+   */
+  getCookies(): Auth0ResponseCookies {
+    return new Auth0ApiResponseCookies(this.res);
+  }
+
+  /**
+   * Redirects the response to the specified URL.
+   * @param url The URL to redirect to.
+   */
+  redirect(url: string) {
+    this.res = this.res.redirect(url);
+    return this;
+  }
+
+  /**
+   * Sets the status code of the response.
+   * @param status The HTTP status code to set.
+   */
+  status(message: string | null, status: number) {
+    this.res = this.res.status(status);
+    this.res.send(message);
+
+    return this;
+  }
+
+  /**
+   * Sends a JSON response.
+   * @param body The body to send as JSON.
+   * @param init Optional response initialization options.
+   */
+  json(body: any, init?: ResponseInit) {
+    if (init) {
+      this.#applyResponseInit(this.res, init);
+    }
+    this.res.json(body);
+
+    return this;
+  }
+
+  /**
+   * Adds cache control headers for session handling.
+   */
+  addCacheControlHeadersForSession(): void {
+    this.res = this.res
+      .setHeader("Cache-Control", "no-store")
+      .setHeader(
+        "Cache-Control",
+        "private, no-cache, no-store, must-revalidate, max-age=0"
+      )
+      .setHeader("Pragma", "no-cache")
+      .setHeader("Expires", "0");
+  }
+
+  /**
+   * Sets the response object (no-op for API routes as response is mutated directly).
+   * @param res The response object to set.
+   */
+  setResponse(res: NextApiResponse): void {
+    this.res = res;
+  }
+
+  /**
+   * Sends a generic response with body and init options.
+   * @param body The body to send.
+   * @param init Response initialization options.
+   */
+  generic(body: BodyInit | null, init: ResponseInit) {
+    this.#applyResponseInit(this.res, init);
+    this.res.send(body);
+
+    return this;
+  }
+
+  #applyResponseInit(res: NextApiResponse, init: ResponseInit) {
+    if (init.status) {
+      res.statusCode = init.status;
+    }
+
+    if (init.statusText) {
+      res.statusMessage = init.statusText;
+    }
+
+    if (init.headers) {
+      const headers = Object.entries(init.headers);
+      headers.forEach(([key, value]) => {
+        res.setHeader(key, value as string);
+      });
+    }
+  }
+}

--- a/src/server/http/auth0-request.ts
+++ b/src/server/http/auth0-request.ts
@@ -1,3 +1,4 @@
+import { NextApiRequest } from "next";
 import { Auth0RequestCookies } from "./auth0-request-cookies.js";
 
 /**
@@ -69,7 +70,7 @@ export abstract class Auth0Request<TRequest = any> {
    *
    * @returns A cloned Request object that is independent of the original.
    */
-  public abstract clone(): Request;
+  public abstract clone(): Request | NextApiRequest;
 
   /**
    * Retrieves the cookies from the request.

--- a/src/server/http/index.ts
+++ b/src/server/http/index.ts
@@ -4,3 +4,5 @@ export { Auth0RequestCookies } from "./auth0-request-cookies.js";
 export { Auth0ResponseCookies } from "./auth0-response-cookies.js";
 export { Auth0NextRequest } from "./auth0-next-request.js";
 export { Auth0NextResponse } from "./auth0-next-response.js";
+export { Auth0NextApiRequest } from "./auth0-next-api-request.js";
+export { Auth0NextApiResponse } from "./auth0-next-api-response.js";

--- a/src/server/proxy-handler.test.ts
+++ b/src/server/proxy-handler.test.ts
@@ -21,9 +21,7 @@ import {
 } from "../test/proxy-handler-test-helpers.js";
 import { generateSecret } from "../test/utils.js";
 import { generateDpopKeyPair } from "../utils/dpopUtils.js";
-import { AuthClient } from "./auth-client.js";
-import { StatelessSessionStore } from "./session/stateless-session-store.js";
-import { TransactionStore } from "./transaction-store.js";
+import { Auth0Client } from "./client.js";
 
 /**
  * Comprehensive Test Suite: AuthClient Custom Proxy Handler
@@ -97,7 +95,7 @@ const _authorizationServerMetadata = {
 let keyPair: jose.GenerateKeyPairResult;
 let dpopKeyPair: Awaited<ReturnType<typeof generateDpopKeyPair>>;
 let secret: string;
-let authClient: AuthClient;
+let authClient: Auth0Client;
 
 const server = setupServer(
   // Discovery endpoint
@@ -176,15 +174,13 @@ afterAll(() => {
 
 describe("Authentication Client - Custom Proxy Handler", async () => {
   beforeEach(async () => {
-    authClient = new AuthClient({
+    authClient = new Auth0Client({
       domain: DEFAULT.domain,
       clientId: DEFAULT.clientId,
       clientSecret: DEFAULT.clientSecret,
       appBaseUrl: DEFAULT.appBaseUrl,
       routes: getDefaultRoutes(),
       secret,
-      sessionStore: new StatelessSessionStore({ secret }),
-      transactionStore: new TransactionStore({ secret }),
       fetch: (url, init) =>
         fetch(url, { ...init, ...(init?.body ? { duplex: "half" } : {}) })
     });
@@ -203,7 +199,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       // Handler uses NextResponse.next() for unmatched routes, allowing them to pass through
       // This is intentional to allow the handler to coexist with other Next.js routes
       expect(response.status).toBe(200);
@@ -215,7 +211,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         { method: "GET" }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(401);
       const text = await response.text();
       expect(text).toContain("active session");
@@ -240,7 +236,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -268,7 +264,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -300,7 +296,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       expect(receivedBody).toEqual(requestBody);
@@ -331,7 +327,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       expect(receivedBody).toEqual(requestBody);
@@ -365,7 +361,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       expect(receivedBody).toEqual(requestBody);
@@ -389,7 +385,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(204);
     });
 
@@ -414,7 +410,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
       expect(response.headers.get("x-total-count")).toBe("42");
     });
@@ -450,7 +446,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(204);
 
       // Preflight should not include Authorization header
@@ -481,7 +477,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
       expect(response.headers.get("allow")).toContain("GET");
     });
@@ -504,7 +500,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       // Should not proxy - should just touch sessions and return Next response
       expect(response.status).toBe(200);
       // Should not have proxied content
@@ -530,7 +526,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -558,7 +554,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -588,7 +584,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       const url = new URL(receivedUrl!);
@@ -621,7 +617,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
     });
 
@@ -643,7 +639,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
     });
   });
@@ -673,7 +669,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       // Only explicitly allow-listed headers should be forwarded
       expect(receivedHeaders!.get("x-request-id")).toBe("req-123");
@@ -705,7 +701,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       // Arbitrary x-* headers should NOT be forwarded
       expect(receivedHeaders!.get("x-custom-header")).toBeNull();
@@ -739,7 +735,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedHeaders!.get("accept")).toBe("application/json");
       expect(receivedHeaders!.get("accept-language")).toBe("en-US");
@@ -768,7 +764,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       // Cookie should be stripped
       expect(receivedHeaders!.get("cookie")).toBeNull();
@@ -799,7 +795,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       // Host should be updated to upstream host
       const upstreamHost = new URL(DEFAULT.upstreamBaseUrl).host;
@@ -829,7 +825,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedHeaders!.get("user-agent")).toBe("Test-Agent/1.0");
     });
@@ -860,7 +856,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.headers.get("x-custom-response")).toBe("response-value");
       expect(response.headers.get("x-rate-limit")).toBe("100");
@@ -893,7 +889,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.headers.get("access-control-allow-origin")).toBe("*");
       expect(response.headers.get("access-control-allow-methods")).toBe(
@@ -928,7 +924,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedBody).toEqual(requestBody);
     });
@@ -962,7 +958,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedBody!).toBe("username=testuser&password=testpass");
     });
@@ -992,7 +988,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedBody!).toBe(textBody);
     });
@@ -1017,7 +1013,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.status).toBe(200);
       expect(bodyWasNull).toBe(true);
@@ -1056,7 +1052,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedBody).toEqual(largeBody);
     });
@@ -1083,26 +1079,24 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await authClient.handler(request);
+      await authClient.middleware(request);
 
       expect(receivedAuthHeader).toBe(`Bearer ${DEFAULT.accessToken}`);
     });
   });
 
   describe("Category 7: DPoP Token Handling", () => {
-    let dpopAuthClient: AuthClient;
+    let dpopAuthClient: Auth0Client;
 
     beforeEach(async () => {
       // Create AuthClient with DPoP enabled
-      dpopAuthClient = new AuthClient({
+      dpopAuthClient = new Auth0Client({
         domain: DEFAULT.domain,
         clientId: DEFAULT.clientId,
         clientSecret: DEFAULT.clientSecret,
         appBaseUrl: DEFAULT.appBaseUrl,
         routes: getDefaultRoutes(),
         secret,
-        sessionStore: new StatelessSessionStore({ secret }),
-        transactionStore: new TransactionStore({ secret }),
         useDPoP: true,
         dpopKeyPair: dpopKeyPair,
         fetch: (url, init) =>
@@ -1138,7 +1132,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await dpopAuthClient.handler(request);
+      await dpopAuthClient.middleware(request);
 
       expect(receivedDPoPHeader).toBeTruthy();
       expect(receivedDPoPHeader).toMatch(
@@ -1179,7 +1173,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await dpopAuthClient.handler(request);
+      await dpopAuthClient.middleware(request);
 
       const dpopInfo = extractDPoPInfo(dpopProof);
       expect(dpopInfo.htm).toBe("POST");
@@ -1214,7 +1208,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await dpopAuthClient.handler(request);
+      await dpopAuthClient.middleware(request);
 
       const dpopInfo = extractDPoPInfo(dpopProof);
       expect(dpopInfo.htu).toBe(`${DEFAULT.upstreamBaseUrl}/users/123`);
@@ -1249,7 +1243,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await dpopAuthClient.handler(request);
+      await dpopAuthClient.middleware(request);
 
       const dpopInfo = extractDPoPInfo(dpopProof);
       expect(dpopInfo.jti).toBeTruthy();
@@ -1286,7 +1280,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      await dpopAuthClient.handler(request);
+      await dpopAuthClient.middleware(request);
 
       expect(receivedAuthHeader).toBe(`DPoP ${DEFAULT.accessToken}`);
     });
@@ -1321,7 +1315,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await dpopAuthClient.handler(request);
+      const response = await dpopAuthClient.middleware(request);
 
       expect(response.status).toBe(200);
       expect(state.requestCount).toBe(2); // Initial + retry
@@ -1366,7 +1360,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await dpopAuthClient.handler(request);
+      const response = await dpopAuthClient.middleware(request);
 
       expect(response.status).toBe(200);
 
@@ -1427,7 +1421,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       // Should have Set-Cookie header with updated session
       const setCookieHeader = response.headers.get("set-cookie");
@@ -1483,7 +1477,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
       expect(response.status).toBe(200);
 
       // Verify session was updated (Set-Cookie present)
@@ -1580,7 +1574,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response1 = await authClient.handler(request1);
+      const response1 = await authClient.middleware(request1);
       expect(response1.status).toBe(200);
 
       // Verify first session was updated after token refresh
@@ -1622,7 +1616,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response2 = await authClient.handler(request2);
+      const response2 = await authClient.middleware(request2);
       expect(response2.status).toBe(200);
 
       // CRITICAL ASSERTION: Verify second session was ALSO updated
@@ -1677,7 +1671,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.status).toBe(500);
       const body = await response.json();
@@ -1702,7 +1696,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.status).toBe(404);
     });
@@ -1728,7 +1722,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.status).toBe(401);
     });
@@ -1767,7 +1761,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
 
       // Make 5 concurrent requests
       const requests = Array.from({ length: 5 }, (_, i) =>
-        authClient.handler(
+        authClient.middleware(
           new NextRequest(
             new URL(`${DEFAULT.proxyPath}/data?id=${i}`, DEFAULT.appBaseUrl),
             {
@@ -1838,7 +1832,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
 
       // Make 3 concurrent requests with expired token
       const requests = Array.from({ length: 3 }, () =>
-        authClient.handler(
+        authClient.middleware(
           new NextRequest(
             new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
             {
@@ -1868,15 +1862,13 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
       const cookie = await createSessionCookie(session, secret);
 
       // Create AuthClient with multiple proxy routes
-      const multiProxyClient = new AuthClient({
+      const multiProxyClient = new Auth0Client({
         domain: DEFAULT.domain,
         clientId: DEFAULT.clientId,
         clientSecret: DEFAULT.clientSecret,
         appBaseUrl: DEFAULT.appBaseUrl,
         routes: getDefaultRoutes(),
         secret,
-        sessionStore: new StatelessSessionStore({ secret }),
-        transactionStore: new TransactionStore({ secret }),
         fetch: (url, init) =>
           fetch(url, { ...init, ...(init?.body ? { duplex: "half" } : {}) })
       });
@@ -1892,7 +1884,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
 
       // Make concurrent requests to /me endpoint
       const requests = [
-        multiProxyClient.handler(
+        multiProxyClient.middleware(
           new NextRequest(
             new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
             {
@@ -1901,7 +1893,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
             }
           )
         ),
-        multiProxyClient.handler(
+        multiProxyClient.middleware(
           new NextRequest(
             new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
             {
@@ -1910,7 +1902,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
             }
           )
         ),
-        multiProxyClient.handler(
+        multiProxyClient.middleware(
           new NextRequest(
             new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
             {
@@ -1961,7 +1953,7 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
         }
       );
 
-      const response = await authClient.handler(request);
+      const response = await authClient.middleware(request);
 
       expect(response.status).toBe(204);
       expect(response.headers.get("access-control-allow-origin")).toBe(

--- a/tests/pages-router-integration.test.ts
+++ b/tests/pages-router-integration.test.ts
@@ -1,0 +1,374 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Auth0Client } from "../src/server/client.js";
+import { AuthClient } from "../src/server/auth-client.js";
+import { StatelessSessionStore } from "../src/server/session/stateless-session-store.js";
+import { TransactionStore } from "../src/server/transaction-store.js";
+import { getDefaultRoutes } from "../src/test/defaults.js";
+
+const DEFAULT = {
+  domain: "test.auth0.com",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "https://example.com",
+  secret: "super-secret-32-character-string"
+};
+
+function getMockAuthorizationServer(options: { supportPAR?: boolean } = {}) {
+  const { supportPAR = true } = options;
+
+  return vi
+    .fn()
+    .mockImplementation(
+      async (
+        input: RequestInfo | URL,
+        init?: RequestInit
+      ): Promise<Response> => {
+        let url: URL;
+        if (input instanceof Request) {
+          url = new URL(input.url);
+        } else {
+          url = new URL(input);
+        }
+
+        // Discovery endpoint
+        if (url.pathname === "/.well-known/openid-configuration") {
+          const metadata = {
+            issuer: `https://${DEFAULT.domain}`,
+            authorization_endpoint: `https://${DEFAULT.domain}/authorize`,
+            token_endpoint: `https://${DEFAULT.domain}/oauth/token`,
+            userinfo_endpoint: `https://${DEFAULT.domain}/userinfo`,
+            end_session_endpoint: `https://${DEFAULT.domain}/v2/logout`,
+            jwks_uri: `https://${DEFAULT.domain}/.well-known/jwks.json`,
+            response_types_supported: ["code"],
+            code_challenge_methods_supported: ["S256"],
+            scopes_supported: ["openid", "profile", "email"]
+          };
+
+          if (supportPAR) {
+            (metadata as any).pushed_authorization_request_endpoint =
+              `https://${DEFAULT.domain}/oauth/par`;
+          }
+
+          return new Response(JSON.stringify(metadata), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          });
+        }
+
+        // PAR endpoint
+        if (url.pathname === "/oauth/par" && supportPAR) {
+          return new Response(
+            JSON.stringify({
+              request_uri: "urn:ietf:params:oauth:request_uri:test",
+              expires_in: 30
+            }),
+            {
+              status: 201,
+              headers: { "Content-Type": "application/json" }
+            }
+          );
+        }
+
+        return new Response(null, { status: 404 });
+      }
+    );
+}
+
+/**
+ * Creates a mock NextApiRequest for testing
+ */
+function createMockNextApiRequest(
+  url: string,
+  options: {
+    method?: string;
+    body?: any;
+    cookies?: Record<string, string>;
+    headers?: Record<string, string>;
+  } = {}
+): NextApiRequest {
+  const urlObj = new URL(url);
+  const { method = "GET", body = {}, cookies = {}, headers = {} } = options;
+
+  return {
+    method,
+    url: urlObj.pathname + urlObj.search,
+    headers: {
+      host: urlObj.host,
+      ...headers
+    },
+    body,
+    cookies,
+    query: Object.fromEntries(urlObj.searchParams.entries())
+  } as NextApiRequest;
+}
+
+/**
+ * Creates a mock NextApiResponse for testing
+ */
+function createMockNextApiResponse(): NextApiResponse {
+  const headers: Record<string, string | string[]> = {};
+  let statusCode = 200;
+  let statusMessage = "OK";
+  const writtenData: any[] = [];
+
+  const res = {
+    statusCode,
+    statusMessage,
+    setHeader: vi.fn((name: string, value: string | string[]) => {
+      headers[name.toLowerCase()] = value;
+      return res;
+    }),
+    getHeader: vi.fn((name: string) => headers[name.toLowerCase()]),
+    getHeaders: vi.fn(() => headers),
+    removeHeader: vi.fn((name: string) => {
+      delete headers[name.toLowerCase()];
+      return res;
+    }),
+    status: vi.fn((code: number) => {
+      statusCode = code;
+      res.statusCode = code;
+      return res;
+    }),
+    redirect: vi.fn((url: string) => {
+      res.setHeader("Location", url);
+      res.status(302);
+      return res;
+    }),
+    json: vi.fn((data: any) => {
+      res.setHeader("Content-Type", "application/json");
+      writtenData.push(JSON.stringify(data));
+      return res;
+    }),
+    send: vi.fn((data: any) => {
+      writtenData.push(data);
+      return res;
+    }),
+    end: vi.fn(() => res)
+  } as unknown as NextApiResponse;
+
+  return res;
+}
+
+describe("Pages Router Integration", () => {
+  const originalAppBaseUrl = process.env.APP_BASE_URL;
+
+  beforeEach(() => {
+    process.env.APP_BASE_URL = DEFAULT.appBaseUrl;
+  });
+
+  afterEach(() => {
+    process.env.APP_BASE_URL = originalAppBaseUrl;
+  });
+
+  describe("AuthClient.handler() with Pages Router", () => {
+    let authClient: AuthClient;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.resetModules();
+
+      const secret = DEFAULT.secret;
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+
+      authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should handle login request with NextApiRequest", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await authClient.handler(mockReq, undefined, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      expect(redirectUrl).toContain(DEFAULT.domain);
+      expect(redirectUrl).toContain("authorize");
+    });
+
+    it("should handle login request with NextRequest (App Router)", async () => {
+      const request = new NextRequest(`${DEFAULT.appBaseUrl}/auth/login`);
+
+      const response = await authClient.handler(request);
+
+      expect(response).toBeInstanceOf(NextResponse);
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toContain(DEFAULT.domain);
+      expect(response.headers.get("location")).toContain("authorize");
+    });
+
+    it("should preserve query parameters in Pages Router", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login?returnTo=/dashboard&organization=org_123`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await authClient.handler(mockReq, undefined, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      expect(redirectUrl).toContain("organization=org_123");
+    });
+
+    it("should normalize HTTP method to uppercase", async () => {
+      const mockReq = {
+        method: "get",
+        url: "/auth/login",
+        headers: { host: "example.com" },
+        body: {},
+        cookies: {},
+        query: {}
+      } as NextApiRequest;
+      const mockRes = createMockNextApiResponse();
+
+      await authClient.handler(mockReq, undefined, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+    });
+  });
+
+  describe("Auth0Client.handleAuth()", () => {
+    let auth0Client: Auth0Client;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.resetModules();
+
+      auth0Client = new Auth0Client({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: DEFAULT.secret,
+        fetch: getMockAuthorizationServer()
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should handle App Router request (NextRequest)", async () => {
+      const request = new NextRequest(`${DEFAULT.appBaseUrl}/auth/login`);
+
+      const response = await auth0Client.handleAuth(request);
+
+      expect(response).toBeInstanceOf(NextResponse);
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toContain("authorize");
+    });
+
+    it("should handle App Router request (standard Request)", async () => {
+      const request = new Request(`${DEFAULT.appBaseUrl}/auth/login`);
+
+      const response = await auth0Client.handleAuth(request);
+
+      expect(response).toBeInstanceOf(NextResponse);
+      expect(response.status).toBe(307);
+    });
+
+    it("should handle Pages Router request (NextApiRequest + NextApiResponse)", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      const result = await auth0Client.handleAuth(mockReq, mockRes);
+
+      // Pages Router should not return anything (void)
+      expect(result).toBeUndefined();
+      // But the response should be modified
+      expect(mockRes.redirect).toHaveBeenCalled();
+    });
+
+    it("should handle organization parameter in App Router", async () => {
+      const request = new NextRequest(
+        `${DEFAULT.appBaseUrl}/auth/login?organization=org_123`
+      );
+
+      const response = await auth0Client.handleAuth(request);
+
+      expect(response.headers.get("location")).toContain("organization=org_123");
+    });
+
+    it("should handle organization parameter in Pages Router", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login?organization=org_456`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await auth0Client.handleAuth(mockReq, mockRes);
+
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      expect(redirectUrl).toContain("organization=org_456");
+    });
+
+    it("should route to correct handler based on path in Pages Router", async () => {
+      // Test login route
+      const loginReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login`
+      );
+      const loginRes = createMockNextApiResponse();
+
+      await auth0Client.handleAuth(loginReq, loginRes);
+
+      expect(loginRes.redirect).toHaveBeenCalled();
+      const loginRedirectUrl = (loginRes.redirect as any).mock.calls[0][0];
+      expect(loginRedirectUrl).toContain("authorize");
+    });
+
+    it("should handle GET method in Pages Router", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login`,
+        { method: "GET" }
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await auth0Client.handleAuth(mockReq, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+    });
+
+    it("should work with custom returnTo parameter in Pages Router", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login?returnTo=/protected/dashboard`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await auth0Client.handleAuth(mockReq, mockRes);
+
+      expect(mockRes.redirect).toHaveBeenCalled();
+    });
+
+    it("should handle multiple query parameters in Pages Router", async () => {
+      const mockReq = createMockNextApiRequest(
+        `${DEFAULT.appBaseUrl}/auth/login?organization=org_123&audience=api.example.com&scope=openid%20profile`
+      );
+      const mockRes = createMockNextApiResponse();
+
+      await auth0Client.handleAuth(mockReq, mockRes);
+
+      const redirectUrl = (mockRes.redirect as any).mock.calls[0][0];
+      expect(redirectUrl).toContain("organization=org_123");
+    });
+  });
+});


### PR DESCRIPTION
### 📋 Changes

This PR adds support for mounting the authentication routes with both Next.js' App Router and Pages Router, enabling developers to use our SDK without handling these in the middleware.

#### Usage

This PR introduces a new `handleAuth` method that works seamlessly with both routing patterns:

**App Router usage:**
```typescript
// app/api/auth/[...auth0]/route.ts
import { auth0 } from "@/lib/auth0";

export const GET = auth0.handleAuth;
export const POST = auth0.handleAuth;
```

**Pages Router usage:**
```typescript
// pages/api/auth/[...auth0].ts
import { auth0 } from "@/lib/auth0";

export default auth0.handleAuth;
```

#### Technical Changes

- **Enhanced `AuthClient.handler` (internal) method** with method overloading to support both `NextRequest` (App Router/Middleware) and `NextApiRequest` (Pages Router)
- **Added new HTTP adapters** (`Auth0NextApiRequest`, `Auth0NextApiResponse`, `Auth0ApiResponseCookies`) to handle Pages Router request/response objects
- **Extended `OnCallbackHook`** context to include `request` and `response` objects for Pages Router compatibility
- **Added runtime detection** using `isRequest()` to automatically determine the routing pattern and use appropriate handlers

### 📎 References

N/A

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
