### PR TITLE
fix: stale session reuse on proxy DPoP nonce retry

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3718,10 +3718,48 @@ export class AuthClient {
       ? await clonedReq.arrayBuffer()
       : undefined;
 
+    // Keep an isolated, request-local session snapshot so retries within this
+    // proxy request can observe token refreshes immediately without writing the
+    // session cookie until the proxy response succeeds.
+    const requestSession = structuredClone(session);
+    const tokenSetResponsesByRequest = new Map<string, GetTokenSetResponse>();
+    const applyTokenSetResponseToRequestSession = (
+      tokenSetResponse: GetTokenSetResponse
+    ) => {
+      const sessionChanges = getSessionChangesAfterGetAccessToken(
+        requestSession,
+        tokenSetResponse.tokenSet,
+        {
+          scope: this.authorizationParameters?.scope ?? DEFAULT_SCOPES,
+          audience: this.authorizationParameters?.audience
+        }
+      );
+
+      if (sessionChanges) {
+        Object.assign(requestSession, sessionChanges);
+      }
+
+      if (tokenSetResponse.idTokenClaims) {
+        requestSession.user = tokenSetResponse.idTokenClaims as User;
+      }
+    };
+
     let tokenSetSideEffect!: GetTokenSetResponse;
 
     const getAccessToken: AccessTokenFactory = async (authParams) => {
-      const [error, tokenSetResponse] = await this.getTokenSet(session, {
+      const cacheKey = JSON.stringify([
+        authParams.refresh ?? false,
+        authParams.audience ?? null,
+        authParams.scope ?? null
+      ]);
+      const cachedTokenSetResponse = tokenSetResponsesByRequest.get(cacheKey);
+
+      if (cachedTokenSetResponse) {
+        tokenSetSideEffect = cachedTokenSetResponse;
+        return cachedTokenSetResponse.tokenSet;
+      }
+
+      const [error, tokenSetResponse] = await this.getTokenSet(requestSession, {
         audience: authParams.audience,
         scope: authParams.scope
       });
@@ -3729,6 +3767,9 @@ export class AuthClient {
       if (error) {
         throw error;
       }
+
+      applyTokenSetResponseToRequestSession(tokenSetResponse);
+      tokenSetResponsesByRequest.set(cacheKey, tokenSetResponse);
 
       // Tracking the last used token set response for session updates later as a side effect.
       // This relies on the fact that `getAccessToken` is called before the actual fetch.
@@ -3792,11 +3833,10 @@ export class AuthClient {
 
       return res;
     } catch (e: any) {
-      // Handle MFA required error - return 403 with MFA context
-      // Note: session.mfa was already mutated by getTokenSet() before the error was thrown.
-      // JavaScript is single-threaded, so no race condition exists.
+      // Handle MFA required error - return 403 with MFA context.
+      // The request-local session snapshot was passed to getTokenSet().
       if (e instanceof MfaRequiredError) {
-        return this.#createMfaRequiredResponse(req, session, e);
+        return this.#createMfaRequiredResponse(req, requestSession, e);
       }
 
       // Return 401 for missing refresh token (cannot refresh expired token)

--- a/src/server/proxy-handler.test.ts
+++ b/src/server/proxy-handler.test.ts
@@ -1360,6 +1360,102 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
       expect(retryDPoPInfo.hasNonce).toBe(true);
       expect(retryDPoPInfo.nonce).toBe("server_nonce_123");
     });
+
+    it("7.8 should not refresh twice when a nonce retry happens after refresh", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const session = createInitialSessionData({
+        tokenSet: {
+          accessToken: "at-old",
+          refreshToken: "rt-old",
+          expiresAt: now - 10,
+          scope: "read:data",
+          audience: DEFAULT.audience,
+          token_type: "DPoP"
+        }
+      });
+      const cookie = await createSessionCookie(session, secret);
+      const refreshCalls: string[] = [];
+      const upstreamAuthHeaders: string[] = [];
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            const params = new URLSearchParams(await request.text());
+            refreshCalls.push(params.get("refresh_token") ?? "");
+
+            if (refreshCalls.length > 1) {
+              return HttpResponse.json(
+                {
+                  error: "invalid_grant",
+                  error_description: "stale refresh token"
+                },
+                { status: 400 }
+              );
+            }
+
+            const jwt = await new jose.SignJWT({
+              sid: DEFAULT.sid,
+              auth_time: Math.floor(Date.now() / 1000),
+              nonce: "nonce-value"
+            })
+              .setProtectedHeader({ alg: DEFAULT.alg })
+              .setSubject(DEFAULT.sub)
+              .setIssuedAt()
+              .setIssuer(_authorizationServerMetadata.issuer)
+              .setAudience(DEFAULT.clientId)
+              .setExpirationTime("2h")
+              .sign(keyPair.privateKey);
+
+            return HttpResponse.json({
+              access_token: "at-new-1",
+              refresh_token: "rt-new-1",
+              id_token: jwt,
+              token_type: "DPoP",
+              expires_in: 3600,
+              scope: "read:data"
+            });
+          }
+        ),
+        http.get(`${DEFAULT.upstreamBaseUrl}/data`, ({ request }) => {
+          upstreamAuthHeaders.push(request.headers.get("authorization") ?? "");
+
+          if (upstreamAuthHeaders.length === 1) {
+            return new HttpResponse(
+              JSON.stringify({
+                error: "use_dpop_nonce",
+                error_description: "DPoP nonce is required"
+              }),
+              {
+                status: 401,
+                headers: {
+                  "www-authenticate": 'DPoP error="use_dpop_nonce"',
+                  "dpop-nonce": "server_nonce_123",
+                  "content-type": "application/json"
+                }
+              }
+            );
+          }
+
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      const request = new NextRequest(
+        new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
+        {
+          method: "GET",
+          headers: { cookie }
+        }
+      );
+
+      const response = await dpopAuthClient.handler(request);
+
+      expect(response.status).toBe(200);
+      expect(refreshCalls).toEqual(["rt-old"]);
+      expect(upstreamAuthHeaders).toEqual(["DPoP at-new-1", "DPoP at-new-1"]);
+      expect(response.headers.get("set-cookie")).toContain("__session=");
+    });
   });
 
   describe("Category 8: Session Update After Token Refresh", () => {
@@ -1716,6 +1812,65 @@ describe("Authentication Client - Custom Proxy Handler", async () => {
       const response = await authClient.handler(request);
 
       expect(response.status).toBe(401);
+    });
+
+    it("9.4 should return MFA required response when token refresh requires MFA", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const session = createInitialSessionData({
+        tokenSet: {
+          accessToken: DEFAULT.accessToken,
+          refreshToken: DEFAULT.refreshToken,
+          expiresAt: now - 10,
+          scope: "read:data",
+          token_type: "Bearer"
+        }
+      });
+      const cookie = await createSessionCookie(session, secret);
+      let upstreamCallCount = 0;
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () => {
+          return HttpResponse.json(
+            {
+              error: "mfa_required",
+              error_description: "Multi-factor authentication is required.",
+              mfa_token: "raw-mfa-token",
+              mfa_requirements: {
+                challenge: [{ type: "otp" }]
+              }
+            },
+            { status: 403 }
+          );
+        }),
+        http.get(`${DEFAULT.upstreamBaseUrl}/data`, () => {
+          upstreamCallCount++;
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      const request = new NextRequest(
+        new URL(`${DEFAULT.proxyPath}/data`, DEFAULT.appBaseUrl),
+        {
+          method: "GET",
+          headers: { cookie }
+        }
+      );
+
+      const response = await authClient.handler(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body).toEqual({
+        error: "mfa_required",
+        error_description: "Multi-factor authentication is required.",
+        mfa_token: expect.any(String),
+        mfa_requirements: {
+          challenge: [{ type: "otp" }]
+        }
+      });
+      expect(body.mfa_token).not.toBe("raw-mfa-token");
+      expect(response.headers.get("set-cookie")).toContain("__session=");
+      expect(upstreamCallCount).toBe(0);
     });
   });
 


### PR DESCRIPTION
Fix a proxy-only `DPoP` retry bug where a nonce challenge immediately after a token refresh could trigger a second refresh using the stale pre-refresh session snapshot.

## Problem

`#handleProxy()` creates a per-request `getAccessToken()` closure over the session loaded at the start of the request.

When that proxied request does all of the following in one flow:

1. starts with an expired access token,
2. refreshes successfully,
3. sends the refreshed access token upstream,
4. receives a `use_dpop_nonce` challenge from the protected resource,

the fetcher retries the protected-resource request by calling `getAccessToken()` again.

Before this change, the second `getAccessToken()` call still read from the original session snapshot loaded at the start of the proxy request. The refreshed token set was only persisted after `fetchWithAuth()` completed, so the retry path could call `getTokenSet()` again and perform a second refresh with the old refresh token.

With rotating refresh tokens enabled, that second refresh uses a token that was already invalidated by the first refresh, causing the proxy request to fail with `invalid_grant` and return a `500`.

## Root Cause

The proxy retry path reused the original session snapshot instead of the refreshed token state produced earlier in the same request.

The `DPoP` nonce retry itself was valid, the issue was that the retry reacquired credentials from stale request-local session state rather than reusing the first refreshed token set.

## Fix

This PR makes proxy token retrieval request-local and retry-safe:

- `#handleProxy()` now keeps a request-local session snapshot for the lifetime of the proxy request.
- After a successful `getTokenSet()` call, that request-local snapshot is updated immediately so subsequent retries in the same request see the refreshed token state.
- Token responses are memoized per proxy request for the same access-token request parameters, so a `DPoP` nonce retry reuses the first token response instead of performing another refresh.
- Session persistence behavior is unchanged: the final session is still written once after the proxy request completes successfully.
- The MFA-required path now uses the request-local mutated snapshot so any in-request state changes are preserved there as well.
