### PR TITLE
adding npm-oidc-trusted-publishing and removing npm-token usage

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -29,10 +27,15 @@ runs:
       with:
         node-version: 22
         cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    - name: Update npm for OIDC trusted publishing
+      shell: bash
+      run: npm install -g npm@~11.10.0
 
     - name: Build package
       if: inputs.require-build == 'true'
@@ -50,9 +53,7 @@ runs:
         else
           TAG="latest"
         fi
-        npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-        pnpm publish --tag $TAG
+        npm publish --tag $TAG
       env:
-        NPM_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}
         NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,8 +15,6 @@ on:
     secrets:
       github-token:
         required: true
-      npm-token:
-        required: true
 
 ### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
@@ -26,6 +24,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write # Required for OIDC trusted publishing to npm
 
     steps:
       # Checkout the code
@@ -70,7 +71,6 @@ jobs:
           require-build: ${{ inputs.require-build }}
           release-directory: ${{ inputs.release-directory }}
           version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.npm-token }}
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
       node-version: 22 ## Updated to Node.js 22
       require-build: false
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## chore: enable npm OIDC trusted publishing

### Summary

Replaces the long-lived `NPM_TOKEN` secret with GitHub's OIDC trusted publishing, eliminating the need to store and rotate npm access tokens in GitHub secrets.

### Problem

The release pipeline was using a long-lived `NPM_TOKEN` secret to authenticate with npmjs.com. This approach has several downsides:
- Tokens can expire or be rotated, causing `E404` / auth failures on publish (as seen in the previous release attempt)
- Long-lived tokens are a security risk — if compromised, they provide persistent write access to the npm package

### Solution

Configured [npm Trusted Publishing](https://docs.npmjs.com/generating-provenance-statements) via GitHub Actions OIDC. During a release, GitHub issues a short-lived OIDC token scoped to the specific workflow run, which npm exchanges for a temporary publish token — no secrets required.

### References

- https://oktainc.atlassian.net/wiki/spaces/DXSDK/pages/673551653/Steps+to+create+new+release+publish+SDK+Packages+to+NPM
