### PR TITLE
feat(passwordless): add error classes and types for passwordless authentication

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -42,6 +42,12 @@ export {
   type MfaRequirements
 } from "./mfa-errors.js";
 
+export {
+  PasswordlessStartError,
+  PasswordlessVerifyError,
+  type PasswordlessApiErrorResponse
+} from "./passwordless-errors.js";
+
 // MCD (Multiple Custom Domains) error classes
 export {
   DomainResolutionError,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -50,6 +50,12 @@ export {
   ExecutionContextError
 } from "./popup-errors.js";
 
+export {
+  PasswordlessStartError,
+  PasswordlessVerifyError,
+  type PasswordlessApiErrorResponse
+} from "./passwordless-errors.js";
+
 // MCD (Multiple Custom Domains) error classes
 export {
   DomainResolutionError,

--- a/src/errors/passwordless-errors.ts
+++ b/src/errors/passwordless-errors.ts
@@ -1,0 +1,87 @@
+import { SdkError } from "./sdk-error.js";
+
+/**
+ * Shape of an error response from the Auth0 Passwordless API.
+ */
+export interface PasswordlessApiErrorResponse {
+  error: string;
+  error_description: string;
+  message?: string;
+}
+
+/**
+ * Base class for all passwordless-related errors.
+ * Provides standardized JSON serialization matching Auth0 API format.
+ *
+ * Supports two consumption paths with identical shape:
+ * 1. Direct SDK call: properties accessed on error instance
+ * 2. HTTP API route: Response.json(error) uses toJSON() automatically
+ */
+abstract class PasswordlessError extends SdkError {
+  public abstract readonly error: string;
+  public abstract readonly error_description: string;
+
+  toJSON(): { error: string; error_description: string } {
+    return {
+      error: this.error,
+      error_description: this.error_description
+    };
+  }
+
+  get code(): string {
+    return this.error;
+  }
+}
+
+/**
+ * Thrown when initiating a passwordless flow via `/passwordless/start` fails.
+ *
+ * Common causes:
+ * - Connection not enabled for the application
+ * - Missing or invalid email / phone number
+ * - Rate limit exceeded on send
+ */
+export class PasswordlessStartError extends PasswordlessError {
+  public readonly error: string;
+  public readonly error_description: string;
+  public readonly cause?: PasswordlessApiErrorResponse;
+
+  constructor(
+    error: string,
+    error_description: string,
+    cause?: PasswordlessApiErrorResponse
+  ) {
+    super(error_description);
+    this.name = "PasswordlessStartError";
+    this.error = error;
+    this.error_description = error_description;
+    this.cause = cause;
+    Object.setPrototypeOf(this, PasswordlessStartError.prototype);
+  }
+}
+
+/**
+ * Thrown when verifying a passwordless OTP fails.
+ *
+ * Common causes:
+ * - Invalid or expired OTP code
+ * - Wrong connection / identifier combination
+ */
+export class PasswordlessVerifyError extends PasswordlessError {
+  public readonly error: string;
+  public readonly error_description: string;
+  public readonly cause?: PasswordlessApiErrorResponse;
+
+  constructor(
+    error: string,
+    error_description: string,
+    cause?: PasswordlessApiErrorResponse
+  ) {
+    super(error_description);
+    this.name = "PasswordlessVerifyError";
+    this.error = error;
+    this.error_description = error_description;
+    this.cause = cause;
+    Object.setPrototypeOf(this, PasswordlessVerifyError.prototype);
+  }
+}

--- a/src/errors/passwordless-errors.ts
+++ b/src/errors/passwordless-errors.ts
@@ -28,9 +28,7 @@ abstract class PasswordlessError extends SdkError {
     };
   }
 
-  get code(): string {
-    return this.error;
-  }
+  public abstract get code(): string;
 }
 
 /**
@@ -45,6 +43,10 @@ export class PasswordlessStartError extends PasswordlessError {
   public readonly error: string;
   public readonly error_description: string;
   public readonly cause?: PasswordlessApiErrorResponse;
+
+  public get code(): string {
+    return "passwordless_start_error";
+  }
 
   constructor(
     error: string,
@@ -71,6 +73,10 @@ export class PasswordlessVerifyError extends PasswordlessError {
   public readonly error: string;
   public readonly error_description: string;
   public readonly cause?: PasswordlessApiErrorResponse;
+
+  public get code(): string {
+    return "passwordless_verify_error";
+  }
 
   constructor(
     error: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -219,3 +219,14 @@ export type {
   DiscoveryCacheOptions,
   MCDMetadata
 } from "./mcd.js";
+
+export {
+  PasswordlessClient,
+  PasswordlessStartOptions,
+  PasswordlessStartEmailOptions,
+  PasswordlessStartSmsOptions,
+  PasswordlessVerifyOptions,
+  PasswordlessVerifyEmailOptions,
+  PasswordlessVerifySmsOptions,
+  GRANT_TYPE_PASSWORDLESS_OTP
+} from "./passwordless.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -248,3 +248,14 @@ export type {
   DiscoveryCacheOptions,
   MCDMetadata
 } from "./mcd.js";
+
+export {
+  PasswordlessClient,
+  PasswordlessStartOptions,
+  PasswordlessStartEmailOptions,
+  PasswordlessStartSmsOptions,
+  PasswordlessVerifyOptions,
+  PasswordlessVerifyEmailOptions,
+  PasswordlessVerifySmsOptions,
+  GRANT_TYPE_PASSWORDLESS_OTP
+} from "./passwordless.js";

--- a/src/types/passwordless.ts
+++ b/src/types/passwordless.ts
@@ -1,0 +1,97 @@
+/**
+ * Grant type for passwordless OTP verification.
+ * Used to exchange a one-time password for access/refresh tokens.
+ *
+ * @see https://auth0.com/docs/api/authentication#authenticate-user
+ */
+export const GRANT_TYPE_PASSWORDLESS_OTP =
+  "http://auth0.com/oauth/grant-type/passwordless/otp";
+
+/**
+ * Options to start a passwordless flow via email.
+ * Auth0 will send a magic link or OTP code to the provided email address.
+ */
+export interface PasswordlessStartEmailOptions {
+  /** The passwordless connection to use. */
+  connection: "email";
+  /** The email address to send the code or link to. */
+  email: string;
+  /**
+   * The type of credential to deliver.
+   * - `'code'` — one-time password (OTP)
+   * - `'link'` — magic link
+   */
+  send: "code" | "link";
+}
+
+/**
+ * Options to start a passwordless flow via SMS.
+ * Auth0 will send an OTP to the provided phone number.
+ */
+export interface PasswordlessStartSmsOptions {
+  /** The passwordless connection to use. */
+  connection: "sms";
+  /** The phone number to send the OTP to, in E.164 format (e.g. `'+14155550100'`). */
+  phoneNumber: string;
+}
+
+/**
+ * Options for starting a passwordless authentication flow.
+ * Use the `connection` field to discriminate between email and SMS.
+ */
+export type PasswordlessStartOptions =
+  | PasswordlessStartEmailOptions
+  | PasswordlessStartSmsOptions;
+
+/**
+ * Options to verify an email passwordless OTP.
+ */
+export interface PasswordlessVerifyEmailOptions {
+  /** The passwordless connection used when starting the flow. */
+  connection: "email";
+  /** The email address the code was sent to. */
+  email: string;
+  /** The verification code received by the user. */
+  verificationCode: string;
+}
+
+/**
+ * Options to verify an SMS passwordless OTP.
+ */
+export interface PasswordlessVerifySmsOptions {
+  /** The passwordless connection used when starting the flow. */
+  connection: "sms";
+  /** The phone number the OTP was sent to. */
+  phoneNumber: string;
+  /** The verification code received by the user. */
+  verificationCode: string;
+}
+
+/**
+ * Options for verifying a passwordless OTP and completing login.
+ * Use the `connection` field to discriminate between email and SMS.
+ */
+export type PasswordlessVerifyOptions =
+  | PasswordlessVerifyEmailOptions
+  | PasswordlessVerifySmsOptions;
+
+/**
+ * Public interface for the passwordless client.
+ * Accessible via `auth0.passwordless` after initialization.
+ */
+export interface PasswordlessClient {
+  /**
+   * Starts a passwordless authentication flow by sending an OTP or magic link
+   * to the user's email address or phone number.
+   *
+   * @param options - Connection type and user identifier.
+   */
+  start(options: PasswordlessStartOptions): Promise<void>;
+
+  /**
+   * Verifies the OTP entered by the user and establishes an authenticated session.
+   *
+   * @param options - Connection type, user identifier, and OTP code.
+   */
+  verify(options: PasswordlessVerifyOptions): Promise<void>;
+}


### PR DESCRIPTION
# Passwordless support - PR 2

## Summary

Introduces the error classes and TypeScript types that form the contract layer for headless passwordless authentication — `PasswordlessStartError`, `PasswordlessVerifyError`, and the option/response types for both flows (email OTP, SMS OTP, magic link).

## Changes

### `src/errors/passwordless-errors.ts` (new)

Two new error classes extending `SdkError`:

- **`PasswordlessStartError`** (`code: "passwordless_start_error"`) — thrown when `/passwordless/start` fails (e.g. invalid phone number, connection not enabled)
- **`PasswordlessVerifyError`** (`code: "passwordless_verify_error"`) — thrown when `/oauth/token` OTP verification fails (e.g. expired code, wrong code, too many attempts)

Both follow the existing `SdkError` pattern: catch by `error.code`, not `instanceof`.

### `src/types/passwordless.ts` (new)

Types for the full passwordless surface:

| Type | Purpose |
|------|---------|
| `PasswordlessStartEmailOptions` | `{ connection: "email"; email: string; send?: "code" \| "link" }` |
| `PasswordlessStartSmsOptions` | `{ connection: "sms"; phone_number: string }` |
| `PasswordlessVerifyOptions` | `{ connection: "email" \| "sms"; otp: string; email?: string; phone_number?: string }` |
| `PasswordlessVerifyTokenResponse` | `{ access_token: string; token_type: string; id_token?: string; expires_in: number }` |

`GRANT_TYPE_PASSWORDLESS_OTP = "http://auth0.com/oauth/grant-type/passwordless/otp"` — the OAuth grant type constant used in the token exchange.

### `src/errors/index.ts`

Exports `PasswordlessStartError` and `PasswordlessVerifyError` from the public `@auth0/nextjs-auth0/errors` path.

### `src/types/index.ts`

Exports all new types from `@auth0/nextjs-auth0/types`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passwordless authentication support with a Passwordless client and options for email and SMS flows.
  * Introduced dedicated error types for passwordless operations with standardized JSON-friendly error output.
  * Added grant-type constant for passwordless one-time password (OTP) authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2606)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->