### PR TITLE
feat(passwordless): add passwordlessStart and passwordlessVerify to AuthClient

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3402,12 +3402,15 @@ export class AuthClient {
    * @param options - Connection type, user identifier, and (for email) delivery method.
    * @throws {PasswordlessStartError} On Auth0 API failure.
    */
-  async passwordlessStart(options: PasswordlessStartOptions): Promise<void> {
+  async passwordlessStart(
+    options: PasswordlessStartOptions,
+    authParams?: Record<string, string>
+  ): Promise<void> {
     const url = new URL("/passwordless/start", this.issuer).toString();
     const httpOptions = this.httpOptions();
     httpOptions.headers.set("Content-Type", "application/json");
 
-    const body: Record<string, string> = {
+    const body: Record<string, unknown> = {
       client_id: this.clientMetadata.client_id,
       connection: options.connection
     };
@@ -3421,6 +3424,10 @@ export class AuthClient {
       body.send = options.send;
     } else {
       body.phone_number = options.phoneNumber;
+    }
+
+    if (authParams) {
+      body.authParams = authParams;
     }
 
     try {
@@ -3477,13 +3484,13 @@ export class AuthClient {
     }
 
     const params = new URLSearchParams();
-    params.append("connection", options.connection);
-    params.append("verification_code", options.verificationCode);
+    params.append("realm", options.connection);
+    params.append("otp", options.verificationCode);
 
     if (options.connection === "email") {
-      params.append("email", options.email);
+      params.append("username", options.email);
     } else {
-      params.append("phone_number", options.phoneNumber);
+      params.append("username", options.phoneNumber);
     }
 
     // Resolve scope and audience from global authorizationParameters

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -34,6 +34,8 @@ import {
   MissingStateError,
   MyAccountApiError,
   OAuth2Error,
+  PasswordlessStartError,
+  PasswordlessVerifyError,
   SdkError
 } from "../errors/index.js";
 import {
@@ -64,9 +66,13 @@ import {
   EnrollOptions,
   GetAccessTokenOptions,
   GRANT_TYPE_CUSTOM_TOKEN_EXCHANGE,
+  GRANT_TYPE_PASSWORDLESS_OTP,
   LogoutStrategy,
   LogoutToken,
   MfaVerifyResponse,
+  PasswordlessStartOptions,
+  PasswordlessVerifyOptions,
+  PasswordlessVerifyTokenResponse,
   ProxyOptions,
   RESPONSE_TYPES,
   SessionData,
@@ -3387,6 +3393,177 @@ export class AuthClient {
 
     // Persist updated session
     await this.sessionStore.set(reqCookies, resCookies, session);
+  }
+
+  /**
+   * Initiates a passwordless authentication flow by POSTing to `/passwordless/start`.
+   * Auth0 sends an OTP code or magic link to the user's email or phone number.
+   *
+   * @param options - Connection type, user identifier, and (for email) delivery method.
+   * @throws {PasswordlessStartError} On Auth0 API failure.
+   */
+  async passwordlessStart(options: PasswordlessStartOptions): Promise<void> {
+    const url = new URL("/passwordless/start", this.issuer).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    const body: Record<string, string> = {
+      client_id: this.clientMetadata.client_id,
+      connection: options.connection
+    };
+
+    if (this.clientSecret) {
+      body.client_secret = this.clientSecret;
+    }
+
+    if (options.connection === "email") {
+      body.email = options.email;
+      body.send = options.send;
+    } else {
+      body.phone_number = options.phoneNumber;
+    }
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to start passwordless flow"
+        }));
+        throw new PasswordlessStartError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description || "Failed to start passwordless flow",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+    } catch (e) {
+      if (e instanceof PasswordlessStartError) throw e;
+      throw new PasswordlessStartError(
+        "unexpected_error",
+        "Unexpected error during passwordless start",
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Verifies a passwordless OTP and exchanges it for tokens via the OAuth token endpoint.
+   * Returns raw tokens — the caller (route handler) is responsible for creating the session.
+   *
+   * Uses `grant_type=http://auth0.com/oauth/grant-type/passwordless/otp`.
+   * DPoP is applied when enabled.
+   *
+   * @param options - Connection type, user identifier, and verification code.
+   * @returns Token response from Auth0.
+   * @throws {PasswordlessVerifyError} On Auth0 API failure or discovery failure.
+   */
+  async passwordlessVerify(
+    options: PasswordlessVerifyOptions
+  ): Promise<PasswordlessVerifyTokenResponse> {
+    const [discoveryError, authorizationServerMetadata] =
+      await this.discoverAuthorizationServerMetadata();
+
+    if (discoveryError) {
+      throw new PasswordlessVerifyError(
+        "discovery_error",
+        "Failed to discover authorization server metadata",
+        undefined
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.append("connection", options.connection);
+    params.append("verification_code", options.verificationCode);
+
+    if (options.connection === "email") {
+      params.append("email", options.email);
+    } else {
+      params.append("phone_number", options.phoneNumber);
+    }
+
+    // Resolve scope and audience from global authorizationParameters
+    const scope =
+      getScopeForAudience(
+        this.authorizationParameters.scope,
+        this.authorizationParameters.audience
+      ) || DEFAULT_SCOPES;
+    params.append("scope", scope);
+
+    if (this.authorizationParameters.audience) {
+      params.append(
+        "audience",
+        this.authorizationParameters.audience as string
+      );
+    }
+
+    // Create DPoP handle ONCE outside the closure so it persists across retries.
+    // This is required by RFC 9449: the handle must learn and reuse the nonce from
+    // the DPoP-Nonce header across multiple attempts.
+    const dpopHandle =
+      this.useDPoP && this.dpopKeyPair
+        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
+        : undefined;
+
+    let tokenEndpointResponse: oauth.TokenEndpointResponse;
+    try {
+      tokenEndpointResponse = await withDPoPNonceRetry(
+        async () => {
+          const httpResponse = await oauth.genericTokenEndpointRequest(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            await this.getClientAuth(),
+            GRANT_TYPE_PASSWORDLESS_OTP,
+            params,
+            {
+              ...this.httpOptions(),
+              [oauth.customFetch]: this.fetch,
+              [oauth.allowInsecureRequests]: this.allowInsecureRequests,
+              ...(dpopHandle && { DPoP: dpopHandle })
+            }
+          );
+          return oauth.processGenericTokenEndpointResponse(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            httpResponse
+          );
+        },
+        {
+          isDPoPEnabled: !!(this.useDPoP && this.dpopKeyPair),
+          ...this.dpopOptions?.retry
+        }
+      );
+    } catch (err: any) {
+      const oauthErr = await extractOAuthErrorDetails(err);
+      throw new PasswordlessVerifyError(
+        oauthErr.error || "unknown_error",
+        oauthErr.error_description ||
+          err.message ||
+          "Passwordless verification failed",
+        oauthErr.error
+          ? {
+              error: oauthErr.error,
+              error_description: oauthErr.error_description ?? ""
+            }
+          : undefined
+      );
+    }
+
+    return {
+      access_token: tokenEndpointResponse.access_token,
+      refresh_token: tokenEndpointResponse.refresh_token,
+      id_token: tokenEndpointResponse.id_token,
+      token_type: tokenEndpointResponse.token_type
+        ? tokenEndpointResponse.token_type.charAt(0).toUpperCase() +
+          tokenEndpointResponse.token_type.slice(1)
+        : "Bearer",
+      scope: tokenEndpointResponse.scope,
+      expires_in: Number(tokenEndpointResponse.expires_in)
+    };
   }
 
   /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3677,12 +3677,15 @@ export class AuthClient {
    * @param options - Connection type, user identifier, and (for email) delivery method.
    * @throws {PasswordlessStartError} On Auth0 API failure.
    */
-  async passwordlessStart(options: PasswordlessStartOptions): Promise<void> {
+  async passwordlessStart(
+    options: PasswordlessStartOptions,
+    authParams?: Record<string, string>
+  ): Promise<void> {
     const url = new URL("/passwordless/start", this.issuer).toString();
     const httpOptions = this.httpOptions();
     httpOptions.headers.set("Content-Type", "application/json");
 
-    const body: Record<string, string> = {
+    const body: Record<string, unknown> = {
       client_id: this.clientMetadata.client_id,
       connection: options.connection
     };
@@ -3696,6 +3699,10 @@ export class AuthClient {
       body.send = options.send;
     } else {
       body.phone_number = options.phoneNumber;
+    }
+
+    if (authParams) {
+      body.authParams = authParams;
     }
 
     try {
@@ -3752,13 +3759,13 @@ export class AuthClient {
     }
 
     const params = new URLSearchParams();
-    params.append("connection", options.connection);
-    params.append("verification_code", options.verificationCode);
+    params.append("realm", options.connection);
+    params.append("otp", options.verificationCode);
 
     if (options.connection === "email") {
-      params.append("email", options.email);
+      params.append("username", options.email);
     } else {
-      params.append("phone_number", options.phoneNumber);
+      params.append("username", options.phoneNumber);
     }
 
     // Resolve scope and audience from global authorizationParameters

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -34,6 +34,8 @@ import {
   MissingStateError,
   MyAccountApiError,
   OAuth2Error,
+  PasswordlessStartError,
+  PasswordlessVerifyError,
   SdkError
 } from "../errors/index.js";
 import {
@@ -64,9 +66,13 @@ import {
   EnrollOtpOptions,
   GetAccessTokenOptions,
   GRANT_TYPE_CUSTOM_TOKEN_EXCHANGE,
+  GRANT_TYPE_PASSWORDLESS_OTP,
   LogoutStrategy,
   LogoutToken,
   MfaVerifyResponse,
+  PasswordlessStartOptions,
+  PasswordlessVerifyOptions,
+  PasswordlessVerifyTokenResponse,
   ProxyOptions,
   RESPONSE_TYPES,
   SessionData,
@@ -3662,6 +3668,177 @@ export class AuthClient {
 
     // Persist updated session
     await this.sessionStore.set(reqCookies, resCookies, session);
+  }
+
+  /**
+   * Initiates a passwordless authentication flow by POSTing to `/passwordless/start`.
+   * Auth0 sends an OTP code or magic link to the user's email or phone number.
+   *
+   * @param options - Connection type, user identifier, and (for email) delivery method.
+   * @throws {PasswordlessStartError} On Auth0 API failure.
+   */
+  async passwordlessStart(options: PasswordlessStartOptions): Promise<void> {
+    const url = new URL("/passwordless/start", this.issuer).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    const body: Record<string, string> = {
+      client_id: this.clientMetadata.client_id,
+      connection: options.connection
+    };
+
+    if (this.clientSecret) {
+      body.client_secret = this.clientSecret;
+    }
+
+    if (options.connection === "email") {
+      body.email = options.email;
+      body.send = options.send;
+    } else {
+      body.phone_number = options.phoneNumber;
+    }
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to start passwordless flow"
+        }));
+        throw new PasswordlessStartError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description || "Failed to start passwordless flow",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+    } catch (e) {
+      if (e instanceof PasswordlessStartError) throw e;
+      throw new PasswordlessStartError(
+        "unexpected_error",
+        "Unexpected error during passwordless start",
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Verifies a passwordless OTP and exchanges it for tokens via the OAuth token endpoint.
+   * Returns raw tokens — the caller (route handler) is responsible for creating the session.
+   *
+   * Uses `grant_type=http://auth0.com/oauth/grant-type/passwordless/otp`.
+   * DPoP is applied when enabled.
+   *
+   * @param options - Connection type, user identifier, and verification code.
+   * @returns Token response from Auth0.
+   * @throws {PasswordlessVerifyError} On Auth0 API failure or discovery failure.
+   */
+  async passwordlessVerify(
+    options: PasswordlessVerifyOptions
+  ): Promise<PasswordlessVerifyTokenResponse> {
+    const [discoveryError, authorizationServerMetadata] =
+      await this.discoverAuthorizationServerMetadata();
+
+    if (discoveryError) {
+      throw new PasswordlessVerifyError(
+        "discovery_error",
+        "Failed to discover authorization server metadata",
+        undefined
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.append("connection", options.connection);
+    params.append("verification_code", options.verificationCode);
+
+    if (options.connection === "email") {
+      params.append("email", options.email);
+    } else {
+      params.append("phone_number", options.phoneNumber);
+    }
+
+    // Resolve scope and audience from global authorizationParameters
+    const scope =
+      getScopeForAudience(
+        this.authorizationParameters.scope,
+        this.authorizationParameters.audience
+      ) || DEFAULT_SCOPES;
+    params.append("scope", scope);
+
+    if (this.authorizationParameters.audience) {
+      params.append(
+        "audience",
+        this.authorizationParameters.audience as string
+      );
+    }
+
+    // Create DPoP handle ONCE outside the closure so it persists across retries.
+    // This is required by RFC 9449: the handle must learn and reuse the nonce from
+    // the DPoP-Nonce header across multiple attempts.
+    const dpopHandle =
+      this.useDPoP && this.dpopKeyPair
+        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
+        : undefined;
+
+    let tokenEndpointResponse: oauth.TokenEndpointResponse;
+    try {
+      tokenEndpointResponse = await withDPoPNonceRetry(
+        async () => {
+          const httpResponse = await oauth.genericTokenEndpointRequest(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            await this.getClientAuth(),
+            GRANT_TYPE_PASSWORDLESS_OTP,
+            params,
+            {
+              ...this.httpOptions(),
+              [oauth.customFetch]: this.fetch,
+              [oauth.allowInsecureRequests]: this.allowInsecureRequests,
+              ...(dpopHandle && { DPoP: dpopHandle })
+            }
+          );
+          return oauth.processGenericTokenEndpointResponse(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            httpResponse
+          );
+        },
+        {
+          isDPoPEnabled: !!(this.useDPoP && this.dpopKeyPair),
+          ...this.dpopOptions?.retry
+        }
+      );
+    } catch (err: any) {
+      const oauthErr = await extractOAuthErrorDetails(err);
+      throw new PasswordlessVerifyError(
+        oauthErr.error || "unknown_error",
+        oauthErr.error_description ||
+          err.message ||
+          "Passwordless verification failed",
+        oauthErr.error
+          ? {
+              error: oauthErr.error,
+              error_description: oauthErr.error_description ?? ""
+            }
+          : undefined
+      );
+    }
+
+    return {
+      access_token: tokenEndpointResponse.access_token,
+      refresh_token: tokenEndpointResponse.refresh_token,
+      id_token: tokenEndpointResponse.id_token,
+      token_type: tokenEndpointResponse.token_type
+        ? tokenEndpointResponse.token_type.charAt(0).toUpperCase() +
+          tokenEndpointResponse.token_type.slice(1)
+        : "Bearer",
+      scope: tokenEndpointResponse.scope,
+      expires_in: Number(tokenEndpointResponse.expires_in)
+    };
   }
 
   /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -135,6 +135,7 @@ import {
   isBeforeOrEqual,
   mergeScopes,
   normalizeExpiresAt,
+  normalizeTokenType,
   tokenSetFromAccessTokenSet
 } from "../utils/token-set-helpers.js";
 import { isUrl, toSafeRedirect } from "../utils/url-helpers.js";
@@ -3612,14 +3613,9 @@ export class AuthClient {
       );
     }
 
-    // Ensure token_type is present (oauth4webapi marks it optional)
-    // oauth4webapi normalizes to lowercase, but we keep Auth0's casing for compatibility
     const result = {
       ...tokenEndpointResponse,
-      token_type: tokenEndpointResponse.token_type
-        ? tokenEndpointResponse.token_type.charAt(0).toUpperCase() +
-          tokenEndpointResponse.token_type.slice(1)
-        : "Bearer"
+      token_type: normalizeTokenType(tokenEndpointResponse.token_type)
     } as MfaVerifyResponse;
 
     return result;
@@ -3747,6 +3743,8 @@ export class AuthClient {
   async passwordlessVerify(
     options: PasswordlessVerifyOptions
   ): Promise<PasswordlessVerifyTokenResponse> {
+    await this.ensureDpopValidated();
+
     const [discoveryError, authorizationServerMetadata] =
       await this.discoverAuthorizationServerMetadata();
 
@@ -3839,10 +3837,7 @@ export class AuthClient {
       access_token: tokenEndpointResponse.access_token,
       refresh_token: tokenEndpointResponse.refresh_token,
       id_token: tokenEndpointResponse.id_token,
-      token_type: tokenEndpointResponse.token_type
-        ? tokenEndpointResponse.token_type.charAt(0).toUpperCase() +
-          tokenEndpointResponse.token_type.slice(1)
-        : "Bearer",
+      token_type: normalizeTokenType(tokenEndpointResponse.token_type),
       scope: tokenEndpointResponse.scope,
       expires_in: Number(tokenEndpointResponse.expires_in)
     };

--- a/src/server/passwordless.flow.test.ts
+++ b/src/server/passwordless.flow.test.ts
@@ -1,0 +1,319 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createAuthorizationServerMetadata,
+  getDefaultRoutes,
+  setupMswLifecycle
+} from "../test/defaults.js";
+import { generateSecret } from "../test/utils.js";
+import { AuthClient } from "./auth-client.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { TransactionStore } from "./transaction-store.js";
+
+const DEFAULT = {
+  domain: "auth0.local",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  email: "user@example.com",
+  phoneNumber: "+14155550100",
+  verificationCode: "123456",
+  accessToken: "test-access-token",
+  refreshToken: "test-refresh-token",
+  idToken: "test-id-token"
+};
+
+const authorizationServerMetadata = createAuthorizationServerMetadata(
+  DEFAULT.domain
+);
+
+const server = setupServer(
+  http.get(`https://${DEFAULT.domain}/.well-known/openid-configuration`, () => {
+    return HttpResponse.json(authorizationServerMetadata);
+  })
+);
+
+setupMswLifecycle(server);
+
+describe("AuthClient passwordless methods", () => {
+  let secret: string;
+  let authClient: AuthClient;
+
+  beforeEach(async () => {
+    secret = await generateSecret(32);
+    const transactionStore = new TransactionStore({ secret });
+    const sessionStore = new StatelessSessionStore({ secret });
+    authClient = new AuthClient({
+      domain: DEFAULT.domain,
+      clientId: DEFAULT.clientId,
+      clientSecret: DEFAULT.clientSecret,
+      appBaseUrl: DEFAULT.appBaseUrl,
+      secret,
+      transactionStore,
+      sessionStore,
+      routes: getDefaultRoutes()
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passwordlessStart
+  // ---------------------------------------------------------------------------
+
+  describe("passwordlessStart", () => {
+    it("sends correct body for email connection", async () => {
+      let capturedBody: Record<string, string> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, string>;
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      await authClient.passwordlessStart({
+        connection: "email",
+        email: DEFAULT.email,
+        send: "code"
+      });
+
+      expect(capturedBody.client_id).toBe(DEFAULT.clientId);
+      expect(capturedBody.client_secret).toBe(DEFAULT.clientSecret);
+      expect(capturedBody.connection).toBe("email");
+      expect(capturedBody.email).toBe(DEFAULT.email);
+      expect(capturedBody.send).toBe("code");
+      expect(capturedBody.phone_number).toBeUndefined();
+    });
+
+    it("sends correct body for sms connection", async () => {
+      let capturedBody: Record<string, string> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, string>;
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      await authClient.passwordlessStart({
+        connection: "sms",
+        phoneNumber: DEFAULT.phoneNumber
+      });
+
+      expect(capturedBody.connection).toBe("sms");
+      expect(capturedBody.phone_number).toBe(DEFAULT.phoneNumber);
+      expect(capturedBody.email).toBeUndefined();
+      expect(capturedBody.send).toBeUndefined();
+    });
+
+    it("throws PasswordlessStartError on Auth0 API error", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () => {
+          return HttpResponse.json(
+            {
+              error: "bad.connection",
+              error_description: "Connection not found."
+            },
+            { status: 400 }
+          );
+        })
+      );
+
+      await expect(
+        authClient.passwordlessStart({
+          connection: "email",
+          email: DEFAULT.email,
+          send: "code"
+        })
+      ).rejects.toMatchObject({
+        name: "PasswordlessStartError",
+        error: "bad.connection",
+        error_description: "Connection not found."
+      });
+    });
+
+    it("throws PasswordlessStartError with unexpected_error on network failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () => {
+          return HttpResponse.error();
+        })
+      );
+
+      await expect(
+        authClient.passwordlessStart({
+          connection: "email",
+          email: DEFAULT.email,
+          send: "link"
+        })
+      ).rejects.toMatchObject({
+        name: "PasswordlessStartError",
+        error: "unexpected_error"
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passwordlessVerify
+  // ---------------------------------------------------------------------------
+
+  describe("passwordlessVerify", () => {
+    it("sends correct params for email connection and returns token response", async () => {
+      let capturedParams: URLSearchParams = new URLSearchParams();
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            capturedParams = new URLSearchParams(await request.text());
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              refresh_token: DEFAULT.refreshToken,
+              token_type: "Bearer",
+              expires_in: 86400,
+              scope: "openid profile email"
+            });
+          }
+        )
+      );
+
+      const result = await authClient.passwordlessVerify({
+        connection: "email",
+        email: DEFAULT.email,
+        verificationCode: DEFAULT.verificationCode
+      });
+
+      expect(capturedParams.get("grant_type")).toBe(
+        "http://auth0.com/oauth/grant-type/passwordless/otp"
+      );
+      expect(capturedParams.get("connection")).toBe("email");
+      expect(capturedParams.get("email")).toBe(DEFAULT.email);
+      expect(capturedParams.get("verification_code")).toBe(
+        DEFAULT.verificationCode
+      );
+      expect(capturedParams.get("phone_number")).toBeNull();
+
+      expect(result.access_token).toBe(DEFAULT.accessToken);
+      expect(result.refresh_token).toBe(DEFAULT.refreshToken);
+      expect(result.token_type).toBe("Bearer");
+      expect(result.expires_in).toBe(86400);
+    });
+
+    it("sends correct params for sms connection", async () => {
+      let capturedParams: URLSearchParams = new URLSearchParams();
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            capturedParams = new URLSearchParams(await request.text());
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              token_type: "Bearer",
+              expires_in: 86400
+            });
+          }
+        )
+      );
+
+      await authClient.passwordlessVerify({
+        connection: "sms",
+        phoneNumber: DEFAULT.phoneNumber,
+        verificationCode: DEFAULT.verificationCode
+      });
+
+      expect(capturedParams.get("connection")).toBe("sms");
+      expect(capturedParams.get("phone_number")).toBe(DEFAULT.phoneNumber);
+      expect(capturedParams.get("verification_code")).toBe(
+        DEFAULT.verificationCode
+      );
+      expect(capturedParams.get("email")).toBeNull();
+    });
+
+    it("capitalizes token_type in response", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () => {
+          return HttpResponse.json({
+            access_token: DEFAULT.accessToken,
+            token_type: "bearer", // lowercase from Auth0
+            expires_in: 86400
+          });
+        })
+      );
+
+      const result = await authClient.passwordlessVerify({
+        connection: "email",
+        email: DEFAULT.email,
+        verificationCode: DEFAULT.verificationCode
+      });
+
+      expect(result.token_type).toBe("Bearer");
+    });
+
+    it("throws PasswordlessVerifyError on invalid_grant", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () => {
+          return HttpResponse.json(
+            {
+              error: "invalid_grant",
+              error_description: "Wrong email or verification code."
+            },
+            { status: 403 }
+          );
+        })
+      );
+
+      await expect(
+        authClient.passwordlessVerify({
+          connection: "email",
+          email: DEFAULT.email,
+          verificationCode: "wrong-code"
+        })
+      ).rejects.toMatchObject({
+        name: "PasswordlessVerifyError",
+        error: "invalid_grant",
+        error_description: "Wrong email or verification code."
+      });
+    });
+
+    it("throws PasswordlessVerifyError on discovery failure", async () => {
+      // Override discovery to fail
+      server.use(
+        http.get(
+          `https://${DEFAULT.domain}/.well-known/openid-configuration`,
+          () => HttpResponse.error()
+        )
+      );
+
+      // Fresh client so discovery cache is empty
+      const freshSecret = await generateSecret(32);
+      const freshClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: freshSecret,
+        transactionStore: new TransactionStore({ secret: freshSecret }),
+        sessionStore: new StatelessSessionStore({ secret: freshSecret }),
+        routes: getDefaultRoutes()
+      });
+
+      await expect(
+        freshClient.passwordlessVerify({
+          connection: "email",
+          email: DEFAULT.email,
+          verificationCode: DEFAULT.verificationCode
+        })
+      ).rejects.toMatchObject({
+        name: "PasswordlessVerifyError",
+        error: "discovery_error"
+      });
+    });
+  });
+});

--- a/src/server/passwordless.flow.test.ts
+++ b/src/server/passwordless.flow.test.ts
@@ -192,12 +192,11 @@ describe("AuthClient passwordless methods", () => {
       expect(capturedParams.get("grant_type")).toBe(
         "http://auth0.com/oauth/grant-type/passwordless/otp"
       );
-      expect(capturedParams.get("connection")).toBe("email");
-      expect(capturedParams.get("email")).toBe(DEFAULT.email);
-      expect(capturedParams.get("verification_code")).toBe(
-        DEFAULT.verificationCode
-      );
+      expect(capturedParams.get("realm")).toBe("email");
+      expect(capturedParams.get("username")).toBe(DEFAULT.email);
+      expect(capturedParams.get("otp")).toBe(DEFAULT.verificationCode);
       expect(capturedParams.get("phone_number")).toBeNull();
+      expect(capturedParams.get("email")).toBeNull();
 
       expect(result.access_token).toBe(DEFAULT.accessToken);
       expect(result.refresh_token).toBe(DEFAULT.refreshToken);
@@ -228,12 +227,11 @@ describe("AuthClient passwordless methods", () => {
         verificationCode: DEFAULT.verificationCode
       });
 
-      expect(capturedParams.get("connection")).toBe("sms");
-      expect(capturedParams.get("phone_number")).toBe(DEFAULT.phoneNumber);
-      expect(capturedParams.get("verification_code")).toBe(
-        DEFAULT.verificationCode
-      );
+      expect(capturedParams.get("realm")).toBe("sms");
+      expect(capturedParams.get("username")).toBe(DEFAULT.phoneNumber);
+      expect(capturedParams.get("otp")).toBe(DEFAULT.verificationCode);
       expect(capturedParams.get("email")).toBeNull();
+      expect(capturedParams.get("phone_number")).toBeNull();
     });
 
     it("capitalizes token_type in response", async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -228,5 +228,6 @@ export {
   PasswordlessVerifyOptions,
   PasswordlessVerifyEmailOptions,
   PasswordlessVerifySmsOptions,
+  PasswordlessVerifyTokenResponse,
   GRANT_TYPE_PASSWORDLESS_OTP
 } from "./passwordless.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -257,5 +257,6 @@ export {
   PasswordlessVerifyOptions,
   PasswordlessVerifyEmailOptions,
   PasswordlessVerifySmsOptions,
+  PasswordlessVerifyTokenResponse,
   GRANT_TYPE_PASSWORDLESS_OTP
 } from "./passwordless.js";

--- a/src/types/passwordless.ts
+++ b/src/types/passwordless.ts
@@ -76,6 +76,25 @@ export type PasswordlessVerifyOptions =
   | PasswordlessVerifySmsOptions;
 
 /**
+ * Token response returned by Auth0 after a successful passwordless OTP verification.
+ * Uses snake_case to match Auth0 API and SPA SDK conventions.
+ */
+export interface PasswordlessVerifyTokenResponse {
+  /** Access token */
+  access_token: string;
+  /** Refresh token (if offline_access scope was granted) */
+  refresh_token?: string;
+  /** ID token */
+  id_token?: string;
+  /** Token type (usually "Bearer") */
+  token_type: string;
+  /** Granted scope */
+  scope?: string;
+  /** Expires in seconds */
+  expires_in: number;
+}
+
+/**
  * Public interface for the passwordless client.
  * Accessible via `auth0.passwordless` after initialization.
  */

--- a/src/utils/token-set-helpers.test.ts
+++ b/src/utils/token-set-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   compareScopes,
   findAccessTokenSet,
   mergeScopes,
+  normalizeTokenType,
   tokenSetFromAccessTokenSet
 } from "./token-set-helpers.js";
 
@@ -867,6 +868,34 @@ describe("token-set-helpers", () => {
       expect(result).toBe(
         "read:user/profile write:user/settings delete:user/account"
       );
+    });
+  });
+
+  describe("normalizeTokenType", () => {
+    it("normalizes lowercase bearer to Bearer", () => {
+      expect(normalizeTokenType("bearer")).toBe("Bearer");
+    });
+
+    it("normalizes uppercase BEARER to Bearer", () => {
+      expect(normalizeTokenType("BEARER")).toBe("Bearer");
+    });
+
+    it("normalizes lowercase dpop to DPoP", () => {
+      expect(normalizeTokenType("dpop")).toBe("DPoP");
+    });
+
+    it("normalizes mixed-case dpop variants to DPoP", () => {
+      expect(normalizeTokenType("Dpop")).toBe("DPoP");
+      expect(normalizeTokenType("DPOP")).toBe("DPoP");
+      expect(normalizeTokenType("DPoP")).toBe("DPoP");
+    });
+
+    it("returns Bearer for undefined", () => {
+      expect(normalizeTokenType(undefined)).toBe("Bearer");
+    });
+
+    it("capitalizes the first letter of unknown token types", () => {
+      expect(normalizeTokenType("mac")).toBe("Mac");
     });
   });
 });

--- a/src/utils/token-set-helpers.ts
+++ b/src/utils/token-set-helpers.ts
@@ -1,6 +1,18 @@
 import { AccessTokenSet, SessionData, TokenSet } from "../types/index.js";
 
 /**
+ * Normalizes oauth4webapi's lowercase token_type to canonical OAuth casing.
+ * oauth4webapi returns token types in lowercase; consumers expect "Bearer" or "DPoP".
+ */
+export function normalizeTokenType(tokenType: string | undefined): string {
+  if (!tokenType) return "Bearer";
+  const lower = tokenType.toLowerCase();
+  if (lower === "dpop") return "DPoP";
+  if (lower === "bearer") return "Bearer";
+  return tokenType.charAt(0).toUpperCase() + tokenType.slice(1);
+}
+
+/**
  * Input type for expires-at values that may come from various sources.
  * Supports number (epoch seconds), string (parseable number), null, or undefined.
  */


### PR DESCRIPTION
# Passwordless support - PR 3

## Summary

Adds `passwordlessStart()` and `passwordlessVerify()` as internal methods on `AuthClient` — the thin HTTP layer that posts to Auth0's `/passwordless/start` and `/oauth/token` endpoints. These are the direct API calls; route wiring and public exports come in subsequent PRs.

## Changes

### `src/server/auth-client.ts`

#### `passwordlessStart(options, authParams?)`

Posts to `POST /passwordless/start` with the client credentials and the caller-supplied options (connection, email or phone_number, send mode). Accepts an optional `authParams` spread so callers can pass extra authorization parameters through to Auth0 (e.g. `audience`, `scope`).

Throws `PasswordlessStartError` on non-2xx responses.

#### `passwordlessVerify(options)`

Posts to `POST /oauth/token` using the `http://auth0.com/oauth/grant-type/passwordless/otp` grant type.

**Parameter naming note:** Auth0's token endpoint uses `realm`, `otp`, and `username` — not `connection`, `verification_code`, or `email`. This PR uses the correct parameter names as required by the Auth0 API spec.

Throws `PasswordlessVerifyError` on failure (wrong code, expired, too many attempts, etc.).

### `src/server/passwordless.flow.test.ts` (new)

Flow tests that instantiate `AuthClient` directly with MSW mocking HTTP endpoints.

- Successful email OTP start + verify
- Successful SMS OTP start + verify
- Magic link start (no verify step)
- Error cases: `PasswordlessStartError` on bad start request, `PasswordlessVerifyError` on wrong OTP

## Depends on

[feat(passwordless): add error classes and types for passwordless authentication](https://github.com/auth0/nextjs-auth0/pull/2606)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Auth0 passwordless flows for email and SMS: OTP initiation and secure token verification
  * Supports optional authorization parameters and DPoP-proofed token exchange

* **Bug Fixes**
  * Normalized token type casing to ensure consistent "Bearer"/"DPoP" responses

* **Tests**
  * Added end-to-end tests covering passwordless success and error scenarios, including discovery and network failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->