### PR TITLE
fix: respect allowInsecureRequests option in AuthClientProvider domain validation

### DIFF
--- a/src/client/helpers/with-page-auth-required.test.tsx
+++ b/src/client/helpers/with-page-auth-required.test.tsx
@@ -250,8 +250,9 @@ describe("with-page-auth-required csr", () => {
       expect(window.location.assign).toHaveBeenCalled();
     });
     const url = new URL(
-      (window.location.assign as MockedFunction<typeof window.location.assign>)
-        .mock.calls[0][0],
+      (
+        window.location.assign as MockedFunction<typeof window.location.assign>
+      ).mock.calls[0][0],
       "https://example.com"
     );
     expect(url.searchParams.get("returnTo")).toEqual("/foo?bar=baz&qux=quux");

--- a/src/client/mfa/mfa-client.flow.test.ts
+++ b/src/client/mfa/mfa-client.flow.test.ts
@@ -123,8 +123,9 @@ describe("ClientMfaClient", () => {
     });
 
     it("should throw MfaGetAuthenticatorsError for network errors", async () => {
-      const { MfaGetAuthenticatorsError } =
-        await import("../../errors/index.js");
+      const { MfaGetAuthenticatorsError } = await import(
+        "../../errors/index.js"
+      );
 
       const encryptedToken = await encryptMfaToken(
         DEFAULT.mfaToken,
@@ -738,8 +739,9 @@ describe("ClientMfaClient", () => {
 
   describe("getAuthenticators - query param validation", () => {
     it("should handle empty query param gracefully", async () => {
-      const { MfaGetAuthenticatorsError } =
-        await import("../../errors/index.js");
+      const { MfaGetAuthenticatorsError } = await import(
+        "../../errors/index.js"
+      );
 
       // Server should reject empty mfa_token
       server.use(

--- a/src/server/auth-client-provider.ts
+++ b/src/server/auth-client-provider.ts
@@ -80,7 +80,8 @@ export class AuthClientProvider {
       // Static mode: normalize and validate domain
       this.mode = "static";
       const normalized = normalizeDomain(options.domain, {
-        allowInsecureRequests: options.allowInsecureRequests ?? process.env.NODE_ENV === "test"
+        allowInsecureRequests:
+          options.allowInsecureRequests ?? process.env.NODE_ENV === "test"
       });
       this.staticDomain = normalized.domain;
 

--- a/src/server/auth-client-provider.ts
+++ b/src/server/auth-client-provider.ts
@@ -26,6 +26,12 @@ interface AuthClientProviderOptions {
    * Called when a new domain client is needed.
    */
   createAuthClient: (domain: string) => AuthClient;
+
+  /**
+   * Allow insecure HTTP requests to localhost during development.
+   * When true, HTTP (non-HTTPS) localhost domains are accepted.
+   */
+  allowInsecureRequests?: boolean;
 }
 
 /**
@@ -74,7 +80,7 @@ export class AuthClientProvider {
       // Static mode: normalize and validate domain
       this.mode = "static";
       const normalized = normalizeDomain(options.domain, {
-        allowInsecureRequests: process.env.NODE_ENV === "test"
+        allowInsecureRequests: options.allowInsecureRequests ?? process.env.NODE_ENV === "test"
       });
       this.staticDomain = normalized.domain;
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -652,6 +652,7 @@ export class Auth0Client {
     // The factory captures 'this' by reference, and will read this.provider when called later (not during construction).
     this.provider = new AuthClientProvider({
       domain: domainForProvider,
+      allowInsecureRequests: options.allowInsecureRequests,
       createAuthClient: (domainForClient) => {
         return new AuthClient({
           transactionStore: this.transactionStore,

--- a/src/server/mfa-server.flow.test.ts
+++ b/src/server/mfa-server.flow.test.ts
@@ -419,8 +419,9 @@ describe("AuthClient MFA Methods", () => {
     });
 
     it("should cache access token in session when cookies provided", async () => {
-      const { RequestCookies, ResponseCookies } =
-        await import("@edge-runtime/cookies");
+      const { RequestCookies, ResponseCookies } = await import(
+        "@edge-runtime/cookies"
+      );
 
       const session: SessionData = {
         user: { sub: DEFAULT.sub },


### PR DESCRIPTION
## Problem

When `allowInsecureRequests: true` is set in `Auth0Client` options, localhost domains are still rejected at startup with a domain validation error. The option has no effect.

Root cause: `AuthClientProvider` constructor hardcodes the insecure-request check to `process.env.NODE_ENV === 'test'`, completely ignoring the user-supplied option:

```ts
// Before — ignores user option entirely:
const normalized = normalizeDomain(options.domain, {
  allowInsecureRequests: process.env.NODE_ENV === "test"
});
```

The `allowInsecureRequests` option IS forwarded to every `AuthClient` instance (in `client.ts`), but `AuthClientProvider` never received it, so the domain is rejected before any `AuthClient` is created.

## Fix

1. Add `allowInsecureRequests?: boolean` to `AuthClientProviderOptions`
2. Forward `options.allowInsecureRequests` from `Auth0Client` when constructing the provider
3. Use `options.allowInsecureRequests ?? process.env.NODE_ENV === 'test'` in the `normalizeDomain` call — preserving the existing test-env fallback

## Testing

All 1367 existing unit tests continue to pass (`pnpm test:unit`).

Fixes #2626