### PR TITLE
fix(mfa): move NextResponse-dependent buildEnrollOptions to server-only module

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -86,8 +86,8 @@ import {
 import { withDPoPNonceRetry } from "../utils/dpopRetry.js";
 import { createSizeLimitedFetch } from "../utils/fetchUtils.js";
 import { createAuthCompletePostMessageResponse } from "../utils/html-helpers.js";
+import { buildEnrollOptions } from "../utils/mfa-server-utils.js";
 import {
-  buildEnrollOptions,
   buildVerifyParams,
   getVerifyGrantType,
   transformVerifyBodyToOptions

--- a/src/utils/mfa-server-utils.ts
+++ b/src/utils/mfa-server-utils.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server.js";
+
+import type { EnrollOobOptions, EnrollOtpOptions } from "../types/index.js";
+
+/**
+ * Builds type-safe enrollment options from request body.
+ * snake_case ONLY (oob_channels, phone_number), no camelCase fallback.
+ *
+ * @param body - Request body
+ * @param authenticatorType - Type of authenticator to enroll
+ * @returns Tuple of [options, null] or [null, errorResponse]
+ */
+export function buildEnrollOptions(
+  body: unknown,
+  authenticatorType: string
+):
+  | [Omit<EnrollOobOptions, "mfaToken">, null]
+  | [Omit<EnrollOtpOptions, "mfaToken">, null]
+  | [null, NextResponse] {
+  const bodyObj = body as Record<string, unknown>;
+  if (authenticatorType === "oob") {
+    // snake_case ONLY
+    const oobChannels = bodyObj.oob_channels;
+    if (!oobChannels || !Array.isArray(oobChannels)) {
+      return [
+        null,
+        NextResponse.json(
+          {
+            error: "invalid_request",
+            error_description:
+              "Missing or invalid oob_channels for OOB enrollment"
+          },
+          { status: 400 }
+        )
+      ];
+    }
+    const phoneNumber =
+      typeof bodyObj.phone_number === "string" && bodyObj.phone_number !== ""
+        ? bodyObj.phone_number
+        : undefined;
+    const email =
+      typeof bodyObj.email === "string" && bodyObj.email !== ""
+        ? bodyObj.email
+        : undefined;
+    return [
+      {
+        authenticatorTypes: ["oob"] as ["oob"],
+        oobChannels: oobChannels as ("sms" | "voice" | "auth0" | "email")[],
+        phoneNumber,
+        email
+      },
+      null
+    ];
+  } else if (authenticatorType === "otp") {
+    return [
+      {
+        authenticatorTypes: ["otp"] as ["otp"]
+      },
+      null
+    ];
+  } else {
+    return [
+      null,
+      NextResponse.json(
+        {
+          error: "invalid_request",
+          error_description: `Unsupported authenticator_type: ${authenticatorType}`
+        },
+        { status: 400 }
+      )
+    ];
+  }
+}

--- a/src/utils/mfa-transform-utils.ts
+++ b/src/utils/mfa-transform-utils.ts
@@ -1,5 +1,3 @@
-import { NextResponse } from "next/server.js";
-
 import { InvalidRequestError, MfaVerifyError } from "../errors/mfa-errors.js";
 import type {
   Authenticator,
@@ -94,76 +92,6 @@ export function buildEnrollmentResponse(
   }
 
   throw new Error(`Unknown authenticator type: ${result.authenticator_type}`);
-}
-
-/**
- * Builds type-safe enrollment options from request body.
- * snake_case ONLY (oob_channels, phone_number), no camelCase fallback.
- *
- * @param body - Request body
- * @param authenticatorType - Type of authenticator to enroll
- * @returns Tuple of [options, null] or [null, errorResponse]
- */
-export function buildEnrollOptions(
-  body: unknown,
-  authenticatorType: string
-):
-  | [Omit<EnrollOobOptions, "mfaToken">, null]
-  | [Omit<EnrollOtpOptions, "mfaToken">, null]
-  | [null, NextResponse] {
-  const bodyObj = body as Record<string, unknown>;
-  if (authenticatorType === "oob") {
-    // snake_case ONLY
-    const oobChannels = bodyObj.oob_channels;
-    if (!oobChannels || !Array.isArray(oobChannels)) {
-      return [
-        null,
-        NextResponse.json(
-          {
-            error: "invalid_request",
-            error_description:
-              "Missing or invalid oob_channels for OOB enrollment"
-          },
-          { status: 400 }
-        )
-      ];
-    }
-    const phoneNumber =
-      typeof bodyObj.phone_number === "string" && bodyObj.phone_number !== ""
-        ? bodyObj.phone_number
-        : undefined;
-    const email =
-      typeof bodyObj.email === "string" && bodyObj.email !== ""
-        ? bodyObj.email
-        : undefined;
-    return [
-      {
-        authenticatorTypes: ["oob"] as ["oob"],
-        oobChannels: oobChannels as ("sms" | "voice" | "auth0" | "email")[],
-        phoneNumber,
-        email
-      },
-      null
-    ];
-  } else if (authenticatorType === "otp") {
-    return [
-      {
-        authenticatorTypes: ["otp"] as ["otp"]
-      },
-      null
-    ];
-  } else {
-    return [
-      null,
-      NextResponse.json(
-        {
-          error: "invalid_request",
-          error_description: `Unsupported authenticator_type: ${authenticatorType}`
-        },
-        { status: 400 }
-      )
-    ];
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

In v4.19.0, `client/mfa/index.ts` added an import from `utils/mfa-transform-utils.ts` which has a top-level `import { NextResponse } from 'next/server.js'`. This causes `ReferenceError: Request is not defined` in any Jest + jest-environment-jsdom test that imports from `@auth0/nextjs-auth0`.

## Root Cause

Only `buildEnrollOptions` (not exported to the client) uses `NextResponse`. The four client-safe helpers (`camelizeAuthenticator`, `camelizeChallengeResponse`, `buildEnrollmentResponse`, `normalizeEnrollOptions`) do not use any server-only APIs.

## Changes

- Create **`src/utils/mfa-server-utils.ts`**: server-only module containing `buildEnrollOptions` with the `next/server` import.
- **`src/utils/mfa-transform-utils.ts`**: Remove `import { NextResponse }` and `buildEnrollOptions` (moved to new file).
- **`src/server/auth-client.ts`**: Import `buildEnrollOptions` from the new `mfa-server-utils.ts` module.

## Testing

`npm run build` (tsc) exits 0. Lint (tsc --noEmit + eslint) passes via pre-commit hook.

Fixes #2639