### PR TITLE
feat(mTLS): add mTLS support to Auth0Client public API

### DIFF
--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -211,6 +211,53 @@ describe("Auth0Client", () => {
         expect(err.cause?.message).toContain("Missing: domain");
       });
     });
+
+    describe("mTLS", () => {
+      const BASE = {
+        domain: "test.auth0.com",
+        clientId: "test-client-id",
+        appBaseUrl: "https://example.com",
+        secret: "a".repeat(32)
+      };
+
+      it("accepts useMtls=true without clientSecret", () => {
+        expect(
+          () =>
+            new Auth0Client({
+              ...BASE,
+              useMtls: true,
+              customFetch: globalThis.fetch
+            })
+        ).not.toThrow();
+      });
+
+      it("reads useMtls from AUTH0_MTLS env var", () => {
+        process.env.AUTH0_MTLS = "true";
+
+        expect(
+          () =>
+            new Auth0Client({
+              ...BASE,
+              customFetch: globalThis.fetch
+            })
+        ).not.toThrow();
+
+        delete process.env.AUTH0_MTLS;
+      });
+
+      it("still requires clientSecret when useMtls is false (default)", () => {
+        const consoleSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+
+        new Auth0Client({ ...BASE });
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("clientAuthentication")
+        );
+        consoleSpy.mockRestore();
+      });
+    });
   });
 
   // TODO: Re-implement DPoP handle management if needed

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -394,6 +394,75 @@ export interface Auth0ClientOptions {
    */
   dpopOptions?: DpopOptions;
 
+  // mTLS Configuration
+  /**
+   * Enable mTLS (Mutual TLS, RFC 8705) client authentication.
+   *
+   * When `true`, the SDK authenticates with Auth0 using a client TLS certificate
+   * instead of a client secret or private-key JWT. Access tokens issued by Auth0
+   * will be certificate-bound (`cnf.x5t#S256` claim), providing strong proof-of-possession
+   * protection against token theft.
+   *
+   * Using mTLS requires:
+   * 1. A TLS-aware `customFetch` implementation that attaches your client certificate
+   *    (e.g. Node.js `undici` configured with `connect: { key, cert }`).
+   * 2. The mTLS feature to be enabled on your Auth0 tenant.
+   *
+   * You do **not** need to provide `clientSecret` or `clientAssertionSigningKey`
+   * when `useMtls` is `true` — the certificate is the sole client credential.
+   *
+   * Can also be enabled by setting the `AUTH0_MTLS=true` environment variable.
+   *
+   * @default false
+   *
+   * @example
+   * ```typescript
+   * import { Agent, fetch as undiciFetch } from "undici";
+   * import { readFileSync } from "fs";
+   *
+   * const tlsAgent = new Agent({
+   *   connect: {
+   *     key: readFileSync("client.key"),
+   *     cert: readFileSync("client.crt")
+   *   }
+   * });
+   *
+   * export const auth0 = new Auth0Client({
+   *   useMtls: true,
+   *   customFetch: (url, init) =>
+   *     undiciFetch(url, { ...init, dispatcher: tlsAgent })
+   * });
+   * ```
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8705 | RFC 8705: OAuth 2.0 Mutual-TLS Client Authentication}
+   */
+  useMtls?: boolean;
+
+  /**
+   * A custom `fetch` implementation used for all outbound requests to Auth0.
+   *
+   * Required when `useMtls` is `true` — provide a TLS-aware implementation that
+   * attaches your client certificate to every request (e.g. `undici` with
+   * `connect: { key, cert }`).
+   *
+   * Can also be used independently (without mTLS) to proxy requests, add custom
+   * headers, or inject test doubles in unit tests.
+   *
+   * @example
+   * ```typescript
+   * import { Agent, fetch as undiciFetch } from "undici";
+   *
+   * const tlsAgent = new Agent({ connect: { cert, key } });
+   *
+   * export const auth0 = new Auth0Client({
+   *   useMtls: true,
+   *   customFetch: (url, init) =>
+   *     undiciFetch(url, { ...init, dispatcher: tlsAgent })
+   * });
+   * ```
+   */
+  customFetch?: typeof fetch;
+
   /**
    * MFA context TTL in seconds. Controls how long encrypted mfa_token remains valid.
    * Default: 300 (5 minutes, matching Auth0's mfa_token expiration)
@@ -689,6 +758,8 @@ export class Auth0Client {
           useDPoP: options.useDPoP || false,
           dpopKeyPair: options.dpopKeyPair,
           dpopOptions: options.dpopOptions,
+          useMtls: options.useMtls ?? process.env.AUTH0_MTLS === "true",
+          fetch: options.customFetch,
           mfaTokenTtl,
           cspNonce: options.cspNonce,
 
@@ -1558,15 +1629,17 @@ export class Auth0Client {
       : process.env.APP_BASE_URL;
     const appBaseUrl = options.appBaseUrl ?? envAppBaseUrl;
 
-    // Check client authentication options - either clientSecret OR clientAssertionSigningKey must be provided
+    // Check client authentication options - either clientSecret OR clientAssertionSigningKey must be provided.
+    // mTLS (useMtls=true / AUTH0_MTLS=true) authenticates via a client certificate so no secret is needed.
     const clientSecret =
       options.clientSecret ?? process.env.AUTH0_CLIENT_SECRET;
     const clientAssertionSigningKey =
       options.clientAssertionSigningKey ??
       process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY;
-    const hasClientAuthentication = !!(
-      clientSecret || clientAssertionSigningKey
-    );
+    const isMtls =
+      options.useMtls === true || process.env.AUTH0_MTLS === "true";
+    const hasClientAuthentication =
+      !!(clientSecret || clientAssertionSigningKey) || isMtls;
 
     const missing = Object.entries(requiredOptions)
       .filter(([, value]) => !value)

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -396,6 +396,75 @@ export interface Auth0ClientOptions {
    */
   dpopOptions?: DpopOptions;
 
+  // mTLS Configuration
+  /**
+   * Enable mTLS (Mutual TLS, RFC 8705) client authentication.
+   *
+   * When `true`, the SDK authenticates with Auth0 using a client TLS certificate
+   * instead of a client secret or private-key JWT. Access tokens issued by Auth0
+   * will be certificate-bound (`cnf.x5t#S256` claim), providing strong proof-of-possession
+   * protection against token theft.
+   *
+   * Using mTLS requires:
+   * 1. A TLS-aware `customFetch` implementation that attaches your client certificate
+   *    (e.g. Node.js `undici` configured with `connect: { key, cert }`).
+   * 2. The mTLS feature to be enabled on your Auth0 tenant.
+   *
+   * You do **not** need to provide `clientSecret` or `clientAssertionSigningKey`
+   * when `useMtls` is `true` — the certificate is the sole client credential.
+   *
+   * Can also be enabled by setting the `AUTH0_MTLS=true` environment variable.
+   *
+   * @default false
+   *
+   * @example
+   * ```typescript
+   * import { Agent, fetch as undiciFetch } from "undici";
+   * import { readFileSync } from "fs";
+   *
+   * const tlsAgent = new Agent({
+   *   connect: {
+   *     key: readFileSync("client.key"),
+   *     cert: readFileSync("client.crt")
+   *   }
+   * });
+   *
+   * export const auth0 = new Auth0Client({
+   *   useMtls: true,
+   *   customFetch: (url, init) =>
+   *     undiciFetch(url, { ...init, dispatcher: tlsAgent })
+   * });
+   * ```
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8705 | RFC 8705: OAuth 2.0 Mutual-TLS Client Authentication}
+   */
+  useMtls?: boolean;
+
+  /**
+   * A custom `fetch` implementation used for all outbound requests to Auth0.
+   *
+   * Required when `useMtls` is `true` — provide a TLS-aware implementation that
+   * attaches your client certificate to every request (e.g. `undici` with
+   * `connect: { key, cert }`).
+   *
+   * Can also be used independently (without mTLS) to proxy requests, add custom
+   * headers, or inject test doubles in unit tests.
+   *
+   * @example
+   * ```typescript
+   * import { Agent, fetch as undiciFetch } from "undici";
+   *
+   * const tlsAgent = new Agent({ connect: { cert, key } });
+   *
+   * export const auth0 = new Auth0Client({
+   *   useMtls: true,
+   *   customFetch: (url, init) =>
+   *     undiciFetch(url, { ...init, dispatcher: tlsAgent })
+   * });
+   * ```
+   */
+  customFetch?: typeof fetch;
+
   /**
    * MFA context TTL in seconds. Controls how long encrypted mfa_token remains valid.
    * Default: 300 (5 minutes, matching Auth0's mfa_token expiration)
@@ -715,6 +784,8 @@ export class Auth0Client {
           useDPoP: options.useDPoP || false,
           dpopKeyPair: options.dpopKeyPair,
           dpopOptions: options.dpopOptions,
+          useMtls: options.useMtls ?? process.env.AUTH0_MTLS === "true",
+          fetch: options.customFetch,
           mfaTokenTtl,
           cspNonce: options.cspNonce,
 
@@ -1610,15 +1681,17 @@ export class Auth0Client {
       : process.env.APP_BASE_URL;
     const appBaseUrl = options.appBaseUrl ?? envAppBaseUrl;
 
-    // Check client authentication options - either clientSecret OR clientAssertionSigningKey must be provided
+    // Check client authentication options - either clientSecret OR clientAssertionSigningKey must be provided.
+    // mTLS (useMtls=true / AUTH0_MTLS=true) authenticates via a client certificate so no secret is needed.
     const clientSecret =
       options.clientSecret ?? process.env.AUTH0_CLIENT_SECRET;
     const clientAssertionSigningKey =
       options.clientAssertionSigningKey ??
       process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY;
-    const hasClientAuthentication = !!(
-      clientSecret || clientAssertionSigningKey
-    );
+    const isMtls =
+      options.useMtls === true || process.env.AUTH0_MTLS === "true";
+    const hasClientAuthentication =
+      !!(clientSecret || clientAssertionSigningKey) || isMtls;
 
     const missing = Object.entries(requiredOptions)
       .filter(([, value]) => !value)

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1688,8 +1688,7 @@ export class Auth0Client {
     const clientAssertionSigningKey =
       options.clientAssertionSigningKey ??
       process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY;
-    const isMtls =
-      options.useMtls === true || process.env.AUTH0_MTLS === "true";
+    const isMtls = options.useMtls ?? process.env.AUTH0_MTLS === "true";
     const hasClientAuthentication =
       !!(clientSecret || clientAssertionSigningKey) || isMtls;
 


### PR DESCRIPTION
## Summary
Exposes mTLS functionality through the public SDK API, making it simple for developers to configure certificate-based authentication in their Auth0 Next.js applications.

## What Developers Can Do
Configure the SDK to use mTLS authentication with minimal setup:

```typescript
import { Auth0Client } from '@auth0/nextjs-auth0/server';
import { Agent, fetch as undiciFetch } from 'undici';

// Create fetch with certificate attached
const tlsAgent = new Agent({
  connect: {
    cert: readFileSync('./certs/client.crt'),
    key: readFileSync('./certs/client.key')
  }
});

const mtlsFetch = (input, init) => 
  undiciFetch(input, { ...init, dispatcher: tlsAgent });

// Enable mTLS
export const auth0 = new Auth0Client({
  useMtls: true,
  customFetch: mtlsFetch
});
```

## API Design
Two configuration options:

1. `useMtls: boolean` 
    - Explicit opt-in for mTLS authentication
    - Switches from ClientSecretPost to TlsClientAuth()
    - Routes token requests to mtls_endpoint_aliases endpoints
    - Validates mTLS prerequisites (custom domain, discovery document)
    - Default: false (backward compatible)

2. `customFetch: typeof fetch`
   - Flexible certificate attachment
   - Allows any HTTP client supporting TLS configuration (undici, node-fetch, custom agents)
   - Certificates remain under application control (not SDK-managed)
   - Supports HSMs, certificate rotation, per-request certificates
   - Required when useMtls: true
   
## Runtime behavior:

- Falls back gracefully if mtls_endpoint_aliases unavailable in discovery document
- Logs warnings for misconfiguration to help debugging
- Compatible with existing error handling patterns catch by error.code

## Breaking Changes
None. This is purely additive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added mTLS (mutual TLS) authentication support as an alternative client authentication mode
* Clients can enable mTLS via the `useMtls` option or the `AUTH0_MTLS` environment variable
* Introduced `customFetch` support to route Auth0 requests through a TLS-aware fetch implementation
* Updated option validation so mTLS mode no longer requires `clientSecret` / `clientAssertionSigningKey`

## Tests
* Added a new mTLS test suite covering `useMtls` true/false behavior and request routing via `customFetch`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->