### PR TITLE
Expose default oncallback

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2535,11 +2535,12 @@ Do realize that this has an impact on the size of the cookie being issued, so it
 
 The `onCallback` hook is run once the user has been redirected back from Auth0 to your application with either an error or the authorization code which will be verified and exchanged.
 
-The `onCallback` hook receives 3 parameters:
+The `onCallback` hook receives 4 parameters:
 
 1. `error`: the error returned from Auth0 or when attempting to complete the transaction. This will be `null` if the transaction was completed successfully.
 2. `context`: provides context on the transaction that initiated the transaction.
 3. `session`: the `SessionData` that will be persisted once the transaction completes successfully. This will be `null` if there was an error.
+4. `defaultOnCallback`: the default onCallback hook that would have been called instead of the user-provided hook. This can be used if you want to take an action on callback, but keep the default callback behaviour instead of overriding it.
 
 The hook must return a Promise that resolves to a `NextResponse`.
 

--- a/V4_MIGRATION_GUIDE.md
+++ b/V4_MIGRATION_GUIDE.md
@@ -375,7 +375,7 @@ import { NextResponse } from 'next/server';
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
 export const auth0 = new Auth0Client({
-  async onCallback(error, context, session) {
+  async onCallback(error, context, session, defaultOnCallback) {
     if (error) {
       console.error('Authentication error:', error);
       return NextResponse.redirect(

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -4309,7 +4309,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           null,
           expectedContext,
-          expectedSession
+          expectedSession,
+          expect.any(Function)
         );
 
         // validate the session cookie
@@ -4374,7 +4375,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           expect.any(Error),
           {},
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual("missing_state");
 
@@ -4453,7 +4455,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           expect.any(Error),
           {},
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual("invalid_state");
 
@@ -4537,7 +4540,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_error"
@@ -4625,7 +4629,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_code_grant_request_error"
@@ -4712,7 +4717,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           "authorization_code_grant_error"
@@ -5220,7 +5226,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(mockOnCallback).toHaveBeenCalledWith(
           null,
           expectedContext,
-          expectedSession
+          expectedSession,
+          expect.any(Function)
         );
       });
 
@@ -5296,7 +5303,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           ConnectAccountErrorCodes.MISSING_SESSION
@@ -5413,7 +5421,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           AccessTokenErrorCode.MISSING_REFRESH_TOKEN
@@ -5533,7 +5542,8 @@ ca/T0LLtgmbMmxSv/MmzIg==
             challengeMode: "redirect",
             appBaseUrl: DEFAULT.appBaseUrl
           },
-          null
+          null,
+          expect.any(Function)
         );
         expect(mockOnCallback.mock.calls[0][0].code).toEqual(
           ConnectAccountErrorCodes.FAILED_TO_COMPLETE

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -2187,7 +2187,12 @@ export class AuthClient {
     // PostMessage branch: return error as postMessage HTML instead of redirect
     if (transactionState?.challengeMode === "popup") {
       // Call onCallback for error observability, matching standard flow behavior
-      await this.onCallback(error, ctx, null, this.defaultOnCallback.bind(this));
+      await this.onCallback(
+        error,
+        ctx,
+        null,
+        this.defaultOnCallback.bind(this)
+      );
 
       const response = createAuthCompletePostMessageResponse({
         success: false,

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -177,6 +177,38 @@ export type OnCallbackContext = {
    */
   challengeMode?: "redirect" | "popup";
 };
+/**
+ * Hook called once the user has been redirected back from Auth0 to your
+ * application's callback route, after the authorization code has been
+ * exchanged (or an error has occurred).
+ *
+ * Return a `NextResponse` to control where the user is sent next.
+ * If you do not need custom routing, simply return the result of calling
+ * the fourth argument (`defaultOnCallback`) to invoke the SDK's default behaviour.
+ *
+ * @param error - The error returned from Auth0 or during token exchange.
+ *   `null` when the callback completed successfully.
+ * @param ctx - Context about the transaction that initiated the auth flow
+ *   (e.g. `returnTo` URL, `responseType`, `challengeMode`).
+ * @param session - The `SessionData` that will be persisted after a
+ *   successful callback. `null` when `error` is present.
+ * @param defaultOnCallback - The SDK's built-in callback handler. Call this
+ *   to keep the default redirect/error behaviour while still running your own
+ *   side effects (e.g. syncing the user to your database, setting extra
+ *   cookies). Signature: `(error, ctx) => Promise<NextResponse>`.
+ *
+ * @example
+ * ```ts
+ * const auth0 = new Auth0Client({
+ *   async onCallback(error, ctx, session, defaultOnCallback) {
+ *     if (!error && session) {
+ *       await db.upsertUser(session.user); // side effect
+ *     }
+ *     return defaultOnCallback(error, ctx); // keep default redirect behaviour
+ *   }
+ * });
+ * ```
+ */
 export type OnCallbackHook = (
   error: SdkError | null,
   ctx: OnCallbackContext,
@@ -481,7 +513,7 @@ export class AuthClient {
 
     // hooks
     this.beforeSessionSaved = options.beforeSessionSaved;
-    this.onCallback = options.onCallback || this.defaultOnCallback;
+    this.onCallback = options.onCallback || this.defaultOnCallback.bind(this);
 
     // routes
     this.routes = options.routes;
@@ -944,7 +976,7 @@ export class AuthClient {
         new InvalidStateError(),
         {},
         null,
-        this.defaultOnCallback
+        this.defaultOnCallback.bind(this)
       );
     }
 
@@ -1042,7 +1074,7 @@ export class AuthClient {
           connectedAccount
         },
         session,
-        this.defaultOnCallback
+        this.defaultOnCallback.bind(this)
       );
 
       await this.transactionStore.delete(res.cookies, state);
@@ -1234,7 +1266,12 @@ export class AuthClient {
         );
 
         // Call onCallback after finalization with the actual saved session
-        await this.onCallback(null, onCallbackCtx, mergedSession, this.defaultOnCallback);
+        await this.onCallback(
+          null,
+          onCallbackCtx,
+          mergedSession,
+          this.defaultOnCallback.bind(this)
+        );
 
         const popupResponse = createAuthCompletePostMessageResponse({
           success: true,
@@ -1279,7 +1316,12 @@ export class AuthClient {
         );
 
         // Call onCallback after finalization with the actual saved session
-        await this.onCallback(null, onCallbackCtx, mergedSession, this.defaultOnCallback);
+        await this.onCallback(
+          null,
+          onCallbackCtx,
+          mergedSession,
+          this.defaultOnCallback.bind(this)
+        );
 
         const popupResponse = createAuthCompletePostMessageResponse({
           success: true,
@@ -1323,7 +1365,7 @@ export class AuthClient {
       null,
       onCallbackCtx,
       session,
-      this.defaultOnCallback
+      this.defaultOnCallback.bind(this)
     );
 
     // call beforeSessionSaved callback if present
@@ -2145,7 +2187,7 @@ export class AuthClient {
     // PostMessage branch: return error as postMessage HTML instead of redirect
     if (transactionState?.challengeMode === "popup") {
       // Call onCallback for error observability, matching standard flow behavior
-      await this.onCallback(error, ctx, null, this.defaultOnCallback);
+      await this.onCallback(error, ctx, null, this.defaultOnCallback.bind(this));
 
       const response = createAuthCompletePostMessageResponse({
         success: false,
@@ -2168,7 +2210,7 @@ export class AuthClient {
       error,
       ctx,
       null,
-      this.defaultOnCallback
+      this.defaultOnCallback.bind(this)
     );
 
     // Clean up the transaction cookie on error to prevent accumulation

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -180,7 +180,11 @@ export type OnCallbackContext = {
 export type OnCallbackHook = (
   error: SdkError | null,
   ctx: OnCallbackContext,
-  session: SessionData | null
+  session: SessionData | null,
+  defaultOnCallback: (
+    error: SdkError | null,
+    ctx: OnCallbackContext
+  ) => Promise<NextResponse>
 ) => Promise<NextResponse>;
 
 // params passed to the /authorize endpoint that cannot be overwritten
@@ -936,7 +940,12 @@ export class AuthClient {
       state
     );
     if (!transactionStateCookie) {
-      return this.onCallback(new InvalidStateError(), {}, null);
+      return this.onCallback(
+        new InvalidStateError(),
+        {},
+        null,
+        this.defaultOnCallback
+      );
     }
 
     const transactionState = transactionStateCookie.payload;
@@ -1032,7 +1041,8 @@ export class AuthClient {
           ...onCallbackCtx,
           connectedAccount
         },
-        session
+        session,
+        this.defaultOnCallback
       );
 
       await this.transactionStore.delete(res.cookies, state);
@@ -1224,7 +1234,7 @@ export class AuthClient {
         );
 
         // Call onCallback after finalization with the actual saved session
-        await this.onCallback(null, onCallbackCtx, mergedSession);
+        await this.onCallback(null, onCallbackCtx, mergedSession, this.defaultOnCallback);
 
         const popupResponse = createAuthCompletePostMessageResponse({
           success: true,
@@ -1269,7 +1279,7 @@ export class AuthClient {
         );
 
         // Call onCallback after finalization with the actual saved session
-        await this.onCallback(null, onCallbackCtx, mergedSession);
+        await this.onCallback(null, onCallbackCtx, mergedSession, this.defaultOnCallback);
 
         const popupResponse = createAuthCompletePostMessageResponse({
           success: true,
@@ -1309,7 +1319,12 @@ export class AuthClient {
       };
     }
 
-    const res = await this.onCallback(null, onCallbackCtx, session);
+    const res = await this.onCallback(
+      null,
+      onCallbackCtx,
+      session,
+      this.defaultOnCallback
+    );
 
     // call beforeSessionSaved callback if present
     // if not then filter id_token claims with default rules
@@ -2130,7 +2145,7 @@ export class AuthClient {
     // PostMessage branch: return error as postMessage HTML instead of redirect
     if (transactionState?.challengeMode === "popup") {
       // Call onCallback for error observability, matching standard flow behavior
-      await this.onCallback(error, ctx, null);
+      await this.onCallback(error, ctx, null, this.defaultOnCallback);
 
       const response = createAuthCompletePostMessageResponse({
         success: false,
@@ -2149,7 +2164,12 @@ export class AuthClient {
       return response;
     }
 
-    const response = await this.onCallback(error, ctx, null);
+    const response = await this.onCallback(
+      error,
+      ctx,
+      null,
+      this.defaultOnCallback
+    );
 
     // Clean up the transaction cookie on error to prevent accumulation
     if (state) {


### PR DESCRIPTION
  ### Summary                                                                                               
                                                                                                              
  The onCallback hook currently requires users to re-implement the SDK's default redirect/error behaviour from
   scratch if they want any custom side effects (e.g. syncing the user to a database). This change passes the 
  SDK's built-in callback handler as a fourth argument (defaultOnCallback) to every onCallback invocation, so 
  custom hooks can run their own logic and then delegate to the default behaviour without duplicating it.     
                                                                                                            
  Changes:                                                                                                    
  - Added defaultOnCallback as the fourth parameter of OnCallbackHook, typed as (error, ctx) => 
  Promise<NextResponse>                                                                                       
  - Passed this.defaultOnCallback.bind(this) at all onCallback call sites (including the popup/postMessage  
  flow added after this was originally authored)                                                              
  - Added full JSDoc to OnCallbackHook with @param descriptions and a usage example — surfaces on hover in VS 
  Code and WebStorm                                                                                          
                                                                                                              
  Usage                                                                                                     
                                                                                                              
```
  const auth0 = new Auth0Client({                                                                           
    async onCallback(error, ctx, session, defaultOnCallback) {                                                
      if (!error && session) {                                                                                
        await db.upsertUser(session.user); // your side effect                                                
      }                                                                                                       
      return defaultOnCallback(error, ctx); // keep default redirect behaviour                                
    }                                                                                                         
  });  
```                                                                                                       
                                                                                                              
  Previously, users had to manually inspect ctx.returnTo and construct a NextResponse.redirect(...) themselves
   to replicate what the SDK does by default.                                                               
                                                                                                                                                                                                                                                          
  ---                                                                                                         
  Co-authored-by: Dan Haughey (greenlynx) — original implementation in #2488    