### PR TITLE
fix: add magic link server-side support, server example, and route ha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ For complete documentation, configuration options, and examples, see [Multiple C
 
 ## Routes
 
-The SDK mounts 8 routes:
+The SDK mounts 13 routes:
 
 1. `/auth/login`: the login route that the user will be redirected to to initiate an authentication transaction
 2. `/auth/logout`: the logout route that must be added to your Auth0 application's Allowed Logout URLs
@@ -459,8 +459,13 @@ The SDK mounts 8 routes:
 4. `/auth/profile`: the route to check the user's session and return their attributes
 5. `/auth/access-token`: the route to check the user's session and return an access token (which will be automatically refreshed if a refresh token is available)
 6. `/auth/backchannel-logout`: the route that will receive a `logout_token` when a configured Back-Channel Logout initiator occurs
-7. `/auth/passwordless/start`: send an OTP code or magic link to a user's email or phone number
-8. `/auth/passwordless/verify`: verify an OTP code and create a session
+7. `/auth/connect`: the route to connect an additional account to the current user's session
+8. `/auth/mfa/authenticators`: the route to list the MFA authenticators enrolled for the current user
+9. `/auth/mfa/challenge`: the route to initiate an MFA challenge for a specific authenticator
+10. `/auth/mfa/verify`: the route to verify an MFA challenge response and step up the session
+11. `/auth/mfa/associate`: the route to enroll a new MFA authenticator for the current user
+12. `/auth/passwordless/start`: send an OTP code or magic link to a user's email or phone number
+13. `/auth/passwordless/verify`: verify an OTP code and create a session
 
 > [!NOTE]
 > The passwordless routes support both **Email OTP**, **SMS OTP**, and **Magic Link** flows. For magic links, the user clicks the emailed link and is redirected to `/auth/callback` — no separate verify step is needed. Magic links require the `allow_magiclink_verify_without_session` tenant flag to be enabled in the Auth0 Dashboard (**Settings → Advanced**). See [Passwordless Authentication](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#passwordless-authentication) in EXAMPLES.md for full setup and usage details.

--- a/examples/with-passwordless/README.md
+++ b/examples/with-passwordless/README.md
@@ -92,6 +92,8 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000). You will see three tabs — **Email OTP**, **SMS OTP**, and **Magic Link**. Sign in using any flow and you will be redirected to `/dashboard`.
 
+For the **server-side example** (no client JS), visit [http://localhost:3000/server-passwordless](http://localhost:3000/server-passwordless). All three flows run entirely via Server Actions. Watch the terminal for per-step logs prefixed with `[server-passwordless]` to trace each operation.
+
 ## How It Works
 
 All auth routes are handled by `proxy.ts` — a Next.js middleware that passes every request through `auth0.middleware()`. The SDK intercepts the relevant paths internally:
@@ -151,12 +153,16 @@ This example shows both approaches side-by-side. The **Universal Login** tab in 
 ```text
 ├── app/
 │   ├── dashboard/
-│   │   └── page.tsx            ← Protected page — shows user profile, email, phone
-│   ├── layout.tsx              ← Root layout
-│   └── page.tsx                ← Home page with the tabbed passwordless form
+│   │   └── page.tsx                  ← Protected page — shows user profile, email, phone
+│   ├── server-passwordless/
+│   │   ├── page.tsx                  ← Server-side example: Email OTP / SMS OTP / Magic Link via Server Actions
+│   │   └── verify/
+│   │       └── page.tsx              ← Server-side OTP verify step (email & SMS)
+│   ├── layout.tsx                    ← Root layout
+│   └── page.tsx                      ← Home page with the tabbed passwordless form
 ├── components/
-│   └── passwordless-form.tsx   ← Tabbed UI: Universal Login / Email OTP / SMS OTP / Magic Link
+│   └── passwordless-form.tsx         ← Tabbed UI: Universal Login / Email OTP / SMS OTP / Magic Link
 ├── lib/
-│   └── auth0.ts                ← Auth0Client singleton (shared across app and proxy)
-└── proxy.ts                    ← Next.js middleware — passes all requests through auth0.middleware()
+│   └── auth0.ts                      ← Auth0Client singleton (shared across app and proxy)
+└── proxy.ts                          ← Next.js middleware — passes all requests through auth0.middleware()
 ```

--- a/examples/with-passwordless/app/dashboard/page.tsx
+++ b/examples/with-passwordless/app/dashboard/page.tsx
@@ -9,60 +9,116 @@ export default async function Dashboard() {
     redirect("/");
   }
 
-  const { user } = session;
+  const { user, tokenSet, internal } = session;
+
+  // Derive the auth method from the subject prefix:
+  //   email|...   → Email OTP or Magic Link
+  //   sms|...     → SMS OTP
+  const method = user.sub?.startsWith("sms|")
+    ? "SMS OTP"
+    : user.sub?.startsWith("email|")
+    ? "Email OTP / Magic Link"
+    : "Passwordless";
+
+  const createdAt = new Date(internal.createdAt * 1000).toLocaleTimeString();
+  const expiresAt = new Date(tokenSet.expiresAt * 1000).toLocaleTimeString();
+  const scopes = tokenSet.scope?.split(" ") ?? [];
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-6">
-      <div className="w-full max-w-lg rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
-        <div className="mb-6 flex items-center gap-4">
-          {user.picture && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={user.picture}
-              alt={user.name ?? "User avatar"}
-              className="h-14 w-14 rounded-full"
-            />
-          )}
-          <div>
-            <h1 className="text-2xl font-bold">Welcome back!</h1>
-            {user.name && (
-              <p className="text-gray-500">{user.name}</p>
-            )}
+      <div className="w-full max-w-lg space-y-4">
+
+        {/* Success banner */}
+        <div className="rounded-2xl border border-green-200 bg-green-50 p-6 text-center">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+            <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
           </div>
+          <h1 className="text-xl font-semibold text-green-900">Signed in successfully</h1>
+          <p className="mt-1 text-sm text-green-700">
+            Authenticated via <span className="font-medium">{method}</span>
+            {user.email && <> as <span className="font-medium">{user.email}</span></>}
+            {user.phone_number && !user.email && <> as <span className="font-medium">{user.phone_number}</span></>}
+          </p>
         </div>
 
-        <dl className="mb-6 divide-y divide-gray-100 rounded-lg border border-gray-100 bg-gray-50 p-4 text-sm">
-          {user.email && (
-            <div className="flex justify-between py-2">
-              <dt className="font-medium text-gray-600">Email</dt>
-              <dd className="text-gray-900">{user.email}</dd>
+        {/* User card */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-3">
+
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-lg font-semibold text-gray-500">
+                {(user.name ?? user.email ?? user.sub)[0].toUpperCase()}
+              </div>
+   
+            <div>
+              <p className="font-semibold text-gray-900">{user.name ?? user.email ?? (user.phone_number as string | undefined) ?? user.sub}</p>
+              {user.email_verified !== undefined && (
+                <p className="text-xs text-gray-500">
+                  Email {user.email_verified ? "verified" : "not verified"}
+                </p>
+              )}
             </div>
-          )}
-          {user.phone_number && (
-            <div className="flex justify-between py-2">
-              <dt className="font-medium text-gray-600">Phone</dt>
-              <dd className="text-gray-900">{user.phone_number}</dd>
-            </div>
-          )}
-          <div className="flex justify-between py-2">
-            <dt className="font-medium text-gray-600">Subject</dt>
-            <dd className="truncate max-w-xs text-gray-900">{user.sub}</dd>
           </div>
-          {user.email_verified !== undefined && (
+
+          <dl className="divide-y divide-gray-100 text-sm">
+            {user.email && (
+              <div className="flex justify-between py-2">
+                <dt className="text-gray-500">Email</dt>
+                <dd className="text-gray-900">{user.email}</dd>
+              </div>
+            )}
+            {user.phone_number && (
+              <div className="flex justify-between py-2">
+                <dt className="text-gray-500">Phone</dt>
+                <dd className="text-gray-900">{user.phone_number}</dd>
+              </div>
+            )}
             <div className="flex justify-between py-2">
-              <dt className="font-medium text-gray-600">Email verified</dt>
-              <dd className="text-gray-900">
-                {user.email_verified ? "Yes" : "No"}
-              </dd>
+              <dt className="text-gray-500">Auth method</dt>
+              <dd className="text-gray-900">{method}</dd>
             </div>
-          )}
-        </dl>
+          </dl>
+        </div>
+
+        {/* Token info — shows what the SDK set up after verify() */}
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="mb-3 text-sm font-semibold text-gray-700">Session &amp; token</h2>
+          <dl className="divide-y divide-gray-100 text-sm">
+            <div className="flex justify-between py-2">
+              <dt className="text-gray-500">Session created</dt>
+              <dd className="text-gray-900">{createdAt}</dd>
+            </div>
+            <div className="flex justify-between py-2">
+              <dt className="text-gray-500">Access token expires</dt>
+              <dd className="text-gray-900">{expiresAt}</dd>
+            </div>
+            <div className="flex justify-between py-2">
+              <dt className="text-gray-500">Token type</dt>
+              <dd className="text-gray-900">{tokenSet.token_type ?? "Bearer"}</dd>
+            </div>
+            {scopes.length > 0 && (
+              <div className="flex justify-between gap-4 py-2">
+                <dt className="shrink-0 text-gray-500">Scopes</dt>
+                <dd className="flex flex-wrap justify-end gap-1">
+                  {scopes.map(s => (
+                    <span key={s} className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">{s}</span>
+                  ))}
+                </dd>
+              </div>
+            )}
+            <div className="flex justify-between py-2">
+              <dt className="text-gray-500">Access token</dt>
+              <dd className="text-gray-900">{tokenSet.accessToken ? "Received" : "Not available"}</dd>
+            </div>
+          </dl>
+        </div>
 
         <a
           href="/auth/logout"
-          className="block w-full rounded-lg border border-gray-300 px-4 py-2 text-center text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+          className="block w-full rounded-lg border border-gray-300 px-4 py-2 text-center text-sm font-medium text-gray-700 transition hover:bg-gray-50"
         >
-          Log out
+          Sign out
         </a>
       </div>
     </main>

--- a/examples/with-passwordless/app/dashboard/page.tsx
+++ b/examples/with-passwordless/app/dashboard/page.tsx
@@ -2,6 +2,16 @@ import { redirect } from "next/navigation";
 
 import { auth0 } from "@/lib/auth0";
 
+/**
+ * Render the authenticated user's dashboard page.
+ *
+ * If no active session is found, performs a redirect to "/". When a session
+ * exists, displays the user's identity and verification status, the derived
+ * authentication method, session creation and token expiration times, token
+ * type and scopes, access token availability, and a sign-out link.
+ *
+ * @returns A JSX element containing the dashboard UI that presents user and session/token information
+ */
 export default async function Dashboard() {
   const session = await auth0.getSession();
 

--- a/examples/with-passwordless/app/page.tsx
+++ b/examples/with-passwordless/app/page.tsx
@@ -3,6 +3,15 @@ import { redirect } from "next/navigation";
 import { PasswordlessForm } from "@/components/passwordless-form";
 import { auth0 } from "@/lib/auth0";
 
+/**
+ * Render the sign-in page or redirect authenticated users to the dashboard.
+ *
+ * Renders a centered sign-in UI that describes available passwordless methods
+ * (email/SMS one-time codes or magic link), includes the <PasswordlessForm />
+ * component to initiate authentication, and links to a server-side example.
+ *
+ * @returns The sign-in page JSX; if a user session exists, the function triggers a navigation to `/dashboard` instead of rendering the page.
+ */
 export default async function Home() {
   const session = await auth0.getSession();
 

--- a/examples/with-passwordless/app/page.tsx
+++ b/examples/with-passwordless/app/page.tsx
@@ -23,6 +23,13 @@ export default async function Home() {
         </div>
 
         <PasswordlessForm />
+
+        <p className="mt-6 text-center text-xs text-gray-400">
+          Looking for a server-side example?{" "}
+          <a href="/server-passwordless" className="text-blue-600 underline hover:text-blue-800">
+            Email OTP / SMS OTP / Magic Link via Server Actions
+          </a>
+        </p>
       </div>
     </main>
   );

--- a/examples/with-passwordless/app/server-passwordless/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/page.tsx
@@ -1,0 +1,227 @@
+import { redirect } from "next/navigation";
+
+import { auth0 } from "@/lib/auth0";
+
+type Tab = "email" | "sms" | "magic-link";
+
+export default async function ServerPasswordlessPage({
+  searchParams
+}: {
+  searchParams: Promise<{
+    tab?: string;
+    sent?: string;
+    email?: string;
+    error?: string;
+  }>;
+}) {
+  const session = await auth0.getSession();
+  if (session) redirect("/dashboard");
+
+  const params = await searchParams;
+  const tab = (params.tab ?? "email") as Tab;
+  const error = params.error ?? null;
+
+  // Magic link sent — show confirmation screen
+  if (params.sent === "1" && params.email) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center p-6">
+        <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm text-center space-y-4">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+            <svg className="h-6 w-6 text-blue-600" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+            </svg>
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900">Check your email</h1>
+          <p className="text-sm text-gray-500">
+            We sent a magic link to{" "}
+            <span className="font-medium text-gray-900">{params.email}</span>.
+            Click the link to sign in — no code required.
+          </p>
+          <p className="text-xs text-gray-400">
+            The link expires in 5 minutes. Check your spam folder if you don&apos;t see it.
+          </p>
+          <a
+            href="/server-passwordless?tab=magic-link"
+            className="block text-xs text-blue-600 underline hover:text-blue-800"
+          >
+            ← Use a different email
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  // Server Actions — one per flow so each form has a typed action
+  async function startEmailOtp(formData: FormData) {
+    "use server";
+    const email = formData.get("email") as string;
+    console.log(`[server-passwordless] email OTP start — email=${email}`);
+    try {
+      await auth0.passwordless.start({ connection: "email", email, send: "code" });
+      console.log(`[server-passwordless] email OTP start success — email=${email}`);
+    } catch (err) {
+      const e = err as { error?: string; error_description?: string };
+      console.error(`[server-passwordless] email OTP start failed — ${e.error}: ${e.error_description}`);
+      redirect(`/server-passwordless?tab=email&error=${encodeURIComponent(e.error_description ?? "Failed to send code")}`);
+    }
+    redirect(`/server-passwordless/verify?connection=email&email=${encodeURIComponent(email)}`);
+  }
+
+  async function startSmsOtp(formData: FormData) {
+    "use server";
+    const phone = formData.get("phone") as string;
+    console.log(`[server-passwordless] SMS OTP start — phone=${phone}`);
+    try {
+      await auth0.passwordless.start({ connection: "sms", phoneNumber: phone });
+      console.log(`[server-passwordless] SMS OTP start success — phone=${phone}`);
+    } catch (err) {
+      const e = err as { error?: string; error_description?: string };
+      console.error(`[server-passwordless] SMS OTP start failed — ${e.error}: ${e.error_description}`);
+      redirect(`/server-passwordless?tab=sms&error=${encodeURIComponent(e.error_description ?? "Failed to send code")}`);
+    }
+    redirect(`/server-passwordless/verify?connection=sms&phone=${encodeURIComponent(phone)}`);
+  }
+
+  async function startMagicLink(formData: FormData) {
+    "use server";
+    const email = formData.get("email") as string;
+    console.log(`[server-passwordless] magic link start — email=${email}`);
+    try {
+      // passwordless.start writes the transaction cookie to next/headers automatically.
+      // No client-side code involved — the entire flow runs server-side.
+      await auth0.passwordless.start({ connection: "email", email, send: "link" });
+      console.log(`[server-passwordless] magic link start success — email=${email}, transaction cookie written`);
+    } catch (err) {
+      const e = err as { error?: string; error_description?: string };
+      console.error(`[server-passwordless] magic link start failed — ${e.error}: ${e.error_description}`);
+      redirect(`/server-passwordless?tab=magic-link&error=${encodeURIComponent(e.error_description ?? "Failed to send link")}`);
+    }
+    redirect(`/server-passwordless?sent=1&email=${encodeURIComponent(email)}`);
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200";
+  const btnPrimary =
+    "w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700";
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "email", label: "Email OTP" },
+    { id: "sms", label: "SMS OTP" },
+    { id: "magic-link", label: "Magic Link" }
+  ];
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-6">
+      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold tracking-tight">Server-side passwordless</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            All flows run via Server Actions — no client JS, no fetch calls.
+            Check your terminal for per-step server logs.
+          </p>
+        </div>
+
+        {/* Tab bar — plain links, no JS */}
+        <div className="mb-6 flex rounded-lg border border-gray-200 p-1 text-sm">
+          {tabs.map(({ id, label }) => (
+            <a
+              key={id}
+              href={`/server-passwordless?tab=${id}`}
+              className={`flex-1 rounded-md py-1.5 text-center font-medium transition ${
+                tab === id
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {label}
+            </a>
+          ))}
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {tab === "email" && (
+          <form action={startEmailOtp} className="space-y-4">
+            <div>
+              <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+                Email address
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                placeholder="you@example.com"
+                required
+                className={inputClass}
+              />
+            </div>
+            <button type="submit" className={btnPrimary}>
+              Send code
+            </button>
+          </form>
+        )}
+
+        {tab === "sms" && (
+          <form action={startSmsOtp} className="space-y-4">
+            <div>
+              <label htmlFor="phone" className="mb-1 block text-sm font-medium text-gray-700">
+                Phone number
+              </label>
+              <input
+                id="phone"
+                name="phone"
+                type="tel"
+                autoComplete="tel"
+                placeholder="+14155550100"
+                required
+                className={inputClass}
+              />
+              <p className="mt-1 text-xs text-gray-400">E.164 format (e.g. +14155550100)</p>
+            </div>
+            <button type="submit" className={btnPrimary}>
+              Send code
+            </button>
+          </form>
+        )}
+
+        {tab === "magic-link" && (
+          <form action={startMagicLink} className="space-y-4">
+            <div>
+              <label htmlFor="ml-email" className="mb-1 block text-sm font-medium text-gray-700">
+                Email address
+              </label>
+              <input
+                id="ml-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                placeholder="you@example.com"
+                required
+                className={inputClass}
+              />
+              <p className="mt-1 text-xs text-gray-400">
+                We&apos;ll email a one-click sign-in link — no code to type.
+                The transaction cookie is written server-side.
+              </p>
+            </div>
+            <button type="submit" className={btnPrimary}>
+              Send magic link
+            </button>
+          </form>
+        )}
+
+        <p className="mt-6 text-center text-xs text-gray-400">
+          Want the client-side version?{" "}
+          <a href="/" className="text-blue-600 underline hover:text-blue-800">
+            Back to home
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/examples/with-passwordless/app/server-passwordless/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/page.tsx
@@ -18,7 +18,10 @@ export default async function ServerPasswordlessPage({
   if (session) redirect("/dashboard");
 
   const params = await searchParams;
-  const tab = (params.tab ?? "email") as Tab;
+  const VALID_TABS: Tab[] = ["email", "sms", "magic-link"];
+  const tab: Tab = VALID_TABS.includes(params.tab as Tab)
+    ? (params.tab as Tab)
+    : "email";
   const error = params.error ?? null;
 
   // Magic link sent — show confirmation screen
@@ -55,10 +58,10 @@ export default async function ServerPasswordlessPage({
   async function startEmailOtp(formData: FormData) {
     "use server";
     const email = formData.get("email") as string;
-    console.log(`[server-passwordless] email OTP start — email=${email}`);
+    console.log("[server-passwordless] email OTP start");
     try {
       await auth0.passwordless.start({ connection: "email", email, send: "code" });
-      console.log(`[server-passwordless] email OTP start success — email=${email}`);
+      console.log("[server-passwordless] email OTP start success");
     } catch (err) {
       const e = err as { error?: string; error_description?: string };
       console.error(`[server-passwordless] email OTP start failed — ${e.error}: ${e.error_description}`);
@@ -70,10 +73,10 @@ export default async function ServerPasswordlessPage({
   async function startSmsOtp(formData: FormData) {
     "use server";
     const phone = formData.get("phone") as string;
-    console.log(`[server-passwordless] SMS OTP start — phone=${phone}`);
+    console.log("[server-passwordless] SMS OTP start");
     try {
       await auth0.passwordless.start({ connection: "sms", phoneNumber: phone });
-      console.log(`[server-passwordless] SMS OTP start success — phone=${phone}`);
+      console.log("[server-passwordless] SMS OTP start success");
     } catch (err) {
       const e = err as { error?: string; error_description?: string };
       console.error(`[server-passwordless] SMS OTP start failed — ${e.error}: ${e.error_description}`);
@@ -85,12 +88,12 @@ export default async function ServerPasswordlessPage({
   async function startMagicLink(formData: FormData) {
     "use server";
     const email = formData.get("email") as string;
-    console.log(`[server-passwordless] magic link start — email=${email}`);
+    console.log("[server-passwordless] magic link start");
     try {
       // passwordless.start writes the transaction cookie to next/headers automatically.
       // No client-side code involved — the entire flow runs server-side.
       await auth0.passwordless.start({ connection: "email", email, send: "link" });
-      console.log(`[server-passwordless] magic link start success — email=${email}, transaction cookie written`);
+      console.log("[server-passwordless] magic link start success — transaction cookie written");
     } catch (err) {
       const e = err as { error?: string; error_description?: string };
       console.error(`[server-passwordless] magic link start failed — ${e.error}: ${e.error_description}`);

--- a/examples/with-passwordless/app/server-passwordless/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/page.tsx
@@ -1,8 +1,15 @@
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { PasswordlessStartError } from "@auth0/nextjs-auth0/errors";
 import { auth0 } from "@/lib/auth0";
 
 type Tab = "email" | "sms" | "magic-link";
+
+// Short-lived HttpOnly cookie that carries the user identifier between the
+// start action and the verify page — keeps PII out of the URL entirely.
+const PL_COOKIE = "pl_pending";
+const PL_COOKIE_MAX_AGE = 600; // 10 minutes — long enough to receive the code
 
 export default async function ServerPasswordlessPage({
   searchParams
@@ -10,7 +17,6 @@ export default async function ServerPasswordlessPage({
   searchParams: Promise<{
     tab?: string;
     sent?: string;
-    email?: string;
     error?: string;
   }>;
 }) {
@@ -24,8 +30,14 @@ export default async function ServerPasswordlessPage({
     : "email";
   const error = params.error ?? null;
 
-  // Magic link sent — show confirmation screen
-  if (params.sent === "1" && params.email) {
+  // Magic link sent — show confirmation screen.
+  // Email is read from the HttpOnly cookie rather than the URL.
+  if (params.sent === "1") {
+    const cookieStore = await cookies();
+    const raw = cookieStore.get(PL_COOKIE)?.value;
+    const pending = raw ? (JSON.parse(raw) as { email?: string }) : null;
+    const sentEmail = pending?.email ?? "";
+
     return (
       <main className="flex min-h-screen flex-col items-center justify-center p-6">
         <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm text-center space-y-4">
@@ -37,7 +49,7 @@ export default async function ServerPasswordlessPage({
           <h1 className="text-xl font-semibold text-gray-900">Check your email</h1>
           <p className="text-sm text-gray-500">
             We sent a magic link to{" "}
-            <span className="font-medium text-gray-900">{params.email}</span>.
+            <span className="font-medium text-gray-900">{sentEmail}</span>.
             Click the link to sign in — no code required.
           </p>
           <p className="text-xs text-gray-400">
@@ -54,7 +66,7 @@ export default async function ServerPasswordlessPage({
     );
   }
 
-  // Server Actions — one per flow so each form has a typed action
+  // Server Actions — one per flow so each form has a typed action.
   async function startEmailOtp(formData: FormData) {
     "use server";
     const email = formData.get("email") as string;
@@ -63,11 +75,22 @@ export default async function ServerPasswordlessPage({
       await auth0.passwordless.start({ connection: "email", email, send: "code" });
       console.log("[server-passwordless] email OTP start success");
     } catch (err) {
-      const e = err as { error?: string; error_description?: string };
-      console.error(`[server-passwordless] email OTP start failed — ${e.error}: ${e.error_description}`);
-      redirect(`/server-passwordless?tab=email&error=${encodeURIComponent(e.error_description ?? "Failed to send code")}`);
+      const message = err instanceof PasswordlessStartError
+        ? err.error_description ?? err.message
+        : (err instanceof Error ? err.message : "Failed to send code");
+      console.error(`[server-passwordless] email OTP start failed — ${message}`);
+      redirect(`/server-passwordless?tab=email&error=${encodeURIComponent(message)}`);
     }
-    redirect(`/server-passwordless/verify?connection=email&email=${encodeURIComponent(email)}`);
+    // Store the identifier in an HttpOnly cookie so the verify page can read it
+    // without it appearing in the URL or being accessible from client-side JS.
+    const cookieStore = await cookies();
+    cookieStore.set(PL_COOKIE, JSON.stringify({ connection: "email", email }), {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/server-passwordless",
+      maxAge: PL_COOKIE_MAX_AGE
+    });
+    redirect("/server-passwordless/verify");
   }
 
   async function startSmsOtp(formData: FormData) {
@@ -78,11 +101,20 @@ export default async function ServerPasswordlessPage({
       await auth0.passwordless.start({ connection: "sms", phoneNumber: phone });
       console.log("[server-passwordless] SMS OTP start success");
     } catch (err) {
-      const e = err as { error?: string; error_description?: string };
-      console.error(`[server-passwordless] SMS OTP start failed — ${e.error}: ${e.error_description}`);
-      redirect(`/server-passwordless?tab=sms&error=${encodeURIComponent(e.error_description ?? "Failed to send code")}`);
+      const message = err instanceof PasswordlessStartError
+        ? err.error_description ?? err.message
+        : (err instanceof Error ? err.message : "Failed to send code");
+      console.error(`[server-passwordless] SMS OTP start failed — ${message}`);
+      redirect(`/server-passwordless?tab=sms&error=${encodeURIComponent(message)}`);
     }
-    redirect(`/server-passwordless/verify?connection=sms&phone=${encodeURIComponent(phone)}`);
+    const cookieStore = await cookies();
+    cookieStore.set(PL_COOKIE, JSON.stringify({ connection: "sms", phone }), {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/server-passwordless",
+      maxAge: PL_COOKIE_MAX_AGE
+    });
+    redirect("/server-passwordless/verify");
   }
 
   async function startMagicLink(formData: FormData) {
@@ -95,11 +127,21 @@ export default async function ServerPasswordlessPage({
       await auth0.passwordless.start({ connection: "email", email, send: "link" });
       console.log("[server-passwordless] magic link start success — transaction cookie written");
     } catch (err) {
-      const e = err as { error?: string; error_description?: string };
-      console.error(`[server-passwordless] magic link start failed — ${e.error}: ${e.error_description}`);
-      redirect(`/server-passwordless?tab=magic-link&error=${encodeURIComponent(e.error_description ?? "Failed to send link")}`);
+      const message = err instanceof PasswordlessStartError
+        ? err.error_description ?? err.message
+        : (err instanceof Error ? err.message : "Failed to send link");
+      console.error(`[server-passwordless] magic link start failed — ${message}`);
+      redirect(`/server-passwordless?tab=magic-link&error=${encodeURIComponent(message)}`);
     }
-    redirect(`/server-passwordless?sent=1&email=${encodeURIComponent(email)}`);
+    // Store email for the confirmation screen — HttpOnly so it never hits the URL.
+    const cookieStore = await cookies();
+    cookieStore.set(PL_COOKIE, JSON.stringify({ connection: "email", email }), {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/server-passwordless",
+      maxAge: PL_COOKIE_MAX_AGE
+    });
+    redirect("/server-passwordless?sent=1");
   }
 
   const inputClass =

--- a/examples/with-passwordless/app/server-passwordless/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/page.tsx
@@ -9,7 +9,16 @@ type Tab = "email" | "sms" | "magic-link";
 // Short-lived HttpOnly cookie that carries the user identifier between the
 // start action and the verify page — keeps PII out of the URL entirely.
 const PL_COOKIE = "pl_pending";
-const PL_COOKIE_MAX_AGE = 600; // 10 minutes — long enough to receive the code
+const PL_COOKIE_MAX_AGE = 600; /**
+ * Renders the server-side passwordless sign-in page with Email OTP, SMS OTP, and Magic Link flows.
+ *
+ * The component gatekeeps authenticated users (redirects to `/dashboard`), reads `searchParams` to determine
+ * the active tab and any error state, shows a confirmation screen when `sent=1` (reading the destination
+ * email from a short-lived HttpOnly cookie), and provides server actions for starting each passwordless flow.
+ *
+ * @param searchParams - A promise resolving to optional query parameters: `tab` (one of "email" | "sms" | "magic-link"), `sent`, and `error`.
+ * @returns The server-rendered JSX for the passwordless entry page, including the tabbed UI, forms wired to server actions, and any error or confirmation UI.
+ */
 
 export default async function ServerPasswordlessPage({
   searchParams
@@ -66,7 +75,15 @@ export default async function ServerPasswordlessPage({
     );
   }
 
-  // Server Actions — one per flow so each form has a typed action.
+  /**
+   * Initiates sending an email one-time passcode and records the pending request in a short-lived HttpOnly cookie.
+   *
+   * On failure, redirects back to `/server-passwordless?tab=email&error=...` with an encoded error message.
+   * On success, sets the `pl_pending` cookie with `{ connection: "email", email }` (HttpOnly, path `/server-passwordless`, limited maxAge)
+   * and redirects to `/server-passwordless/verify`.
+   *
+   * @param formData - FormData that must include the `email` field to receive the OTP code
+   */
   async function startEmailOtp(formData: FormData) {
     "use server";
     const email = formData.get("email") as string;
@@ -93,6 +110,11 @@ export default async function ServerPasswordlessPage({
     redirect("/server-passwordless/verify");
   }
 
+  /**
+   * Initiates an SMS one-time-password (OTP) start flow, stores a short-lived transaction cookie, and redirects to the verification page.
+   *
+   * @param formData - A FormData object containing a `phone` field (the destination phone number, expected in E.164 format).
+   */
   async function startSmsOtp(formData: FormData) {
     "use server";
     const phone = formData.get("phone") as string;
@@ -117,6 +139,13 @@ export default async function ServerPasswordlessPage({
     redirect("/server-passwordless/verify");
   }
 
+  /**
+   * Initiates a passwordless magic-link email flow and stores a short-lived server-side transaction cookie.
+   *
+   * Calls the Auth0 passwordless start for the email connection to send a magic link. On failure, redirects the request back to the passwordless page with `tab=magic-link` and an `error` query parameter describing the failure. On success, sets an HttpOnly transaction cookie containing `{ connection: "email", email }` and redirects to `/server-passwordless?sent=1`.
+   *
+   * @param formData - FormData containing an `email` field with the recipient address
+   */
   async function startMagicLink(formData: FormData) {
     "use server";
     const email = formData.get("email") as string;

--- a/examples/with-passwordless/app/server-passwordless/verify/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/verify/page.tsx
@@ -16,7 +16,9 @@ export default async function ServerPasswordlessVerifyPage({
   if (session) redirect("/dashboard");
 
   const params = await searchParams;
-  const connection = params.connection as "email" | "sms" | undefined;
+  const raw = params.connection;
+  const connection: "email" | "sms" | undefined =
+    raw === "email" || raw === "sms" ? raw : undefined;
   const email = params.email ?? "";
   const phone = params.phone ?? "";
   const error = params.error ?? null;
@@ -35,7 +37,7 @@ export default async function ServerPasswordlessVerifyPage({
     const code = formData.get("code") as string;
 
     if (connection === "email") {
-      console.log(`[server-passwordless] email OTP verify — email=${email} code=${code}`);
+      console.log("[server-passwordless] email OTP verify");
       try {
         // passwordless.verify exchanges the OTP for tokens and writes the
         // session cookie to next/headers — the user is signed in after this call.
@@ -44,7 +46,7 @@ export default async function ServerPasswordlessVerifyPage({
           email,
           verificationCode: code
         });
-        console.log(`[server-passwordless] email OTP verify success — session created for email=${email}`);
+        console.log("[server-passwordless] email OTP verify success — session created");
       } catch (err) {
         const e = err as { error?: string; error_description?: string };
         console.error(`[server-passwordless] email OTP verify failed — ${e.error}: ${e.error_description}`);
@@ -53,14 +55,14 @@ export default async function ServerPasswordlessVerifyPage({
         );
       }
     } else {
-      console.log(`[server-passwordless] SMS OTP verify — phone=${phone} code=${code}`);
+      console.log("[server-passwordless] SMS OTP verify");
       try {
         await auth0.passwordless.verify({
           connection: "sms",
           phoneNumber: phone,
           verificationCode: code
         });
-        console.log(`[server-passwordless] SMS OTP verify success — session created for phone=${phone}`);
+        console.log("[server-passwordless] SMS OTP verify success — session created");
       } catch (err) {
         const e = err as { error?: string; error_description?: string };
         console.error(`[server-passwordless] SMS OTP verify failed — ${e.error}: ${e.error_description}`);

--- a/examples/with-passwordless/app/server-passwordless/verify/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/verify/page.tsx
@@ -7,6 +7,15 @@ import { auth0 } from "@/lib/auth0";
 // Same name as in page.tsx — keeps both files in sync.
 const PL_COOKIE = "pl_pending";
 
+/**
+ * Renders the server-side passwordless OTP verification page and provides an action to verify the submitted 6-digit code.
+ *
+ * The page reads the pending verification target (email or phone) from an HttpOnly cookie and shows a hint where the code was sent.
+ * If a user is already authenticated, the function redirects to `/dashboard`. If the pending cookie is missing or invalid, it redirects to `/server-passwordless`.
+ *
+ * @param searchParams - A promise resolving to an object that may contain `error` used to display an error banner on the page
+ * @returns The JSX element for the OTP verification page
+ */
 export default async function ServerPasswordlessVerifyPage({
   searchParams
 }: {

--- a/examples/with-passwordless/app/server-passwordless/verify/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/verify/page.tsx
@@ -1,32 +1,38 @@
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { PasswordlessVerifyError } from "@auth0/nextjs-auth0/errors";
 import { auth0 } from "@/lib/auth0";
+
+// Same name as in page.tsx — keeps both files in sync.
+const PL_COOKIE = "pl_pending";
 
 export default async function ServerPasswordlessVerifyPage({
   searchParams
 }: {
-  searchParams: Promise<{
-    connection?: string;
-    email?: string;
-    phone?: string;
-    error?: string;
-  }>;
+  searchParams: Promise<{ error?: string }>;
 }) {
   const session = await auth0.getSession();
   if (session) redirect("/dashboard");
 
-  const params = await searchParams;
-  const raw = params.connection;
-  const connection: "email" | "sms" | undefined =
-    raw === "email" || raw === "sms" ? raw : undefined;
-  const email = params.email ?? "";
-  const phone = params.phone ?? "";
-  const error = params.error ?? null;
+  // Read the identifier from the HttpOnly cookie set by the start action.
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(PL_COOKIE)?.value;
+  const pending = raw
+    ? (JSON.parse(raw) as { connection: "email" | "sms"; email?: string; phone?: string })
+    : null;
 
-  if (!connection || (connection === "email" && !email) || (connection === "sms" && !phone)) {
+  if (
+    !pending ||
+    (pending.connection === "email" && !pending.email) ||
+    (pending.connection === "sms" && !pending.phone)
+  ) {
     redirect("/server-passwordless");
   }
 
+  const { connection, email = "", phone = "" } = pending!;
+  const params = await searchParams;
+  const error = params.error ?? null;
   const hint =
     connection === "email"
       ? `We sent a 6-digit code to ${email}`
@@ -36,42 +42,54 @@ export default async function ServerPasswordlessVerifyPage({
     "use server";
     const code = formData.get("code") as string;
 
-    if (connection === "email") {
+    // Re-read inside the action — Server Actions have their own execution context.
+    const actionCookies = await cookies();
+    const actionRaw = actionCookies.get(PL_COOKIE)?.value;
+    const actionPending = actionRaw
+      ? (JSON.parse(actionRaw) as { connection: "email" | "sms"; email?: string; phone?: string })
+      : null;
+
+    if (!actionPending) redirect("/server-passwordless");
+
+    if (actionPending!.connection === "email") {
       console.log("[server-passwordless] email OTP verify");
       try {
-        // passwordless.verify exchanges the OTP for tokens and writes the
-        // session cookie to next/headers — the user is signed in after this call.
+        // passwordless.verify exchanges the OTP for tokens and writes the session
+        // cookie via next/headers — the same mechanism as auth0.passwordless.start.
+        // After this call the user is signed in.
         await auth0.passwordless.verify({
           connection: "email",
-          email,
+          email: actionPending!.email!,
           verificationCode: code
         });
         console.log("[server-passwordless] email OTP verify success — session created");
       } catch (err) {
-        const e = err as { error?: string; error_description?: string };
-        console.error(`[server-passwordless] email OTP verify failed — ${e.error}: ${e.error_description}`);
-        redirect(
-          `/server-passwordless/verify?connection=email&email=${encodeURIComponent(email)}&error=${encodeURIComponent(e.error_description ?? "Invalid or expired code")}`
-        );
+        const message = err instanceof PasswordlessVerifyError
+          ? err.error_description ?? err.message
+          : (err instanceof Error ? err.message : "Invalid or expired code");
+        console.error(`[server-passwordless] email OTP verify failed — ${message}`);
+        redirect(`/server-passwordless/verify?error=${encodeURIComponent(message)}`);
       }
     } else {
       console.log("[server-passwordless] SMS OTP verify");
       try {
         await auth0.passwordless.verify({
           connection: "sms",
-          phoneNumber: phone,
+          phoneNumber: actionPending!.phone!,
           verificationCode: code
         });
         console.log("[server-passwordless] SMS OTP verify success — session created");
       } catch (err) {
-        const e = err as { error?: string; error_description?: string };
-        console.error(`[server-passwordless] SMS OTP verify failed — ${e.error}: ${e.error_description}`);
-        redirect(
-          `/server-passwordless/verify?connection=sms&phone=${encodeURIComponent(phone)}&error=${encodeURIComponent(e.error_description ?? "Invalid or expired code")}`
-        );
+        const message = err instanceof PasswordlessVerifyError
+          ? err.error_description ?? err.message
+          : (err instanceof Error ? err.message : "Invalid or expired code");
+        console.error(`[server-passwordless] SMS OTP verify failed — ${message}`);
+        redirect(`/server-passwordless/verify?error=${encodeURIComponent(message)}`);
       }
     }
 
+    // Clear the pending cookie — it's consumed once the session is created.
+    actionCookies.delete(PL_COOKIE);
     redirect("/dashboard");
   }
 
@@ -107,7 +125,8 @@ export default async function ServerPasswordlessVerifyPage({
               autoComplete="one-time-code"
               placeholder="123456"
               required
-              minLength={4}
+              minLength={6}
+              maxLength={6}
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
             />
           </div>

--- a/examples/with-passwordless/app/server-passwordless/verify/page.tsx
+++ b/examples/with-passwordless/app/server-passwordless/verify/page.tsx
@@ -1,0 +1,130 @@
+import { redirect } from "next/navigation";
+
+import { auth0 } from "@/lib/auth0";
+
+export default async function ServerPasswordlessVerifyPage({
+  searchParams
+}: {
+  searchParams: Promise<{
+    connection?: string;
+    email?: string;
+    phone?: string;
+    error?: string;
+  }>;
+}) {
+  const session = await auth0.getSession();
+  if (session) redirect("/dashboard");
+
+  const params = await searchParams;
+  const connection = params.connection as "email" | "sms" | undefined;
+  const email = params.email ?? "";
+  const phone = params.phone ?? "";
+  const error = params.error ?? null;
+
+  if (!connection || (connection === "email" && !email) || (connection === "sms" && !phone)) {
+    redirect("/server-passwordless");
+  }
+
+  const hint =
+    connection === "email"
+      ? `We sent a 6-digit code to ${email}`
+      : `We sent a 6-digit code to ${phone}`;
+
+  async function verifyOtp(formData: FormData) {
+    "use server";
+    const code = formData.get("code") as string;
+
+    if (connection === "email") {
+      console.log(`[server-passwordless] email OTP verify — email=${email} code=${code}`);
+      try {
+        // passwordless.verify exchanges the OTP for tokens and writes the
+        // session cookie to next/headers — the user is signed in after this call.
+        await auth0.passwordless.verify({
+          connection: "email",
+          email,
+          verificationCode: code
+        });
+        console.log(`[server-passwordless] email OTP verify success — session created for email=${email}`);
+      } catch (err) {
+        const e = err as { error?: string; error_description?: string };
+        console.error(`[server-passwordless] email OTP verify failed — ${e.error}: ${e.error_description}`);
+        redirect(
+          `/server-passwordless/verify?connection=email&email=${encodeURIComponent(email)}&error=${encodeURIComponent(e.error_description ?? "Invalid or expired code")}`
+        );
+      }
+    } else {
+      console.log(`[server-passwordless] SMS OTP verify — phone=${phone} code=${code}`);
+      try {
+        await auth0.passwordless.verify({
+          connection: "sms",
+          phoneNumber: phone,
+          verificationCode: code
+        });
+        console.log(`[server-passwordless] SMS OTP verify success — session created for phone=${phone}`);
+      } catch (err) {
+        const e = err as { error?: string; error_description?: string };
+        console.error(`[server-passwordless] SMS OTP verify failed — ${e.error}: ${e.error_description}`);
+        redirect(
+          `/server-passwordless/verify?connection=sms&phone=${encodeURIComponent(phone)}&error=${encodeURIComponent(e.error_description ?? "Invalid or expired code")}`
+        );
+      }
+    }
+
+    redirect("/dashboard");
+  }
+
+  const backHref =
+    connection === "email"
+      ? `/server-passwordless?tab=email`
+      : `/server-passwordless?tab=sms`;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-6">
+      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold tracking-tight">Enter your code</h1>
+          <p className="mt-2 text-sm text-gray-500">{hint}</p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form action={verifyOtp} className="space-y-4">
+          <div>
+            <label htmlFor="code" className="mb-1 block text-sm font-medium text-gray-700">
+              Verification code
+            </label>
+            <input
+              id="code"
+              name="code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="123456"
+              required
+              minLength={4}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+          >
+            Sign in
+          </button>
+        </form>
+
+        <a
+          href={backHref}
+          className="mt-4 block text-center text-xs text-gray-500 underline hover:text-gray-700"
+        >
+          ← Use a different {connection === "email" ? "email" : "phone number"}
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/examples/with-passwordless/components/passwordless-form.tsx
+++ b/examples/with-passwordless/components/passwordless-form.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 
 import { passwordless } from "@auth0/nextjs-auth0/client";
-import { PasswordlessStartError, PasswordlessVerifyError } from "@auth0/nextjs-auth0/errors";
 
 type ConnectionType = "email" | "sms" | "magic-link" | "universal-login";
 type Step = "start" | "verify" | "link-sent";
@@ -34,9 +33,10 @@ export function PasswordlessForm() {
       }
       setStep("verify");
     } catch (err) {
+      const e = err as { code?: string; error_description?: string };
       setError(
-        err instanceof PasswordlessStartError
-          ? err.error_description
+        e.code === "passwordless_start_error"
+          ? (e.error_description ?? "Failed to send. Please try again.")
           : "An unexpected error occurred. Please try again."
       );
     } finally {
@@ -66,11 +66,12 @@ export function PasswordlessForm() {
       // Session cookie set — navigate to dashboard
       window.location.href = "/dashboard";
     } catch (err) {
+      const e = err as { code?: string; error?: string; error_description?: string };
       setError(
-        err instanceof PasswordlessVerifyError
-          ? err.error === "invalid_grant"
+        e.code === "passwordless_verify_error"
+          ? e.error === "invalid_grant"
             ? "Invalid or expired code. Please check and try again."
-            : err.error_description
+            : (e.error_description ?? "Verification failed. Please try again.")
           : "An unexpected error occurred. Please try again."
       );
     } finally {
@@ -155,7 +156,7 @@ export function PasswordlessForm() {
           />
         </div>
 
-        <button type="submit" disabled={loading || code.length < 4} className={btnPrimary}>
+        <button type="submit" disabled={loading || code.length < 6} className={btnPrimary}>
           {loading ? "Verifying…" : "Sign in"}
         </button>
 

--- a/examples/with-passwordless/components/passwordless-form.tsx
+++ b/examples/with-passwordless/components/passwordless-form.tsx
@@ -7,6 +7,13 @@ import { passwordless } from "@auth0/nextjs-auth0/client";
 type ConnectionType = "email" | "sms" | "magic-link" | "universal-login";
 type Step = "start" | "verify" | "link-sent";
 
+/**
+ * Renders a passwordless authentication form that supports email OTP, SMS OTP, magic links, and redirect to Universal Login.
+ *
+ * The component manages input state, starts passwordless flows (send code or magic link), verifies one-time codes, displays errors, and navigates to /dashboard on successful verification. UI flows: "start" (choose method and send), "verify" (enter 6-digit code), and "link-sent" (magic link confirmation).
+ *
+ * @returns The JSX element for the passwordless authentication UI.
+ */
 export function PasswordlessForm() {
   const [connection, setConnection] = useState<ConnectionType>("email");
   const [email, setEmail] = useState("");

--- a/examples/with-passwordless/components/passwordless-form.tsx
+++ b/examples/with-passwordless/components/passwordless-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { passwordless } from "@auth0/nextjs-auth0/client";
+import { PasswordlessStartError, PasswordlessVerifyError } from "@auth0/nextjs-auth0/errors";
 
 type ConnectionType = "email" | "sms" | "magic-link" | "universal-login";
 type Step = "start" | "verify" | "link-sent";
@@ -33,15 +34,11 @@ export function PasswordlessForm() {
       }
       setStep("verify");
     } catch (err) {
-      const code = (err as { code?: string; error_description?: string })?.code;
-      if (code) {
-        setError(
-          (err as { error_description?: string }).error_description ??
-            "Unable to start passwordless flow."
-        );
-      } else {
-        setError("An unexpected error occurred. Please try again.");
-      }
+      setError(
+        err instanceof PasswordlessStartError
+          ? err.error_description
+          : "An unexpected error occurred. Please try again."
+      );
     } finally {
       setLoading(false);
     }
@@ -69,16 +66,13 @@ export function PasswordlessForm() {
       // Session cookie set — navigate to dashboard
       window.location.href = "/dashboard";
     } catch (err) {
-      const e = err as { code?: string; error?: string; error_description?: string };
-      if (e.code) {
-        setError(
-          e.error === "invalid_grant"
+      setError(
+        err instanceof PasswordlessVerifyError
+          ? err.error === "invalid_grant"
             ? "Invalid or expired code. Please check and try again."
-            : e.error_description ?? "Unable to verify code."
-        );
-      } else {
-        setError("An unexpected error occurred. Please try again.");
-      }
+            : err.error_description
+          : "An unexpected error occurred. Please try again."
+      );
     } finally {
       setLoading(false);
     }
@@ -154,6 +148,8 @@ export function PasswordlessForm() {
             value={code}
             onChange={(e) => setCode(e.target.value)}
             required
+            minLength={6}
+            maxLength={6}
             disabled={loading}
             className={inputClass}
           />

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -1556,97 +1556,11 @@ export class AuthClient {
           | "code"
           | "link";
 
-        if (send === "link") {
-          // Magic link flow: generate our own state, pass it as authParams.state
-          // to /passwordless/start so Auth0 embeds it in the emailed link, and
-          // save a transaction cookie keyed by it. When the user clicks the link,
-          // Auth0's /passwordless/verify_redirect will redirect to our callback
-          // with the same state, and handleCallback can resolve the transaction.
-          //
-          // Requires tenant setting `allow_magiclink_verify_without_session: true`
-          // so Auth0 does not require an nstate session cookie at link-click time
-          // (those cookies live on the Auth0 domain and cannot be planted from
-          // the application's domain).
-          const appBaseUrl = resolveAppBaseUrl(this.appBaseUrl, req);
-          const redirectUri = createRouteUrl(
-            this.routes.callback,
-            appBaseUrl
-          ).toString();
-
-          const state = oauth.generateRandomState();
-
-          // Start from all global authorizationParameters so tenant-level defaults
-          // (organization, invitation, acr_values, login_hint, etc.) are preserved,
-          // then set magic-link specific fields on top.
-          // Exclude PKCE params (not applicable without code_verifier) and fields
-          // we set explicitly below.
-          const MAGIC_LINK_EXCLUDED_PARAMS = [
-            "client_id",
-            "redirect_uri",
-            "response_type",
-            "state",
-            "nonce",
-            "code_challenge",
-            "code_challenge_method"
-          ];
-          const baseParams = mergeAuthorizationParamsIntoSearchParams(
-            this.authorizationParameters,
-            undefined,
-            MAGIC_LINK_EXCLUDED_PARAMS
-          );
-
-          // Derive scope explicitly via getScopeForAudience so map-form scopes
-          // are resolved correctly, falling back to default if none configured.
-          const audience = this.authorizationParameters.audience as
-            | string
-            | undefined;
-          const scope =
-            getScopeForAudience(this.authorizationParameters.scope, audience) ||
-            "openid email profile";
-
-          const authParams: Record<string, string> = {
-            ...Object.fromEntries(baseParams),
-            redirect_uri: redirectUri,
-            response_type: RESPONSE_TYPES.CODE,
-            scope,
-            state,
-            ...(audience && { audience })
-          };
-
-          await this.passwordlessStart({
-            connection: "email",
-            email,
-            send,
-            authParams,
-            language
-          });
-
-          const transactionState: TransactionState = {
-            responseType: RESPONSE_TYPES.CODE,
-            state,
-            returnTo: this.signInReturnToPath,
-            scope: scope || undefined,
-            audience: this.authorizationParameters.audience as
-              | string
-              | undefined,
-            originDomain: this.provider?.isResolverMode
-              ? this.domain
-              : undefined,
-            originIssuer: this.provider?.isResolverMode
-              ? this.issuer
-              : undefined
-          };
-
-          await this.transactionStore.save(res.cookies, transactionState);
-        } else {
-          // OTP flow: send the code directly, no authorize step needed
-          await this.passwordlessStart({
-            connection: "email",
-            email,
-            send,
-            language
-          });
-        }
+        await this.passwordlessStart(
+          { connection: "email", email, send, language },
+          res.cookies,
+          req
+        );
       } else if (connection === "sms") {
         const phoneNumber = validateStringFieldAndThrow(
           bodyRecord.phoneNumber,
@@ -3987,17 +3901,86 @@ export class AuthClient {
    * Initiates a passwordless authentication flow by POSTing to `/passwordless/start`.
    * Auth0 sends an OTP code or magic link to the user's email or phone number.
    *
+   * When `options.send === 'link'` (magic link), `resCookies` must be provided so
+   * the transaction state can be persisted for the callback to resolve. `req` is
+   * optional and used for MCD domain resolution and appBaseUrl inference.
+   *
    * @param options - Connection type, user identifier, and (for email) delivery method.
+   * @param resCookies - Response cookies to write the transaction cookie into (magic link only).
+   * @param req - Optional NextRequest for MCD domain resolution and appBaseUrl inference.
    * @throws {PasswordlessStartError} On Auth0 API failure.
    */
-  async passwordlessStart(options: PasswordlessStartOptions): Promise<void> {
+  async passwordlessStart(
+    options: PasswordlessStartOptions,
+    resCookies?: ResponseCookies,
+    req?: NextRequest
+  ): Promise<void> {
+    // Magic link flow: build authParams (state, redirect_uri, etc.) and save
+    // a transaction cookie so /auth/callback can complete the code exchange.
+    let magicLinkTransactionState: TransactionState | undefined;
+    if (
+      options.connection === "email" &&
+      "send" in options &&
+      options.send === "link"
+    ) {
+      const appBaseUrl = resolveAppBaseUrl(this.appBaseUrl, req);
+      const redirectUri = createRouteUrl(
+        this.routes.callback,
+        appBaseUrl
+      ).toString();
+      const state = oauth.generateRandomState();
+
+      // Preserve tenant-level authorizationParameters (org, acr_values, etc.)
+      // but exclude PKCE and fields we set explicitly.
+      const MAGIC_LINK_EXCLUDED_PARAMS = [
+        "client_id",
+        "redirect_uri",
+        "response_type",
+        "state",
+        "nonce",
+        "code_challenge",
+        "code_challenge_method"
+      ];
+      const baseParams = mergeAuthorizationParamsIntoSearchParams(
+        this.authorizationParameters,
+        undefined,
+        MAGIC_LINK_EXCLUDED_PARAMS
+      );
+
+      const audience = this.authorizationParameters.audience as
+        | string
+        | undefined;
+      const scope =
+        getScopeForAudience(this.authorizationParameters.scope, audience) ||
+        "openid email profile";
+
+      options = {
+        ...options,
+        authParams: {
+          ...Object.fromEntries(baseParams),
+          redirect_uri: redirectUri,
+          response_type: RESPONSE_TYPES.CODE,
+          scope,
+          state,
+          ...(audience && { audience })
+        }
+      };
+
+      magicLinkTransactionState = {
+        responseType: RESPONSE_TYPES.CODE,
+        state,
+        returnTo: this.signInReturnToPath,
+        scope: scope || undefined,
+        audience: this.authorizationParameters.audience as string | undefined,
+        originDomain: this.provider?.isResolverMode ? this.domain : undefined,
+        originIssuer: this.provider?.isResolverMode ? this.issuer : undefined
+      };
+    }
+
     const url = new URL("/passwordless/start", this.issuer).toString();
     const httpOptions = this.httpOptions();
     httpOptions.headers.set("Content-Type", "application/json");
 
-    // Forward locale preference for Auth0 email template localization.
-    // Auth0's /passwordless/start respects x-request-language to select the
-    // correct email template language when multiple are configured.
     if (options.language) {
       httpOptions.headers.set("x-request-language", options.language);
     }
@@ -4047,6 +4030,10 @@ export class AuthClient {
         "Unexpected error during passwordless start",
         undefined
       );
+    }
+
+    if (magicLinkTransactionState && resCookies) {
+      await this.transactionStore.save(resCookies, magicLinkTransactionState);
     }
   }
 

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3970,7 +3970,7 @@ export class AuthClient {
         responseType: RESPONSE_TYPES.CODE,
         state,
         returnTo: this.signInReturnToPath,
-        scope: scope || undefined,
+        scope,
         audience: this.authorizationParameters.audience as string | undefined,
         originDomain: this.provider?.isResolverMode ? this.domain : undefined,
         originIssuer: this.provider?.isResolverMode ? this.issuer : undefined
@@ -3981,6 +3981,9 @@ export class AuthClient {
     const httpOptions = this.httpOptions();
     httpOptions.headers.set("Content-Type", "application/json");
 
+    // Forward locale preference for Auth0 email template localization.
+    // Auth0's /passwordless/start respects x-request-language to select the
+    // correct email template language when multiple are configured.
     if (options.language) {
       httpOptions.headers.set("x-request-language", options.language);
     }
@@ -4032,7 +4035,13 @@ export class AuthClient {
       );
     }
 
-    if (magicLinkTransactionState && resCookies) {
+    if (magicLinkTransactionState) {
+      if (!resCookies) {
+        throw new InvalidConfigurationError(
+          "Magic link requires a response cookies object to persist the transaction state. " +
+            "Pass the NextResponse cookies (App Router: next/headers cookies; Pages Router: res.cookies)."
+        );
+      }
       await this.transactionStore.save(resCookies, magicLinkTransactionState);
     }
   }

--- a/src/server/passwordless-server.flow.test.ts
+++ b/src/server/passwordless-server.flow.test.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server.js";
+import { ResponseCookies } from "@edge-runtime/cookies";
 import * as jose from "jose";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -201,6 +202,175 @@ describe("AuthClient passwordless methods", () => {
         name: "PasswordlessStartError",
         error: "unexpected_error"
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passwordlessStart — magic link
+  // ---------------------------------------------------------------------------
+
+  describe("passwordlessStart — magic link (send: link)", () => {
+    it("POSTs to Auth0 with send: link and authParams containing state and redirect_uri", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      const resCookies = new ResponseCookies(new Headers());
+      await authClient.passwordlessStart(
+        { connection: "email", email: DEFAULT.email, send: "link" },
+        resCookies
+      );
+
+      expect(capturedBody.connection).toBe("email");
+      expect(capturedBody.email).toBe(DEFAULT.email);
+      expect(capturedBody.send).toBe("link");
+
+      const authParams = capturedBody.authParams as Record<string, string>;
+      expect(authParams).toBeDefined();
+      expect(authParams.state).toBeTruthy();
+      expect(authParams.redirect_uri).toContain("/auth/callback");
+      expect(authParams.response_type).toBe("code");
+    });
+
+    it("writes a transaction cookie to resCookies after a successful start", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      const headers = new Headers();
+      const resCookies = new ResponseCookies(headers);
+      await authClient.passwordlessStart(
+        { connection: "email", email: DEFAULT.email, send: "link" },
+        resCookies
+      );
+
+      const setCookieHeader = headers.get("set-cookie");
+      expect(setCookieHeader).toBeTruthy();
+      expect(setCookieHeader).toMatch(/HttpOnly/i);
+    });
+
+    it("forwards x-request-language when language is provided", async () => {
+      let capturedHeaders: Record<string, string> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedHeaders = Object.fromEntries(request.headers.entries());
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      const resCookies = new ResponseCookies(new Headers());
+      await authClient.passwordlessStart(
+        {
+          connection: "email",
+          email: DEFAULT.email,
+          send: "link",
+          language: "pt-BR"
+        },
+        resCookies
+      );
+
+      expect(capturedHeaders["x-request-language"]).toBe("pt-BR");
+    });
+
+    it("includes audience in authParams when configured", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      const scopedSecret = await generateSecret(32);
+      const scopedClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: scopedSecret,
+        transactionStore: new TransactionStore({ secret: scopedSecret }),
+        sessionStore: new StatelessSessionStore({ secret: scopedSecret }),
+        routes: getDefaultRoutes(),
+        authorizationParameters: {
+          scope: "openid profile email",
+          audience: "https://api.example.com"
+        }
+      });
+
+      const resCookies = new ResponseCookies(new Headers());
+      await scopedClient.passwordlessStart(
+        { connection: "email", email: DEFAULT.email, send: "link" },
+        resCookies
+      );
+
+      const authParams = capturedBody.authParams as Record<string, string>;
+      expect(authParams.audience).toBe("https://api.example.com");
+      expect(authParams.scope).toBe("openid profile email");
+    });
+
+    it("does not write a transaction cookie when resCookies is omitted", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      // No resCookies — the call should succeed but the cookie guard
+      // (if magicLinkTransactionState && resCookies) must be a no-op.
+      await expect(
+        authClient.passwordlessStart({
+          connection: "email",
+          email: DEFAULT.email,
+          send: "link"
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not write a transaction cookie on Auth0 API failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json(
+            {
+              error: "bad.connection",
+              error_description: "Connection not found."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const headers = new Headers();
+      const resCookies = new ResponseCookies(headers);
+      await expect(
+        authClient.passwordlessStart(
+          { connection: "email", email: DEFAULT.email, send: "link" },
+          resCookies
+        )
+      ).rejects.toMatchObject({
+        name: "PasswordlessStartError",
+        error: "bad.connection"
+      });
+
+      // transactionStore.save runs after the fetch — must not have been called
+      expect(headers.get("set-cookie")).toBeNull();
     });
   });
 
@@ -1079,35 +1249,25 @@ describe("AuthClient passwordless methods", () => {
   // ---------------------------------------------------------------------------
 
   describe("ServerPasswordlessClient", () => {
-    it("throws TypeError when start is called with send: 'link' (App Router overload)", async () => {
-      const passwordlessClient = new ServerPasswordlessClient({} as any);
-      await expect(
-        passwordlessClient.start({
-          connection: "email",
-          email: DEFAULT.email,
-          send: "link"
-        })
-      ).rejects.toThrow(TypeError);
-    });
-
-    it("throws TypeError when start is called with send: 'link' (Pages Router overload)", async () => {
+    it("throws TypeError when start(req, res, options) Pages Router call is missing res", async () => {
+      // The guard fires before connection/send is inspected — one test covers all variants.
       const passwordlessClient = new ServerPasswordlessClient({} as any);
       const req = new NextRequest(
         new URL("/auth/passwordless/start", DEFAULT.appBaseUrl),
         { method: "POST" }
       );
       await expect(
-        passwordlessClient.start(req, {
+        (passwordlessClient.start as any)(req, {
           connection: "email",
           email: DEFAULT.email,
-          send: "link"
+          send: "code"
         })
       ).rejects.toThrow(TypeError);
     });
   });
 
   describe("MCD resolver mode — ServerPasswordlessClient", () => {
-    it("start(req, options) routes to the correct tenant domain via host header", async () => {
+    it("start(req, res, options) routes to the correct tenant domain via host header", async () => {
       const capturedUrls: string[] = [];
 
       server.use(
@@ -1147,7 +1307,7 @@ describe("AuthClient passwordless methods", () => {
         { method: "POST", headers: { host: "tenant-a.example.com" } }
       );
 
-      await passwordlessClient.start(req, {
+      await passwordlessClient.start(req, new NextResponse(), {
         connection: "email",
         email: DEFAULT.email,
         send: "code"
@@ -1308,13 +1468,13 @@ describe("AuthClient passwordless methods", () => {
         { method: "POST", headers: { host: "tenant-b.example.com" } }
       );
 
-      await passwordlessClient.start(reqA, {
+      await passwordlessClient.start(reqA, new NextResponse(), {
         connection: "email",
         email: DEFAULT.email,
         send: "code"
       });
 
-      await passwordlessClient.start(reqB, {
+      await passwordlessClient.start(reqB, new NextResponse(), {
         connection: "email",
         email: DEFAULT.email,
         send: "code"

--- a/src/server/passwordless-server.flow.test.ts
+++ b/src/server/passwordless-server.flow.test.ts
@@ -326,22 +326,22 @@ describe("AuthClient passwordless methods", () => {
       expect(authParams.scope).toBe("openid profile email");
     });
 
-    it("does not write a transaction cookie when resCookies is omitted", async () => {
+    it("throws InvalidConfigurationError when resCookies is omitted for magic link", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
           HttpResponse.json({}, { status: 200 })
         )
       );
 
-      // No resCookies — the call should succeed but the cookie guard
-      // (if magicLinkTransactionState && resCookies) must be a no-op.
+      // Magic link requires resCookies to persist the transaction state.
+      // Omitting it is a developer mistake — throw rather than silently skip.
       await expect(
         authClient.passwordlessStart({
           connection: "email",
           email: DEFAULT.email,
           send: "link"
         })
-      ).resolves.toBeUndefined();
+      ).rejects.toMatchObject({ name: "InvalidConfigurationError" });
     });
 
     it("does not write a transaction cookie on Auth0 API failure", async () => {

--- a/src/server/passwordless/server-passwordless-client.test.ts
+++ b/src/server/passwordless/server-passwordless-client.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Unit tests for ServerPasswordlessClient — App Router path (next/headers mock).
+ *
+ * The flow-level tests for Pages Router and MCD resolver mode live in
+ * passwordless-server.flow.test.ts. This file covers the App Router
+ * getCookies() integration which requires next/headers to be mocked at
+ * the module level.
+ */
+import { NextRequest, NextResponse } from "next/server.js";
+import { ResponseCookies } from "@edge-runtime/cookies";
+import * as jose from "jose";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAuthorizationServerMetadata,
+  getDefaultRoutes,
+  setupMswLifecycle
+} from "../../test/defaults.js";
+import { AuthClientProvider } from "../auth-client-provider.js";
+import { AuthClient } from "../auth-client.js";
+import { StatelessSessionStore } from "../session/stateless-session-store.js";
+import { TransactionStore } from "../transaction-store.js";
+import { ServerPasswordlessClient } from "./server-passwordless-client.js";
+
+// Shared mutable headers that the mocked next/headers cookies() returns.
+// Tests reset this in beforeEach so each test gets a clean slate.
+let mockCookieHeaders: Headers;
+
+vi.mock("next/headers.js", () => ({
+  cookies: vi.fn(async () => new ResponseCookies(mockCookieHeaders)),
+  headers: vi.fn(() => new Headers())
+}));
+
+const DEFAULT = {
+  domain: "auth0.local",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  email: "user@example.com",
+  phoneNumber: "+14155550100",
+  verificationCode: "123456",
+  sub: "auth0|test-user-id",
+  sid: "test-sid"
+};
+
+let keyPair: jose.GenerateKeyPairResult;
+
+const authorizationServerMetadata = createAuthorizationServerMetadata(
+  DEFAULT.domain
+);
+
+const server = setupServer(
+  http.get(`https://${DEFAULT.domain}/.well-known/openid-configuration`, () =>
+    HttpResponse.json(authorizationServerMetadata)
+  ),
+  http.get(`https://${DEFAULT.domain}/.well-known/jwks.json`, async () => {
+    const jwk = await jose.exportJWK(keyPair.publicKey);
+    return HttpResponse.json({
+      keys: [{ ...jwk, kid: "test-key-1", alg: "RS256", use: "sig" }]
+    });
+  })
+);
+
+setupMswLifecycle(server);
+
+beforeAll(async () => {
+  keyPair = await jose.generateKeyPair("RS256");
+});
+
+async function makeIdToken(
+  claims: Record<string, unknown> = {}
+): Promise<string> {
+  return new jose.SignJWT({ sub: DEFAULT.sub, sid: DEFAULT.sid, ...claims })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(`https://${DEFAULT.domain}`)
+    .setAudience(DEFAULT.clientId)
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(keyPair.privateKey);
+}
+
+function makePasswordlessClient(): ServerPasswordlessClient {
+  return new ServerPasswordlessClient({
+    forRequest: async () =>
+      new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: "test-secret-long-enough-for-hs256-algorithm",
+        transactionStore: new TransactionStore({
+          secret: "test-secret-long-enough-for-hs256-algorithm"
+        }),
+        sessionStore: new StatelessSessionStore({
+          secret: "test-secret-long-enough-for-hs256-algorithm"
+        }),
+        routes: getDefaultRoutes()
+      }),
+    isResolverMode: false
+  } as unknown as AuthClientProvider);
+}
+
+// ---------------------------------------------------------------------------
+// start() — App Router path
+// ---------------------------------------------------------------------------
+
+describe("ServerPasswordlessClient.start() — App Router", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  describe("magic link (send: link)", () => {
+    it("writes a transaction cookie to next/headers on success", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      await makePasswordlessClient().start({
+        connection: "email",
+        email: DEFAULT.email,
+        send: "link"
+      });
+
+      const setCookie = mockCookieHeaders.get("set-cookie");
+      expect(setCookie).toBeTruthy();
+      expect(setCookie).toMatch(/HttpOnly/i);
+    });
+
+    it("throws PasswordlessStartError and does not write cookie on Auth0 failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json(
+            {
+              error: "bad.connection",
+              error_description: "Connection not found."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      await expect(
+        makePasswordlessClient().start({
+          connection: "email",
+          email: DEFAULT.email,
+          send: "link"
+        })
+      ).rejects.toMatchObject({
+        name: "PasswordlessStartError",
+        error: "bad.connection"
+      });
+
+      expect(mockCookieHeaders.get("set-cookie")).toBeNull();
+    });
+  });
+
+  describe("email OTP (send: code)", () => {
+    it("succeeds without calling getCookies()", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      await expect(
+        makePasswordlessClient().start({
+          connection: "email",
+          email: DEFAULT.email,
+          send: "code"
+        })
+      ).resolves.toBeUndefined();
+
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SMS OTP", () => {
+    it("succeeds without calling getCookies()", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      await expect(
+        makePasswordlessClient().start({
+          connection: "sms",
+          phoneNumber: DEFAULT.phoneNumber
+        })
+      ).resolves.toBeUndefined();
+
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Pages Router overload (req, res, options)", () => {
+    it("succeeds for email OTP and does not touch next/headers", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passwordless/start", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+      const res = new NextResponse();
+
+      await expect(
+        makePasswordlessClient().start(req, res, {
+          connection: "email",
+          email: DEFAULT.email,
+          send: "code"
+        })
+      ).resolves.toBeUndefined();
+
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+
+    it("writes transaction cookie to res for magic link and does not touch next/headers", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passwordless/start`, () =>
+          HttpResponse.json({}, { status: 200 })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passwordless/start", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+      const res = new NextResponse();
+
+      await expect(
+        makePasswordlessClient().start(req, res, {
+          connection: "email",
+          email: DEFAULT.email,
+          send: "link"
+        })
+      ).resolves.toBeUndefined();
+
+      // Transaction cookie must land on res, not on next/headers
+      expect(res.headers.get("set-cookie")).toBeTruthy();
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+
+    it("throws TypeError when res is missing", async () => {
+      const req = new NextRequest(
+        new URL("/auth/passwordless/start", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+
+      await expect(
+        (makePasswordlessClient().start as any)(req, {
+          connection: "email",
+          email: DEFAULT.email,
+          send: "code"
+        })
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify() — App Router path
+// ---------------------------------------------------------------------------
+
+describe("ServerPasswordlessClient.verify() — App Router", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("creates a session cookie in next/headers for email OTP", async () => {
+    const idToken = await makeIdToken({ email: DEFAULT.email });
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json({
+          access_token: "test-access-token",
+          token_type: "Bearer",
+          expires_in: 86400,
+          scope: "openid profile email",
+          id_token: idToken
+        })
+      )
+    );
+
+    await makePasswordlessClient().verify({
+      connection: "email",
+      email: DEFAULT.email,
+      verificationCode: DEFAULT.verificationCode
+    });
+
+    // Session cookie written to next/headers — value is an encrypted JWE blob.
+    const setCookie = mockCookieHeaders.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toMatch(/__session=/);
+  });
+
+  it("creates a session cookie in next/headers for SMS OTP", async () => {
+    const idToken = await makeIdToken();
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json({
+          access_token: "test-access-token",
+          token_type: "Bearer",
+          expires_in: 86400,
+          id_token: idToken
+        })
+      )
+    );
+
+    await makePasswordlessClient().verify({
+      connection: "sms",
+      phoneNumber: DEFAULT.phoneNumber,
+      verificationCode: DEFAULT.verificationCode
+    });
+
+    const setCookie = mockCookieHeaders.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toMatch(/__session=/);
+  });
+
+  it("throws PasswordlessVerifyError on Auth0 token failure", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Wrong email or verification code."
+          },
+          { status: 403 }
+        )
+      )
+    );
+
+    await expect(
+      makePasswordlessClient().verify({
+        connection: "email",
+        email: DEFAULT.email,
+        verificationCode: "wrong-code"
+      })
+    ).rejects.toMatchObject({
+      name: "PasswordlessVerifyError",
+      error: "invalid_grant"
+    });
+
+    expect(mockCookieHeaders.get("set-cookie")).toBeNull();
+  });
+
+  it("throws TypeError when extra arguments are passed (App Router guard)", async () => {
+    await expect(
+      (makePasswordlessClient().verify as any)(
+        {
+          connection: "email",
+          email: DEFAULT.email,
+          verificationCode: DEFAULT.verificationCode
+        },
+        new NextResponse()
+      )
+    ).rejects.toThrow(TypeError);
+  });
+
+  describe("Pages Router overload (req, res, options)", () => {
+    it("writes session cookie to res and not to next/headers", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      const idToken = await makeIdToken({ email: DEFAULT.email });
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json({
+            access_token: "test-access-token",
+            token_type: "Bearer",
+            expires_in: 86400,
+            scope: "openid profile email",
+            id_token: idToken
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passwordless/verify", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+      const res = new NextResponse();
+
+      await makePasswordlessClient().verify(req, res, {
+        connection: "email",
+        email: DEFAULT.email,
+        verificationCode: DEFAULT.verificationCode
+      });
+
+      expect(res.headers.get("set-cookie")).toBeTruthy();
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+
+    it("throws TypeError when res is missing", async () => {
+      const req = new NextRequest(
+        new URL("/auth/passwordless/verify", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+
+      await expect(
+        (makePasswordlessClient().verify as any)(req, {
+          connection: "email",
+          email: DEFAULT.email,
+          verificationCode: DEFAULT.verificationCode
+        })
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/src/server/passwordless/server-passwordless-client.ts
+++ b/src/server/passwordless/server-passwordless-client.ts
@@ -101,8 +101,10 @@ export class ServerPasswordlessClient implements PasswordlessClient {
     // App Router: start(options)
     // Only read next/headers cookies for magic link — OTP flows don't write cookies.
     const authClient = await this.getAuthClient();
-    const isMagicLink =
-      arg1.connection === "email" && "send" in arg1 && arg1.send === "link";
+    const isMagicLink = arg1.connection === "email" && arg1.send === "link";
+    // `as any`: ReadonlyRequestCookies is typed as Omit<RequestCookies, 'set'|'clear'|'delete'>
+    // & Pick<ResponseCookies, 'set'|'delete'>, so it does expose .set() at runtime despite
+    // the name. The cast suppresses the TS mismatch against the ResponseCookies parameter type.
     const cookiesLib = isMagicLink ? await getCookies() : undefined;
     return authClient.passwordlessStart(arg1, cookiesLib as any);
   }

--- a/src/server/passwordless/server-passwordless-client.ts
+++ b/src/server/passwordless/server-passwordless-client.ts
@@ -14,13 +14,25 @@ import type { AuthClient } from "../auth-client.js";
  * Delegates all operations to AuthClient business logic.
  * Provides overload support for App Router and Pages Router.
  *
- * @example App Router — start
+ * @example App Router — OTP start
  * ```typescript
  * import { auth0 } from '@/lib/auth0';
  *
  * export async function POST(req: NextRequest) {
  *   const { connection, email, send } = await req.json();
  *   await auth0.passwordless.start({ connection, email, send });
+ *   return new Response(null, { status: 204 });
+ * }
+ * ```
+ *
+ * @example App Router — magic link start
+ * ```typescript
+ * import { auth0 } from '@/lib/auth0';
+ *
+ * export async function POST(req: NextRequest) {
+ *   const { email } = await req.json();
+ *   // Transaction cookie written to next/headers automatically
+ *   await auth0.passwordless.start({ connection: 'email', email, send: 'link' });
  *   return new Response(null, { status: 204 });
  * }
  * ```
@@ -47,52 +59,52 @@ export class ServerPasswordlessClient implements PasswordlessClient {
   }
 
   /**
-   * Initiate a passwordless flow by sending an OTP to the user's email or phone.
+   * Initiate a passwordless flow by sending an OTP or magic link to the user's email or phone.
    * App Router overload — reads headers from `next/headers`.
+   * For magic link (`send: 'link'`), the transaction cookie is written via `next/headers` automatically.
    *
    * @param options - Connection type and user identifier (email or phone)
    */
   async start(options: PasswordlessStartOptions): Promise<void>;
 
   /**
-   * Initiate a passwordless flow by sending an OTP to the user's email or phone.
-   * Pages Router / Middleware overload — pass the request for Multi-Custom Domain resolution.
+   * Initiate a passwordless flow by sending an OTP or magic link to the user's email or phone.
+   * Pages Router overload — explicit req/res for cookie and MCD domain resolution.
+   * For magic link (`send: 'link'`), the transaction cookie is written to `res`.
    *
    * @param req - Next.js request (provides URL context for MCD domain resolution)
+   * @param res - Next.js response (receives the transaction cookie for magic link)
    * @param options - Connection type and user identifier (email or phone)
    */
   async start(
     req: NextRequest,
+    res: NextResponse,
     options: PasswordlessStartOptions
   ): Promise<void>;
 
   async start(
     arg1: PasswordlessStartOptions | NextRequest,
-    arg2?: PasswordlessStartOptions
+    arg2?: NextResponse | PasswordlessStartOptions,
+    arg3?: PasswordlessStartOptions
   ): Promise<void> {
-    const options = arg1 instanceof NextRequest ? arg2 : arg1;
-    if (
-      options &&
-      "send" in options &&
-      options.connection === "email" &&
-      options.send === "link"
-    ) {
-      throw new TypeError(
-        "send: 'link' is not supported on this API surface. Magic-link flows require a response object to persist the transaction cookie. Use the /auth/passwordless/start route handler instead."
-      );
-    }
-
+    // Pages Router: start(req, res, options)
     if (arg1 instanceof NextRequest) {
-      if (!arg2) {
+      if (!(arg2 instanceof NextResponse) || !arg3) {
         throw new TypeError(
-          "start(req, options): options argument is required"
+          "start(req, res, options): All three arguments required for Pages Router"
         );
       }
       const authClient = await this.getAuthClient(arg1);
-      return authClient.passwordlessStart(arg2);
+      return authClient.passwordlessStart(arg3, arg2.cookies, arg1);
     }
+
+    // App Router: start(options)
+    // Only read next/headers cookies for magic link — OTP flows don't write cookies.
     const authClient = await this.getAuthClient();
-    return authClient.passwordlessStart(arg1);
+    const isMagicLink =
+      arg1.connection === "email" && "send" in arg1 && arg1.send === "link";
+    const cookiesLib = isMagicLink ? await getCookies() : undefined;
+    return authClient.passwordlessStart(arg1, cookiesLib as any);
   }
 
   /**
@@ -124,7 +136,6 @@ export class ServerPasswordlessClient implements PasswordlessClient {
   ): Promise<void> {
     if (arg1 instanceof NextRequest) {
       // Pages Router / Middleware: verify(req, res, options)
-      // req is passed so MCD resolver can pick the correct Auth0 domain
       if (!arg2 || !arg3) {
         throw new TypeError(
           "verify(req, res, options): All three arguments required for Pages Router"

--- a/src/types/passwordless.ts
+++ b/src/types/passwordless.ts
@@ -136,6 +136,10 @@ export interface PasswordlessClient {
    * Starts a passwordless authentication flow by sending an OTP or magic link
    * to the user's email address or phone number.
    *
+   * For magic link (`send: 'link'`) in App Router, the transaction cookie is
+   * written via `next/headers` automatically. In Pages Router, pass explicit
+   * `req` and `res` so the cookie can be set on the response.
+   *
    * @param options - Connection type and user identifier.
    */
   start(options: PasswordlessStartOptions): Promise<void>;


### PR DESCRIPTION
## Summary

- **Magic link server-side support**: `AuthClient.passwordlessStart()` now accepts optional `resCookies` and `req` parameters. When `send: 'link'`, it builds the OAuth `authParams` (state, redirect_uri, scope, audience) and writes the transaction cookie directly — no separate method needed. The `ServerPasswordlessClient` App Router path fetches `next/headers` cookies only for magic link flows; Pages Router path accepts an explicit `res` as the third argument.
- **Removed `passwordlessMagicLinkStart`**: Logic folded into `passwordlessStart` to eliminate duplication with `handlePasswordlessStart`.
- **Server-side example**: `app/server-passwordless/` demonstrates Email OTP, SMS OTP, and Magic Link entirely via Server Actions — no client JS, no fetch calls. Per-step terminal logs included for tracing.
- **README**: Updated route count (8 → 13), added all MFA and connect routes, updated project structure tree.

## What changed

### `src/server/auth-client.ts`
- `passwordlessStart(options, resCookies?, req?)` — magic link setup (authParams, transaction state) is now inline; cookie is saved after a successful POST only.
- `handlePasswordlessStart` simplified to a single `passwordlessStart(options, res.cookies, req)` call.

### `src/server/passwordless/server-passwordless-client.ts`
- App Router `start()`: calls `getCookies()` only when `send === 'link'`.
- Pages Router `start(req, res, options)`: passes `res.cookies` and `req` directly to `passwordlessStart`.

### `src/types/passwordless.ts`
- JSDoc updated to document magic link behaviour for both App Router and Pages Router overloads.

### Tests (`passwordless-server.flow.test.ts`)
- Renamed and deduplicated `ServerPasswordlessClient` TypeError guard tests.
- New magic link describe block: authParams shape, transaction cookie written, cookie NOT written on failure, cookie NOT written when `resCookies` omitted.

### Examples (`examples/with-passwordless/`)
- `app/server-passwordless/page.tsx` — tabbed start form (Email OTP / SMS OTP / Magic Link), plain HTML forms, Server Actions.
- `app/server-passwordless/verify/page.tsx` — OTP verify step for email and SMS.
- `README.md` — project structure updated, server-side example documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-side passwordless flow (Email OTP, SMS OTP, Magic Link) with a verification page and updated dashboard sign-in UI.

* **Documentation**
  * SDK Routes updated to list 13 auth endpoints (includes connect and MFA family).
  * Added docs and example guidance for the server-side passwordless flows and logs.

* **Bug Fixes / UX**
  * Improved error messaging and enforced 6-digit OTP validation.

* **Tests**
  * Added tests covering passwordless start/verify and cookie behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->