### PR TITLE
Passkey server logic implementaion

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -34,6 +34,11 @@ import {
   MissingStateError,
   MyAccountApiError,
   OAuth2Error,
+  PasskeyEnrollmentChallengeError,
+  PasskeyEnrollVerifyError,
+  PasskeyLoginChallengeError,
+  PasskeySignupChallengeError,
+  PasskeyVerifyError,
   PasswordlessStartError,
   PasswordlessVerifyError,
   SdkError
@@ -66,10 +71,18 @@ import {
   EnrollOtpOptions,
   GetAccessTokenOptions,
   GRANT_TYPE_CUSTOM_TOKEN_EXCHANGE,
+  GRANT_TYPE_PASSKEY,
   GRANT_TYPE_PASSWORDLESS_OTP,
   LogoutStrategy,
   LogoutToken,
   MfaVerifyResponse,
+  PasskeyAuthenticationMethod,
+  PasskeyChallengeResponse,
+  PasskeyEnrollmentChallengeResponse,
+  PasskeyEnrollVerifyOptions,
+  PasskeyLoginChallengeOptions,
+  PasskeySignupChallengeOptions,
+  PasskeyVerifyOptions,
   PasswordlessStartOptions,
   PasswordlessVerifyOptions,
   PasswordlessVerifyTokenResponse,
@@ -235,6 +248,9 @@ export interface Routes {
   mfaAssociate: string;
   passwordlessStart: string;
   passwordlessVerify: string;
+  passkeySignupChallenge: string;
+  passkeyLoginChallenge: string;
+  passkeyVerify: string;
 }
 export type RoutesOptions = Partial<Routes>;
 
@@ -625,6 +641,21 @@ export class AuthClient {
       sanitizedPathname === this.routes.passwordlessVerify
     ) {
       return this.handlePasswordlessVerify(req);
+    } else if (
+      method === "POST" &&
+      sanitizedPathname === this.routes.passkeySignupChallenge
+    ) {
+      return this.handlePasskeySignupChallenge(req);
+    } else if (
+      method === "POST" &&
+      sanitizedPathname === this.routes.passkeyLoginChallenge
+    ) {
+      return this.handlePasskeyLoginChallenge(req);
+    } else if (
+      method === "POST" &&
+      sanitizedPathname === this.routes.passkeyVerify
+    ) {
+      return this.handlePasskeyVerify(req);
     } else if (sanitizedPathname.startsWith("/me/")) {
       return this.handleMyAccount(req);
     } else if (sanitizedPathname.startsWith("/my-org/")) {
@@ -3854,6 +3885,598 @@ export class AuthClient {
 
     // Persist updated session
     await this.sessionStore.set(reqCookies, resCookies, session);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Passkey core methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Request a WebAuthn credential creation challenge for new user signup.
+   * Calls Auth0 POST /passkey/register.
+   */
+  async passkeySignupChallenge(
+    options?: PasskeySignupChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    const url = new URL("/passkey/register", this.issuer).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    const body: Record<string, unknown> = {
+      client_id: this.clientMetadata.client_id
+    };
+
+    if (this.clientSecret) {
+      body.client_secret = this.clientSecret;
+    }
+
+    if (options?.userDisplayName) {
+      body.user_display_name = options.userDisplayName;
+    }
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to get passkey signup challenge"
+        }));
+        throw new PasskeySignupChallengeError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description ||
+            "Failed to get passkey signup challenge",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+
+      const result = await response.json();
+      return {
+        authSession: result.auth_session,
+        authnParamsPublicKey: result.authn_params_public_key
+      };
+    } catch (e) {
+      if (e instanceof PasskeySignupChallengeError) throw e;
+      throw new PasskeySignupChallengeError(
+        "unexpected_error",
+        "Unexpected error during passkey signup challenge",
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Request a WebAuthn credential assertion challenge for login.
+   * Calls Auth0 POST /passkey/challenge.
+   */
+  async passkeyLoginChallenge(
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    const url = new URL("/passkey/challenge", this.issuer).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    const body: Record<string, unknown> = {
+      client_id: this.clientMetadata.client_id
+    };
+
+    if (this.clientSecret) {
+      body.client_secret = this.clientSecret;
+    }
+
+    if (options?.username) {
+      body.username = options.username;
+    }
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to get passkey login challenge"
+        }));
+        throw new PasskeyLoginChallengeError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description ||
+            "Failed to get passkey login challenge",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+
+      const result = await response.json();
+      return {
+        authSession: result.auth_session,
+        authnParamsPublicKey: result.authn_params_public_key
+      };
+    } catch (e) {
+      if (e instanceof PasskeyLoginChallengeError) throw e;
+      throw new PasskeyLoginChallengeError(
+        "unexpected_error",
+        "Unexpected error during passkey login challenge",
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Complete a passkey signup or login by exchanging the WebAuthn assertion for a session.
+   * Calls Auth0 POST /oauth/token with the WebAuthn grant type.
+   */
+  async passkeyVerify(
+    options: PasskeyVerifyOptions,
+    reqCookies: RequestCookies,
+    resCookies: ResponseCookies
+  ): Promise<void> {
+    await this.ensureDpopValidated();
+
+    const [discoveryError, authorizationServerMetadata] =
+      await this.discoverAuthorizationServerMetadata();
+
+    if (discoveryError) {
+      throw new PasskeyVerifyError(
+        "discovery_error",
+        "Failed to discover authorization server metadata",
+        undefined
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.append("auth_session", options.authSession);
+    params.append("authn_response", JSON.stringify(options.authResponse));
+
+    const scope =
+      getScopeForAudience(
+        this.authorizationParameters.scope,
+        this.authorizationParameters.audience
+      ) || DEFAULT_SCOPES;
+    params.append("scope", scope);
+
+    if (this.authorizationParameters.audience) {
+      params.append(
+        "audience",
+        this.authorizationParameters.audience as string
+      );
+    }
+
+    const dpopHandle =
+      this.useDPoP && this.dpopKeyPair
+        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
+        : undefined;
+
+    let tokenEndpointResponse: oauth.TokenEndpointResponse;
+    try {
+      tokenEndpointResponse = await withDPoPNonceRetry(
+        async () => {
+          const httpResponse = await oauth.genericTokenEndpointRequest(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            await this.getClientAuth(),
+            GRANT_TYPE_PASSKEY,
+            params,
+            {
+              ...this.httpOptions(),
+              [oauth.customFetch]: this.fetch,
+              [oauth.allowInsecureRequests]: this.allowInsecureRequests,
+              ...(dpopHandle && { DPoP: dpopHandle })
+            }
+          );
+          return oauth.processGenericTokenEndpointResponse(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            httpResponse
+          );
+        },
+        {
+          isDPoPEnabled: !!(this.useDPoP && this.dpopKeyPair),
+          ...this.dpopOptions?.retry
+        }
+      );
+    } catch (err: any) {
+      if (err?.code === oauth.JWT_CLAIM_COMPARISON) {
+        const claim = (err.cause as any)?.claim;
+        if (claim === "iss") {
+          throw new PasskeyVerifyError(
+            "invalid_issuer",
+            "ID token issuer mismatch. Check AUTH0_DOMAIN configuration."
+          );
+        }
+        if (claim === "aud") {
+          throw new PasskeyVerifyError(
+            "invalid_audience",
+            "ID token audience mismatch. Check AUTH0_CLIENT_ID configuration."
+          );
+        }
+      }
+
+      const oauthErr = await extractOAuthErrorDetails(err);
+      throw new PasskeyVerifyError(
+        oauthErr.error || "unknown_error",
+        oauthErr.error_description ||
+          err.message ||
+          "Passkey verification failed",
+        oauthErr.error
+          ? {
+              error: oauthErr.error,
+              error_description: oauthErr.error_description ?? ""
+            }
+          : undefined
+      );
+    }
+
+    if (!tokenEndpointResponse.id_token) {
+      throw new PasskeyVerifyError(
+        "missing_id_token",
+        "No id_token in passkey verify response. Ensure 'openid' scope is requested."
+      );
+    }
+
+    const claims = jose.decodeJwt(tokenEndpointResponse.id_token);
+    const user = claims as unknown as User;
+
+    let session: SessionData = {
+      user,
+      tokenSet: {
+        accessToken: tokenEndpointResponse.access_token,
+        idToken: tokenEndpointResponse.id_token,
+        scope: tokenEndpointResponse.scope,
+        refreshToken: tokenEndpointResponse.refresh_token,
+        expiresAt:
+          Math.floor(Date.now() / 1000) +
+          Number(tokenEndpointResponse.expires_in),
+        token_type: normalizeTokenType(tokenEndpointResponse.token_type)
+      },
+      internal: {
+        sid: (claims.sid as string) || "",
+        createdAt: Math.floor(Date.now() / 1000),
+        ...(this.provider?.isResolverMode && {
+          mcd: { domain: this.domain, issuer: this.issuer }
+        })
+      }
+    };
+
+    session = await this.finalizeSession(
+      session,
+      tokenEndpointResponse.id_token
+    );
+    await this.sessionStore.set(reqCookies, resCookies, session, true);
+  }
+
+  /**
+   * Request a WebAuthn credential creation challenge for enrolling a new passkey
+   * on an existing authenticated account.
+   * Calls Auth0 MyAccount API POST /me/v1/authentication-methods.
+   */
+  async passkeyEnrollmentChallenge(
+    req?: NextRequest
+  ): Promise<PasskeyEnrollmentChallengeResponse> {
+    const { error: sessionError, session } =
+      await this.getSessionWithDomainCheck(
+        req
+          ? req.cookies
+          : await import("next/headers.js").then((m) => m.cookies())
+      );
+
+    if (sessionError || !session) {
+      throw new PasskeyEnrollmentChallengeError(
+        "not_authenticated",
+        "The user does not have an active session."
+      );
+    }
+
+    const [tokenError, tokenSetResponse] = await this.getTokenSet(session, {
+      audience: `${this.issuer}me/`,
+      scope: "create:me:authentication_methods"
+    });
+
+    if (tokenError) {
+      throw new PasskeyEnrollmentChallengeError(
+        "access_token_error",
+        tokenError.message
+      );
+    }
+
+    const { tokenSet } = tokenSetResponse;
+    const accessToken = tokenSet.accessToken;
+
+    if (!accessToken) {
+      throw new PasskeyEnrollmentChallengeError(
+        "missing_access_token",
+        "Could not obtain an access token for the MyAccount API."
+      );
+    }
+
+    const url = new URL(
+      "/me/v1/authentication-methods",
+      this.issuer
+    ).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Authorization", `Bearer ${accessToken}`);
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify({ type: "passkey" }),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to get passkey enrollment challenge"
+        }));
+        throw new PasskeyEnrollmentChallengeError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description ||
+            "Failed to get passkey enrollment challenge",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+
+      const location = response.headers.get("location") ?? "";
+      const authenticationMethodId = location.split("/").pop() ?? "";
+
+      if (!authenticationMethodId) {
+        throw new PasskeyEnrollmentChallengeError(
+          "missing_location_header",
+          "Auth0 did not return a Location header with the authentication method ID."
+        );
+      }
+
+      const result = await response.json();
+      return {
+        authenticationMethodId,
+        authSession: result.auth_session,
+        authnParamsPublicKey: result.authn_params_public_key
+      };
+    } catch (e) {
+      if (e instanceof PasskeyEnrollmentChallengeError) throw e;
+      throw new PasskeyEnrollmentChallengeError(
+        "unexpected_error",
+        "Unexpected error during passkey enrollment challenge",
+        undefined
+      );
+    }
+  }
+
+  /**
+   * Complete a passkey enrollment by verifying the newly created credential.
+   * Calls Auth0 MyAccount API POST /me/v1/authentication-methods/{id}/verify.
+   */
+  async passkeyEnrollVerify(
+    options: PasskeyEnrollVerifyOptions,
+    req?: NextRequest
+  ): Promise<PasskeyAuthenticationMethod> {
+    const { error: sessionError, session } =
+      await this.getSessionWithDomainCheck(
+        req
+          ? req.cookies
+          : await import("next/headers.js").then((m) => m.cookies())
+      );
+
+    if (sessionError || !session) {
+      throw new PasskeyEnrollVerifyError(
+        "not_authenticated",
+        "The user does not have an active session."
+      );
+    }
+
+    const [tokenError, tokenSetResponse] = await this.getTokenSet(session, {
+      audience: `${this.issuer}me/`,
+      scope: "create:me:authentication_methods"
+    });
+
+    if (tokenError) {
+      throw new PasskeyEnrollVerifyError(
+        "access_token_error",
+        tokenError.message
+      );
+    }
+
+    const { tokenSet } = tokenSetResponse;
+    const accessToken = tokenSet.accessToken;
+
+    if (!accessToken) {
+      throw new PasskeyEnrollVerifyError(
+        "missing_access_token",
+        "Could not obtain an access token for the MyAccount API."
+      );
+    }
+
+    const url = new URL(
+      `/me/v1/authentication-methods/${options.authenticationMethodId}/verify`,
+      this.issuer
+    ).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Authorization", `Bearer ${accessToken}`);
+    httpOptions.headers.set("Content-Type", "application/json");
+
+    const body = {
+      auth_session: options.authSession,
+      authn_response: options.authResponse
+    };
+
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error: "unknown_error",
+          error_description: "Failed to verify passkey enrollment"
+        }));
+        throw new PasskeyEnrollVerifyError(
+          errorBody.error || "unknown_error",
+          errorBody.error_description || "Failed to verify passkey enrollment",
+          errorBody.error ? errorBody : undefined
+        );
+      }
+
+      const result = await response.json();
+      return {
+        id: result.id,
+        type: result.type,
+        name: result.name,
+        createdAt: result.created_at,
+        lastAuthenticatedAt: result.last_authenticated_at
+      };
+    } catch (e) {
+      if (e instanceof PasskeyEnrollVerifyError) throw e;
+      throw new PasskeyEnrollVerifyError(
+        "unexpected_error",
+        "Unexpected error during passkey enrollment verification",
+        undefined
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Passkey route handlers
+  // ---------------------------------------------------------------------------
+
+  async handlePasskeySignupChallenge(req: NextRequest): Promise<NextResponse> {
+    try {
+      const body = await parseJsonBody(req);
+      const bodyRecord = body as Record<string, any>;
+      const options: PasskeySignupChallengeOptions = {};
+      if (typeof bodyRecord.userDisplayName === "string") {
+        options.userDisplayName = bodyRecord.userDisplayName;
+      }
+      const challenge = await this.passkeySignupChallenge(options);
+      return NextResponse.json(challenge);
+    } catch (e) {
+      if (e instanceof PasskeySignupChallengeError) {
+        if (e.error === "unexpected_error") {
+          return NextResponse.json(
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
+            { status: 500 }
+          );
+        }
+        return NextResponse.json(e.toJSON(), { status: 400 });
+      }
+      if (e instanceof SdkError) {
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json(
+        { error: "server_error", error_description: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  async handlePasskeyLoginChallenge(req: NextRequest): Promise<NextResponse> {
+    try {
+      const body = await parseJsonBody(req);
+      const bodyRecord = body as Record<string, any>;
+      const options: PasskeyLoginChallengeOptions = {};
+      if (typeof bodyRecord.username === "string") {
+        options.username = bodyRecord.username;
+      }
+      const challenge = await this.passkeyLoginChallenge(options);
+      return NextResponse.json(challenge);
+    } catch (e) {
+      if (e instanceof PasskeyLoginChallengeError) {
+        if (e.error === "unexpected_error") {
+          return NextResponse.json(
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
+            { status: 500 }
+          );
+        }
+        return NextResponse.json(e.toJSON(), { status: 400 });
+      }
+      if (e instanceof SdkError) {
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json(
+        { error: "server_error", error_description: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  async handlePasskeyVerify(req: NextRequest): Promise<NextResponse> {
+    try {
+      const body = await parseJsonBody(req);
+      const bodyRecord = body as Record<string, any>;
+
+      const authSession = validateStringFieldAndThrow(
+        bodyRecord.authSession,
+        "authSession"
+      );
+      if (
+        !bodyRecord.authResponse ||
+        typeof bodyRecord.authResponse !== "object"
+      ) {
+        return NextResponse.json(
+          {
+            error: "invalid_request",
+            error_description: "authResponse is required"
+          },
+          { status: 400 }
+        );
+      }
+
+      const options: PasskeyVerifyOptions = {
+        authSession,
+        authResponse: bodyRecord.authResponse
+      };
+
+      const res = NextResponse.json({ success: true });
+      await this.passkeyVerify(options, req.cookies, res.cookies);
+      addCacheControlHeadersForSession(res);
+      return res;
+    } catch (e) {
+      if (e instanceof PasskeyVerifyError) {
+        const serverErrorCodes = new Set([
+          "discovery_error",
+          "unexpected_error"
+        ]);
+        if (serverErrorCodes.has(e.error)) {
+          return NextResponse.json(
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
+            { status: 500 }
+          );
+        }
+        return NextResponse.json(e.toJSON(), { status: 403 });
+      }
+      if (e instanceof SdkError) {
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json(
+        { error: "server_error", error_description: "Internal server error" },
+        { status: 500 }
+      );
+    }
   }
 
   /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -644,12 +644,12 @@ export class AuthClient {
       method === "POST" &&
       sanitizedPathname === this.routes.passkeyRegister
     ) {
-      return this.handlePasskeySignupChallenge(req);
+      return this.handlePasskeyRegister(req);
     } else if (
       method === "POST" &&
       sanitizedPathname === this.routes.passkeyChallenge
     ) {
-      return this.handlePasskeyLoginChallenge(req);
+      return this.handlePasskeyChallenge(req);
     } else if (
       method === "POST" &&
       sanitizedPathname === this.routes.passkeyGetToken
@@ -4196,7 +4196,7 @@ export class AuthClient {
   // Passkey route handlers
   // ---------------------------------------------------------------------------
 
-  async handlePasskeySignupChallenge(req: NextRequest): Promise<NextResponse> {
+  async handlePasskeyRegister(req: NextRequest): Promise<NextResponse> {
     try {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
@@ -4242,7 +4242,7 @@ export class AuthClient {
     }
   }
 
-  async handlePasskeyLoginChallenge(req: NextRequest): Promise<NextResponse> {
+  async handlePasskeyChallenge(req: NextRequest): Promise<NextResponse> {
     try {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -34,9 +34,9 @@ import {
   MissingStateError,
   MyAccountApiError,
   OAuth2Error,
-  PasskeyLoginChallengeError,
-  PasskeySignupChallengeError,
-  PasskeyVerifyError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
+  PasskeyRegisterError,
   PasswordlessStartError,
   PasswordlessVerifyError,
   SdkError
@@ -74,10 +74,11 @@ import {
   LogoutStrategy,
   LogoutToken,
   MfaVerifyResponse,
+  PasskeyChallengeOptions,
   PasskeyChallengeResponse,
-  PasskeyLoginChallengeOptions,
-  PasskeySignupChallengeOptions,
-  PasskeyVerifyOptions,
+  PasskeyGetTokenOptions,
+  PasskeyRegisterOptions,
+  PasskeyRegisterResponse,
   PasswordlessStartOptions,
   PasswordlessVerifyOptions,
   PasswordlessVerifyTokenResponse,
@@ -148,7 +149,10 @@ import {
 } from "../utils/token-set-helpers.js";
 import { isUrl, toSafeRedirect } from "../utils/url-helpers.js";
 import type { AuthClientProvider } from "./auth-client-provider.js";
-import { addCacheControlHeadersForSession } from "./cookies.js";
+import {
+  addCacheControlHeadersForSession,
+  type ReadonlyRequestCookies
+} from "./cookies.js";
 import { DiscoveryCache } from "./discovery-cache.js";
 import {
   AccessTokenFactory,
@@ -243,9 +247,9 @@ export interface Routes {
   mfaAssociate: string;
   passwordlessStart: string;
   passwordlessVerify: string;
-  passkeySignupChallenge: string;
-  passkeyLoginChallenge: string;
-  passkeyVerify: string;
+  passkeyRegister: string;
+  passkeyChallenge: string;
+  passkeyGetToken: string;
 }
 export type RoutesOptions = Partial<Routes>;
 
@@ -638,19 +642,19 @@ export class AuthClient {
       return this.handlePasswordlessVerify(req);
     } else if (
       method === "POST" &&
-      sanitizedPathname === this.routes.passkeySignupChallenge
+      sanitizedPathname === this.routes.passkeyRegister
     ) {
       return this.handlePasskeySignupChallenge(req);
     } else if (
       method === "POST" &&
-      sanitizedPathname === this.routes.passkeyLoginChallenge
+      sanitizedPathname === this.routes.passkeyChallenge
     ) {
       return this.handlePasskeyLoginChallenge(req);
     } else if (
       method === "POST" &&
-      sanitizedPathname === this.routes.passkeyVerify
+      sanitizedPathname === this.routes.passkeyGetToken
     ) {
-      return this.handlePasskeyVerify(req);
+      return this.handlePasskeyGetToken(req);
     } else if (sanitizedPathname.startsWith("/me/")) {
       return this.handleMyAccount(req);
     } else if (sanitizedPathname.startsWith("/my-org/")) {
@@ -3890,9 +3894,9 @@ export class AuthClient {
    * Request a WebAuthn credential creation challenge for new user signup.
    * Calls Auth0 POST /passkey/register.
    */
-  async passkeySignupChallenge(
-    options?: PasskeySignupChallengeOptions
-  ): Promise<PasskeyChallengeResponse> {
+  async passkeyRegister(
+    options?: PasskeyRegisterOptions
+  ): Promise<PasskeyRegisterResponse> {
     const url = new URL("/passkey/register", this.issuer).toString();
     const httpOptions = this.httpOptions();
     httpOptions.headers.set("Content-Type", "application/json");
@@ -3915,9 +3919,9 @@ export class AuthClient {
     if (options?.familyName) userProfile.family_name = options.familyName;
     if (options?.nickname) userProfile.nickname = options.nickname;
     if (options?.picture) userProfile.picture = options.picture;
-    if (options?.userMetadata) userProfile.user_metadata = options.userMetadata;
     body.user_profile = userProfile;
 
+    if (options?.userMetadata) body.user_metadata = options.userMetadata;
     if (options?.connection) body.realm = options.connection;
     if (options?.organization) body.organization = options.organization;
 
@@ -3933,7 +3937,7 @@ export class AuthClient {
           error: "unknown_error",
           error_description: "Failed to get passkey signup challenge"
         }));
-        throw new PasskeySignupChallengeError(
+        throw new PasskeyRegisterError(
           errorBody.error || "unknown_error",
           errorBody.error_description ||
             "Failed to get passkey signup challenge",
@@ -3947,8 +3951,8 @@ export class AuthClient {
         authnParamsPublicKey: result.authn_params_public_key
       };
     } catch (e) {
-      if (e instanceof PasskeySignupChallengeError) throw e;
-      throw new PasskeySignupChallengeError(
+      if (e instanceof PasskeyRegisterError) throw e;
+      throw new PasskeyRegisterError(
         "unexpected_error",
         "Unexpected error during passkey signup challenge",
         undefined
@@ -3960,8 +3964,8 @@ export class AuthClient {
    * Request a WebAuthn credential assertion challenge for login.
    * Calls Auth0 POST /passkey/challenge.
    */
-  async passkeyLoginChallenge(
-    options?: PasskeyLoginChallengeOptions
+  async passkeyChallenge(
+    options?: PasskeyChallengeOptions
   ): Promise<PasskeyChallengeResponse> {
     const url = new URL("/passkey/challenge", this.issuer).toString();
     const httpOptions = this.httpOptions();
@@ -3975,7 +3979,6 @@ export class AuthClient {
       body.client_secret = this.clientSecret;
     }
 
-    if (options?.username) body.username = options.username;
     if (options?.connection) body.realm = options.connection;
     if (options?.organization) body.organization = options.organization;
 
@@ -3991,7 +3994,7 @@ export class AuthClient {
           error: "unknown_error",
           error_description: "Failed to get passkey login challenge"
         }));
-        throw new PasskeyLoginChallengeError(
+        throw new PasskeyChallengeError(
           errorBody.error || "unknown_error",
           errorBody.error_description ||
             "Failed to get passkey login challenge",
@@ -4005,8 +4008,8 @@ export class AuthClient {
         authnParamsPublicKey: result.authn_params_public_key
       };
     } catch (e) {
-      if (e instanceof PasskeyLoginChallengeError) throw e;
-      throw new PasskeyLoginChallengeError(
+      if (e instanceof PasskeyChallengeError) throw e;
+      throw new PasskeyChallengeError(
         "unexpected_error",
         "Unexpected error during passkey login challenge",
         undefined
@@ -4018,9 +4021,9 @@ export class AuthClient {
    * Complete a passkey signup or login by exchanging the WebAuthn assertion for a session.
    * Calls Auth0 POST /oauth/token with the WebAuthn grant type.
    */
-  async passkeyVerify(
-    options: PasskeyVerifyOptions,
-    reqCookies: RequestCookies,
+  async passkeyGetToken(
+    options: PasskeyGetTokenOptions,
+    reqCookies: RequestCookies | ReadonlyRequestCookies,
     resCookies: ResponseCookies
   ): Promise<void> {
     await this.ensureDpopValidated();
@@ -4029,7 +4032,7 @@ export class AuthClient {
       await this.discoverAuthorizationServerMetadata();
 
     if (discoveryError) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "discovery_error",
         "Failed to discover authorization server metadata",
         undefined
@@ -4044,9 +4047,10 @@ export class AuthClient {
 
     // Auth0's passkey token endpoint requires a JSON body because authn_response
     // is a nested object — URLSearchParams would stringify it, causing a 400.
+    // This means we cannot use oauth.genericTokenEndpointRequest (which only
+    // sends URLSearchParams), so DPoP must be attached manually via the handle's
+    // internal addProof method.
     const tokenUrl = new URL("/oauth/token", this.issuer).toString();
-    const httpOptions = this.httpOptions();
-    httpOptions.headers.set("Content-Type", "application/json");
 
     const jsonBody: Record<string, unknown> = {
       grant_type: GRANT_TYPE_PASSKEY,
@@ -4062,38 +4066,73 @@ export class AuthClient {
     if (options.connection) jsonBody.realm = options.connection;
     if (options.organization) jsonBody.organization = options.organization;
 
+    // Create DPoP handle once outside the retry closure so the handle can
+    // learn and reuse the server-issued nonce across attempts (RFC 9449).
+    const dpopHandle =
+      this.useDPoP && this.dpopKeyPair
+        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
+        : undefined;
+
     let tokenEndpointResponse: oauth.TokenEndpointResponse;
     try {
-      const httpResponse = await this.fetch(tokenUrl, {
-        method: "POST",
-        body: JSON.stringify(jsonBody),
-        ...httpOptions
-      });
+      tokenEndpointResponse = await withDPoPNonceRetry(
+        async () => {
+          const httpOptions = this.httpOptions();
+          httpOptions.headers.set("Content-Type", "application/json");
 
-      if (!httpResponse.ok) {
-        const errBody = await httpResponse.json().catch(() => ({}));
-        throw Object.assign(
-          new Error(errBody.error_description || "token request failed"),
-          errBody
-        );
-      }
+          const url = new URL(tokenUrl);
 
-      tokenEndpointResponse = await oauth.processGenericTokenEndpointResponse(
-        authorizationServerMetadata,
-        this.clientMetadata,
-        httpResponse
+          // oauth4webapi does not expose addProof/cacheNonce publicly, but they
+          // are the only way to attach a DPoP proof to a manually-built JSON
+          // request (genericTokenEndpointRequest only sends URLSearchParams).
+          if (dpopHandle) {
+            await (dpopHandle as any).addProof(
+              url,
+              httpOptions.headers,
+              "POST"
+            );
+          }
+
+          const httpResponse = await this.fetch(tokenUrl, {
+            method: "POST",
+            body: JSON.stringify(jsonBody),
+            ...httpOptions
+          });
+
+          // Let the handle learn the server-issued nonce from the response so
+          // it can be included in the next attempt's proof (RFC 9449 §8).
+          // Must happen before processGenericTokenEndpointResponse consumes
+          // the body, and before the retry check so the nonce is available on
+          // the next attempt even when the response is an error.
+          if (dpopHandle) {
+            (dpopHandle as any).cacheNonce(httpResponse, url);
+          }
+
+          // Let oauth4webapi process the response — this throws a
+          // ResponseBodyError for error responses (including use_dpop_nonce),
+          // which withDPoPNonceRetry can detect and retry on.
+          return oauth.processGenericTokenEndpointResponse(
+            authorizationServerMetadata,
+            this.clientMetadata,
+            httpResponse
+          );
+        },
+        {
+          isDPoPEnabled: !!dpopHandle,
+          ...this.dpopOptions?.retry
+        }
       );
     } catch (err: any) {
       if (err?.code === oauth.JWT_CLAIM_COMPARISON) {
         const claim = (err.cause as any)?.claim;
         if (claim === "iss") {
-          throw new PasskeyVerifyError(
+          throw new PasskeyGetTokenError(
             "invalid_issuer",
             "ID token issuer mismatch. Check AUTH0_DOMAIN configuration."
           );
         }
         if (claim === "aud") {
-          throw new PasskeyVerifyError(
+          throw new PasskeyGetTokenError(
             "invalid_audience",
             "ID token audience mismatch. Check AUTH0_CLIENT_ID configuration."
           );
@@ -4101,7 +4140,7 @@ export class AuthClient {
       }
 
       const oauthErr = await extractOAuthErrorDetails(err);
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         oauthErr.error || "unknown_error",
         oauthErr.error_description ||
           err.message ||
@@ -4116,9 +4155,9 @@ export class AuthClient {
     }
 
     if (!tokenEndpointResponse.id_token) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "missing_id_token",
-        "No id_token in passkey verify response. Ensure 'openid' scope is requested."
+        "No id_token in passkey get-token response. Ensure 'openid' scope is requested."
       );
     }
 
@@ -4161,7 +4200,7 @@ export class AuthClient {
     try {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
-      const options: PasskeySignupChallengeOptions = {};
+      const options: PasskeyRegisterOptions = {};
       if (bodyRecord.email) options.email = bodyRecord.email;
       if (bodyRecord.username) options.username = bodyRecord.username;
       if (bodyRecord.phoneNumber) options.phoneNumber = bodyRecord.phoneNumber;
@@ -4175,10 +4214,10 @@ export class AuthClient {
       if (bodyRecord.connection) options.connection = bodyRecord.connection;
       if (bodyRecord.organization)
         options.organization = bodyRecord.organization;
-      const challenge = await this.passkeySignupChallenge(options);
+      const challenge = await this.passkeyRegister(options);
       return NextResponse.json(challenge);
     } catch (e) {
-      if (e instanceof PasskeySignupChallengeError) {
+      if (e instanceof PasskeyRegisterError) {
         if (e.error === "unexpected_error") {
           return NextResponse.json(
             {
@@ -4207,17 +4246,15 @@ export class AuthClient {
     try {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
-      const options: PasskeyLoginChallengeOptions = {};
-      if (typeof bodyRecord.username === "string")
-        options.username = bodyRecord.username;
+      const options: PasskeyChallengeOptions = {};
       if (typeof bodyRecord.connection === "string")
         options.connection = bodyRecord.connection;
       if (typeof bodyRecord.organization === "string")
         options.organization = bodyRecord.organization;
-      const challenge = await this.passkeyLoginChallenge(options);
+      const challenge = await this.passkeyChallenge(options);
       return NextResponse.json(challenge);
     } catch (e) {
-      if (e instanceof PasskeyLoginChallengeError) {
+      if (e instanceof PasskeyChallengeError) {
         if (e.error === "unexpected_error") {
           return NextResponse.json(
             {
@@ -4242,7 +4279,7 @@ export class AuthClient {
     }
   }
 
-  async handlePasskeyVerify(req: NextRequest): Promise<NextResponse> {
+  async handlePasskeyGetToken(req: NextRequest): Promise<NextResponse> {
     try {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
@@ -4264,7 +4301,7 @@ export class AuthClient {
         );
       }
 
-      const options: PasskeyVerifyOptions = {
+      const options: PasskeyGetTokenOptions = {
         authSession,
         authResponse: bodyRecord.authResponse
       };
@@ -4274,11 +4311,11 @@ export class AuthClient {
         options.organization = bodyRecord.organization;
 
       const res = NextResponse.json({ success: true });
-      await this.passkeyVerify(options, req.cookies, res.cookies);
+      await this.passkeyGetToken(options, req.cookies, res.cookies);
       addCacheControlHeadersForSession(res);
       return res;
     } catch (e) {
-      if (e instanceof PasskeyVerifyError) {
+      if (e instanceof PasskeyGetTokenError) {
         const serverErrorCodes = new Set([
           "discovery_error",
           "unexpected_error"

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -34,8 +34,6 @@ import {
   MissingStateError,
   MyAccountApiError,
   OAuth2Error,
-  PasskeyEnrollmentChallengeError,
-  PasskeyEnrollVerifyError,
   PasskeyLoginChallengeError,
   PasskeySignupChallengeError,
   PasskeyVerifyError,
@@ -76,10 +74,7 @@ import {
   LogoutStrategy,
   LogoutToken,
   MfaVerifyResponse,
-  PasskeyAuthenticationMethod,
   PasskeyChallengeResponse,
-  PasskeyEnrollmentChallengeResponse,
-  PasskeyEnrollVerifyOptions,
   PasskeyLoginChallengeOptions,
   PasskeySignupChallengeOptions,
   PasskeyVerifyOptions,
@@ -3910,9 +3905,21 @@ export class AuthClient {
       body.client_secret = this.clientSecret;
     }
 
-    if (options?.userDisplayName) {
-      body.user_display_name = options.userDisplayName;
-    }
+    // Build user_profile from provided identity fields
+    const userProfile: Record<string, unknown> = {};
+    if (options?.name) userProfile.name = options.name;
+    if (options?.email) userProfile.email = options.email;
+    if (options?.username) userProfile.username = options.username;
+    if (options?.phoneNumber) userProfile.phone_number = options.phoneNumber;
+    if (options?.givenName) userProfile.given_name = options.givenName;
+    if (options?.familyName) userProfile.family_name = options.familyName;
+    if (options?.nickname) userProfile.nickname = options.nickname;
+    if (options?.picture) userProfile.picture = options.picture;
+    if (options?.userMetadata) userProfile.user_metadata = options.userMetadata;
+    body.user_profile = userProfile;
+
+    if (options?.connection) body.realm = options.connection;
+    if (options?.organization) body.organization = options.organization;
 
     try {
       const response = await this.fetch(url, {
@@ -3968,9 +3975,9 @@ export class AuthClient {
       body.client_secret = this.clientSecret;
     }
 
-    if (options?.username) {
-      body.username = options.username;
-    }
+    if (options?.username) body.username = options.username;
+    if (options?.connection) body.realm = options.connection;
+    if (options?.organization) body.organization = options.organization;
 
     try {
       const response = await this.fetch(url, {
@@ -4029,56 +4036,52 @@ export class AuthClient {
       );
     }
 
-    const params = new URLSearchParams();
-    params.append("auth_session", options.authSession);
-    params.append("authn_response", JSON.stringify(options.authResponse));
-
     const scope =
       getScopeForAudience(
         this.authorizationParameters.scope,
         this.authorizationParameters.audience
       ) || DEFAULT_SCOPES;
-    params.append("scope", scope);
 
-    if (this.authorizationParameters.audience) {
-      params.append(
-        "audience",
-        this.authorizationParameters.audience as string
-      );
-    }
+    // Auth0's passkey token endpoint requires a JSON body because authn_response
+    // is a nested object — URLSearchParams would stringify it, causing a 400.
+    const tokenUrl = new URL("/oauth/token", this.issuer).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
 
-    const dpopHandle =
-      this.useDPoP && this.dpopKeyPair
-        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
-        : undefined;
+    const jsonBody: Record<string, unknown> = {
+      grant_type: GRANT_TYPE_PASSKEY,
+      client_id: this.clientMetadata.client_id,
+      auth_session: options.authSession,
+      authn_response: options.authResponse,
+      scope
+    };
+
+    if (this.clientSecret) jsonBody.client_secret = this.clientSecret;
+    if (this.authorizationParameters.audience)
+      jsonBody.audience = this.authorizationParameters.audience;
+    if (options.connection) jsonBody.realm = options.connection;
+    if (options.organization) jsonBody.organization = options.organization;
 
     let tokenEndpointResponse: oauth.TokenEndpointResponse;
     try {
-      tokenEndpointResponse = await withDPoPNonceRetry(
-        async () => {
-          const httpResponse = await oauth.genericTokenEndpointRequest(
-            authorizationServerMetadata,
-            this.clientMetadata,
-            await this.getClientAuth(),
-            GRANT_TYPE_PASSKEY,
-            params,
-            {
-              ...this.httpOptions(),
-              [oauth.customFetch]: this.fetch,
-              [oauth.allowInsecureRequests]: this.allowInsecureRequests,
-              ...(dpopHandle && { DPoP: dpopHandle })
-            }
-          );
-          return oauth.processGenericTokenEndpointResponse(
-            authorizationServerMetadata,
-            this.clientMetadata,
-            httpResponse
-          );
-        },
-        {
-          isDPoPEnabled: !!(this.useDPoP && this.dpopKeyPair),
-          ...this.dpopOptions?.retry
-        }
+      const httpResponse = await this.fetch(tokenUrl, {
+        method: "POST",
+        body: JSON.stringify(jsonBody),
+        ...httpOptions
+      });
+
+      if (!httpResponse.ok) {
+        const errBody = await httpResponse.json().catch(() => ({}));
+        throw Object.assign(
+          new Error(errBody.error_description || "token request failed"),
+          errBody
+        );
+      }
+
+      tokenEndpointResponse = await oauth.processGenericTokenEndpointResponse(
+        authorizationServerMetadata,
+        this.clientMetadata,
+        httpResponse
       );
     } catch (err: any) {
       if (err?.code === oauth.JWT_CLAIM_COMPARISON) {
@@ -4150,198 +4153,6 @@ export class AuthClient {
     await this.sessionStore.set(reqCookies, resCookies, session, true);
   }
 
-  /**
-   * Request a WebAuthn credential creation challenge for enrolling a new passkey
-   * on an existing authenticated account.
-   * Calls Auth0 MyAccount API POST /me/v1/authentication-methods.
-   */
-  async passkeyEnrollmentChallenge(
-    req?: NextRequest
-  ): Promise<PasskeyEnrollmentChallengeResponse> {
-    const { error: sessionError, session } =
-      await this.getSessionWithDomainCheck(
-        req
-          ? req.cookies
-          : await import("next/headers.js").then((m) => m.cookies())
-      );
-
-    if (sessionError || !session) {
-      throw new PasskeyEnrollmentChallengeError(
-        "not_authenticated",
-        "The user does not have an active session."
-      );
-    }
-
-    const [tokenError, tokenSetResponse] = await this.getTokenSet(session, {
-      audience: `${this.issuer}me/`,
-      scope: "create:me:authentication_methods"
-    });
-
-    if (tokenError) {
-      throw new PasskeyEnrollmentChallengeError(
-        "access_token_error",
-        tokenError.message
-      );
-    }
-
-    const { tokenSet } = tokenSetResponse;
-    const accessToken = tokenSet.accessToken;
-
-    if (!accessToken) {
-      throw new PasskeyEnrollmentChallengeError(
-        "missing_access_token",
-        "Could not obtain an access token for the MyAccount API."
-      );
-    }
-
-    const url = new URL(
-      "/me/v1/authentication-methods",
-      this.issuer
-    ).toString();
-    const httpOptions = this.httpOptions();
-    httpOptions.headers.set("Authorization", `Bearer ${accessToken}`);
-    httpOptions.headers.set("Content-Type", "application/json");
-
-    try {
-      const response = await this.fetch(url, {
-        method: "POST",
-        body: JSON.stringify({ type: "passkey" }),
-        ...httpOptions
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({
-          error: "unknown_error",
-          error_description: "Failed to get passkey enrollment challenge"
-        }));
-        throw new PasskeyEnrollmentChallengeError(
-          errorBody.error || "unknown_error",
-          errorBody.error_description ||
-            "Failed to get passkey enrollment challenge",
-          errorBody.error ? errorBody : undefined
-        );
-      }
-
-      const location = response.headers.get("location") ?? "";
-      const authenticationMethodId = location.split("/").pop() ?? "";
-
-      if (!authenticationMethodId) {
-        throw new PasskeyEnrollmentChallengeError(
-          "missing_location_header",
-          "Auth0 did not return a Location header with the authentication method ID."
-        );
-      }
-
-      const result = await response.json();
-      return {
-        authenticationMethodId,
-        authSession: result.auth_session,
-        authnParamsPublicKey: result.authn_params_public_key
-      };
-    } catch (e) {
-      if (e instanceof PasskeyEnrollmentChallengeError) throw e;
-      throw new PasskeyEnrollmentChallengeError(
-        "unexpected_error",
-        "Unexpected error during passkey enrollment challenge",
-        undefined
-      );
-    }
-  }
-
-  /**
-   * Complete a passkey enrollment by verifying the newly created credential.
-   * Calls Auth0 MyAccount API POST /me/v1/authentication-methods/{id}/verify.
-   */
-  async passkeyEnrollVerify(
-    options: PasskeyEnrollVerifyOptions,
-    req?: NextRequest
-  ): Promise<PasskeyAuthenticationMethod> {
-    const { error: sessionError, session } =
-      await this.getSessionWithDomainCheck(
-        req
-          ? req.cookies
-          : await import("next/headers.js").then((m) => m.cookies())
-      );
-
-    if (sessionError || !session) {
-      throw new PasskeyEnrollVerifyError(
-        "not_authenticated",
-        "The user does not have an active session."
-      );
-    }
-
-    const [tokenError, tokenSetResponse] = await this.getTokenSet(session, {
-      audience: `${this.issuer}me/`,
-      scope: "create:me:authentication_methods"
-    });
-
-    if (tokenError) {
-      throw new PasskeyEnrollVerifyError(
-        "access_token_error",
-        tokenError.message
-      );
-    }
-
-    const { tokenSet } = tokenSetResponse;
-    const accessToken = tokenSet.accessToken;
-
-    if (!accessToken) {
-      throw new PasskeyEnrollVerifyError(
-        "missing_access_token",
-        "Could not obtain an access token for the MyAccount API."
-      );
-    }
-
-    const url = new URL(
-      `/me/v1/authentication-methods/${options.authenticationMethodId}/verify`,
-      this.issuer
-    ).toString();
-    const httpOptions = this.httpOptions();
-    httpOptions.headers.set("Authorization", `Bearer ${accessToken}`);
-    httpOptions.headers.set("Content-Type", "application/json");
-
-    const body = {
-      auth_session: options.authSession,
-      authn_response: options.authResponse
-    };
-
-    try {
-      const response = await this.fetch(url, {
-        method: "POST",
-        body: JSON.stringify(body),
-        ...httpOptions
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({
-          error: "unknown_error",
-          error_description: "Failed to verify passkey enrollment"
-        }));
-        throw new PasskeyEnrollVerifyError(
-          errorBody.error || "unknown_error",
-          errorBody.error_description || "Failed to verify passkey enrollment",
-          errorBody.error ? errorBody : undefined
-        );
-      }
-
-      const result = await response.json();
-      return {
-        id: result.id,
-        type: result.type,
-        name: result.name,
-        createdAt: result.created_at,
-        lastAuthenticatedAt: result.last_authenticated_at
-      };
-    } catch (e) {
-      if (e instanceof PasskeyEnrollVerifyError) throw e;
-      throw new PasskeyEnrollVerifyError(
-        "unexpected_error",
-        "Unexpected error during passkey enrollment verification",
-        undefined
-      );
-    }
-  }
-
   // ---------------------------------------------------------------------------
   // Passkey route handlers
   // ---------------------------------------------------------------------------
@@ -4351,9 +4162,19 @@ export class AuthClient {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
       const options: PasskeySignupChallengeOptions = {};
-      if (typeof bodyRecord.userDisplayName === "string") {
-        options.userDisplayName = bodyRecord.userDisplayName;
-      }
+      if (bodyRecord.email) options.email = bodyRecord.email;
+      if (bodyRecord.username) options.username = bodyRecord.username;
+      if (bodyRecord.phoneNumber) options.phoneNumber = bodyRecord.phoneNumber;
+      if (bodyRecord.name) options.name = bodyRecord.name;
+      if (bodyRecord.givenName) options.givenName = bodyRecord.givenName;
+      if (bodyRecord.familyName) options.familyName = bodyRecord.familyName;
+      if (bodyRecord.nickname) options.nickname = bodyRecord.nickname;
+      if (bodyRecord.picture) options.picture = bodyRecord.picture;
+      if (bodyRecord.userMetadata)
+        options.userMetadata = bodyRecord.userMetadata;
+      if (bodyRecord.connection) options.connection = bodyRecord.connection;
+      if (bodyRecord.organization)
+        options.organization = bodyRecord.organization;
       const challenge = await this.passkeySignupChallenge(options);
       return NextResponse.json(challenge);
     } catch (e) {
@@ -4387,9 +4208,12 @@ export class AuthClient {
       const body = await parseJsonBody(req);
       const bodyRecord = body as Record<string, any>;
       const options: PasskeyLoginChallengeOptions = {};
-      if (typeof bodyRecord.username === "string") {
+      if (typeof bodyRecord.username === "string")
         options.username = bodyRecord.username;
-      }
+      if (typeof bodyRecord.connection === "string")
+        options.connection = bodyRecord.connection;
+      if (typeof bodyRecord.organization === "string")
+        options.organization = bodyRecord.organization;
       const challenge = await this.passkeyLoginChallenge(options);
       return NextResponse.json(challenge);
     } catch (e) {
@@ -4444,6 +4268,10 @@ export class AuthClient {
         authSession,
         authResponse: bodyRecord.authResponse
       };
+      if (typeof bodyRecord.connection === "string")
+        options.connection = bodyRecord.connection;
+      if (typeof bodyRecord.organization === "string")
+        options.organization = bodyRecord.organization;
 
       const res = NextResponse.json({ success: true });
       await this.passkeyVerify(options, req.cookies, res.cookies);

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -64,6 +64,7 @@ import {
   toNextResponse,
   toUrlFromPagesRouter
 } from "./next-compat.js";
+import { ServerPasskeyClient } from "./passkey/server-passkey-client.js";
 import { ServerPasswordlessClient } from "./passwordless/server-passwordless-client.js";
 import {
   AbstractSessionStore,
@@ -449,6 +450,7 @@ export class Auth0Client {
   private routes: Routes;
   private _mfa?: ServerMfaClient;
   private _passwordless?: ServerPasswordlessClient;
+  private _passkey?: ServerPasskeyClient;
   #options: Auth0ClientOptions;
 
   constructor(options: Auth0ClientOptions = {}) {
@@ -608,6 +610,14 @@ export class Auth0Client {
       passwordlessVerify:
         process.env.NEXT_PUBLIC_PASSWORDLESS_VERIFY_ROUTE ||
         "/auth/passwordless/verify",
+      passkeySignupChallenge:
+        process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
+        "/auth/passkey/signup-challenge",
+      passkeyLoginChallenge:
+        process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
+        "/auth/passkey/login-challenge",
+      passkeyVerify:
+        process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify",
       ...options.routes
     };
 
@@ -1185,6 +1195,19 @@ export class Auth0Client {
       this._passwordless = new ServerPasswordlessClient(this.provider);
     }
     return this._passwordless;
+  }
+
+  /**
+   * Access server-side passkey (WebAuthn) authentication and enrollment operations.
+   *
+   * Authentication: `auth0.passkey.signupChallenge()`, `auth0.passkey.loginChallenge()`, `auth0.passkey.verify()`
+   * Enrollment: `auth0.passkey.enrollmentChallenge()`, `auth0.passkey.enrollVerify()`
+   */
+  get passkey(): ServerPasskeyClient {
+    if (!this._passkey) {
+      this._passkey = new ServerPasskeyClient(this.provider);
+    }
+    return this._passkey;
   }
 
   /**

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -610,14 +610,15 @@ export class Auth0Client {
       passwordlessVerify:
         process.env.NEXT_PUBLIC_PASSWORDLESS_VERIFY_ROUTE ||
         "/auth/passwordless/verify",
-      passkeySignupChallenge:
-        process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
-        "/auth/passkey/signup-challenge",
-      passkeyLoginChallenge:
-        process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
-        "/auth/passkey/login-challenge",
-      passkeyVerify:
-        process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify",
+      passkeyRegister:
+        process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE ||
+        "/auth/passkey/register",
+      passkeyChallenge:
+        process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE ||
+        "/auth/passkey/challenge",
+      passkeyGetToken:
+        process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE ||
+        "/auth/passkey/get-token",
       ...options.routes
     };
 
@@ -1200,8 +1201,8 @@ export class Auth0Client {
   /**
    * Access server-side passkey (WebAuthn) authentication and enrollment operations.
    *
-   * Authentication: `auth0.passkey.signupChallenge()`, `auth0.passkey.loginChallenge()`, `auth0.passkey.verify()`
-   * Enrollment: `auth0.passkey.enrollmentChallenge()`, `auth0.passkey.enrollVerify()`
+   * Authentication: `auth0.passkey.register()`, `auth0.passkey.challenge()`, `auth0.passkey.getToken()`
+   * Enrollment: `auth0.passkey.enrollmentChallenge()`, `auth0.passkey.enrollmentVerify()`
    */
   get passkey(): ServerPasskeyClient {
     if (!this._passkey) {

--- a/src/server/dynamic-base-url.test.ts
+++ b/src/server/dynamic-base-url.test.ts
@@ -24,7 +24,10 @@ const defaultRoutes = {
   mfaVerify: "/auth/mfa/verify",
   mfaAssociate: "/auth/mfa/associate",
   passwordlessStart: "/auth/passwordless/start",
-  passwordlessVerify: "/auth/passwordless/verify"
+  passwordlessVerify: "/auth/passwordless/verify",
+  passkeySignupChallenge: "/auth/passkey/signup-challenge",
+  passkeyLoginChallenge: "/auth/passkey/login-challenge",
+  passkeyVerify: "/auth/passkey/verify"
 };
 
 describe("APP_BASE_URL Configuration", () => {

--- a/src/server/dynamic-base-url.test.ts
+++ b/src/server/dynamic-base-url.test.ts
@@ -25,9 +25,9 @@ const defaultRoutes = {
   mfaAssociate: "/auth/mfa/associate",
   passwordlessStart: "/auth/passwordless/start",
   passwordlessVerify: "/auth/passwordless/verify",
-  passkeySignupChallenge: "/auth/passkey/signup-challenge",
-  passkeyLoginChallenge: "/auth/passkey/login-challenge",
-  passkeyVerify: "/auth/passkey/verify"
+  passkeyRegister: "/auth/passkey/register",
+  passkeyChallenge: "/auth/passkey/challenge",
+  passkeyGetToken: "/auth/passkey/get-token"
 };
 
 describe("APP_BASE_URL Configuration", () => {

--- a/src/server/passkey-server.flow.test.ts
+++ b/src/server/passkey-server.flow.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Flow tests for AuthClient passkey route handlers.
+ * Tests handlePasskeySignupChallenge / handlePasskeyLoginChallenge /
+ * handlePasskeyVerify via authClient.handler() — the full HTTP dispatch layer.
+ *
+ * Core AuthClient passkey method tests live in passkey.flow.test.ts.
+ * ServerPasskeyClient (App/Pages Router overloads) is in
+ * passkey/server-passkey-client.test.ts.
+ */
+import { NextRequest } from "next/server.js";
+import * as jose from "jose";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createAuthorizationServerMetadata,
+  getDefaultRoutes,
+  setupMswLifecycle
+} from "../test/defaults.js";
+import { generateSecret } from "../test/utils.js";
+import { AuthClient } from "./auth-client.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { TransactionStore } from "./transaction-store.js";
+
+const DEFAULT = {
+  domain: "auth0.local",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  sub: "passkeys|test-user-id",
+  sid: "test-sid",
+  authSession: "test-auth-session-token",
+  accessToken: "test-access-token"
+};
+
+const MOCK_AUTH_RESPONSE = {
+  id: "cred-id",
+  rawId: "cred-raw-id",
+  type: "public-key",
+  response: {
+    clientDataJSON: "clientDataJSON-base64url",
+    attestationObject: "attestationObject-base64url"
+  }
+};
+
+let keyPair: jose.GenerateKeyPairResult;
+
+const authorizationServerMetadata = createAuthorizationServerMetadata(
+  DEFAULT.domain
+);
+
+const server = setupServer(
+  http.get(`https://${DEFAULT.domain}/.well-known/openid-configuration`, () =>
+    HttpResponse.json(authorizationServerMetadata)
+  ),
+  http.get(`https://${DEFAULT.domain}/.well-known/jwks.json`, async () => {
+    const jwk = await jose.exportJWK(keyPair.publicKey);
+    return HttpResponse.json({
+      keys: [{ ...jwk, kid: "test-key-1", alg: "RS256", use: "sig" }]
+    });
+  })
+);
+
+setupMswLifecycle(server);
+
+beforeAll(async () => {
+  keyPair = await jose.generateKeyPair("RS256");
+});
+
+describe("AuthClient passkey route handlers", () => {
+  let secret: string;
+  let authClient: AuthClient;
+
+  beforeEach(async () => {
+    secret = await generateSecret(32);
+    const transactionStore = new TransactionStore({ secret });
+    const sessionStore = new StatelessSessionStore({ secret });
+    authClient = new AuthClient({
+      domain: DEFAULT.domain,
+      clientId: DEFAULT.clientId,
+      clientSecret: DEFAULT.clientSecret,
+      appBaseUrl: DEFAULT.appBaseUrl,
+      secret,
+      transactionStore,
+      sessionStore,
+      routes: getDefaultRoutes()
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /auth/passkey/signup-challenge
+  // ---------------------------------------------------------------------------
+
+  describe("POST /auth/passkey/signup-challenge", () => {
+    it("returns 200 with challenge on success", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: { challenge: "signup-abc" }
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.authSession).toBe(DEFAULT.authSession);
+      expect(body.authnParamsPublicKey).toEqual({ challenge: "signup-abc" });
+    });
+
+    it("forwards userDisplayName from request body", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/register`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({ userDisplayName: "Jane Doe" }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      await authClient.handler(req);
+      expect(capturedBody.user_display_name).toBe("Jane Doe");
+    });
+
+    it("returns 400 with Auth0 error details on API failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.json(
+            {
+              error: "passkeys_not_enabled",
+              error_description: "Passkeys are not enabled."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("passkeys_not_enabled");
+      expect(body.error_description).toBe("Passkeys are not enabled.");
+    });
+
+    it("returns 500 on unexpected_error", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.error()
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe("server_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /auth/passkey/login-challenge
+  // ---------------------------------------------------------------------------
+
+  describe("POST /auth/passkey/login-challenge", () => {
+    it("returns 200 with challenge on success", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: { challenge: "login-abc" }
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.authSession).toBe(DEFAULT.authSession);
+      expect(body.authnParamsPublicKey).toEqual({ challenge: "login-abc" });
+    });
+
+    it("forwards username from request body", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/challenge`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({ username: "user@example.com" }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      await authClient.handler(req);
+      expect(capturedBody.username).toBe("user@example.com");
+    });
+
+    it("returns 400 with Auth0 error details on API failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.json(
+            {
+              error: "passkeys_not_enabled",
+              error_description: "Passkeys are not enabled."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("passkeys_not_enabled");
+    });
+
+    it("returns 500 on unexpected_error", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.error()
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe("server_error");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /auth/passkey/verify
+  // ---------------------------------------------------------------------------
+
+  describe("POST /auth/passkey/verify", () => {
+    it("returns 200 with session cookie on successful verify", async () => {
+      const idToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json({
+            access_token: DEFAULT.accessToken,
+            token_type: "Bearer",
+            expires_in: 86400,
+            scope: "openid profile email",
+            id_token: idToken
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(res.headers.get("set-cookie")).toMatch(/__session=/);
+    });
+
+    it("returns 400 for missing authSession", async () => {
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({ authResponse: MOCK_AUTH_RESPONSE }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeTruthy();
+    });
+
+    it("returns 400 for missing authResponse", async () => {
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({ authSession: DEFAULT.authSession }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toBe("authResponse is required");
+    });
+
+    it("returns 403 with error details on invalid_grant from Auth0", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json(
+            {
+              error: "invalid_grant",
+              error_description: "Invalid passkey assertion."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_grant");
+      expect(body.error_description).toBe("Invalid passkey assertion.");
+    });
+
+    it("returns 403 with invalid_issuer when id_token iss does not match domain", async () => {
+      const wrongIdToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer("https://wrong.tenant.auth0.com")
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json({
+            access_token: DEFAULT.accessToken,
+            token_type: "Bearer",
+            expires_in: 86400,
+            id_token: wrongIdToken
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await authClient.handler(req);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_issuer");
+    });
+
+    it("returns 500 on discovery_error", async () => {
+      server.use(
+        http.get(
+          `https://${DEFAULT.domain}/.well-known/openid-configuration`,
+          () => HttpResponse.error()
+        )
+      );
+
+      const freshSecret = await generateSecret(32);
+      const freshClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: freshSecret,
+        transactionStore: new TransactionStore({ secret: freshSecret }),
+        sessionStore: new StatelessSessionStore({ secret: freshSecret }),
+        routes: getDefaultRoutes()
+      });
+
+      const req = new NextRequest(
+        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        {
+          method: "POST",
+          body: JSON.stringify({
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          }),
+          headers: { "Content-Type": "application/json" }
+        }
+      );
+
+      const res = await freshClient.handler(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe("server_error");
+    });
+  });
+});

--- a/src/server/passkey-server.flow.test.ts
+++ b/src/server/passkey-server.flow.test.ts
@@ -119,7 +119,7 @@ describe("AuthClient passkey route handlers", () => {
       expect(body.authnParamsPublicKey).toEqual({ challenge: "signup-abc" });
     });
 
-    it("forwards userDisplayName from request body", async () => {
+    it("forwards user_profile fields from request body", async () => {
       let capturedBody: Record<string, unknown> = {};
 
       server.use(
@@ -139,13 +139,16 @@ describe("AuthClient passkey route handlers", () => {
         new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
         {
           method: "POST",
-          body: JSON.stringify({ userDisplayName: "Jane Doe" }),
+          body: JSON.stringify({ email: "jane@example.com", name: "Jane Doe" }),
           headers: { "Content-Type": "application/json" }
         }
       );
 
       await authClient.handler(req);
-      expect(capturedBody.user_display_name).toBe("Jane Doe");
+      expect(capturedBody.user_profile).toMatchObject({
+        email: "jane@example.com",
+        name: "Jane Doe"
+      });
     });
 
     it("returns 400 with Auth0 error details on API failure", async () => {

--- a/src/server/passkey-server.flow.test.ts
+++ b/src/server/passkey-server.flow.test.ts
@@ -1,7 +1,7 @@
 /**
  * Flow tests for AuthClient passkey route handlers.
  * Tests handlePasskeySignupChallenge / handlePasskeyLoginChallenge /
- * handlePasskeyVerify via authClient.handler() — the full HTTP dispatch layer.
+ * handlePasskeyGetToken via authClient.handler() — the full HTTP dispatch layer.
  *
  * Core AuthClient passkey method tests live in passkey.flow.test.ts.
  * ServerPasskeyClient (App/Pages Router overloads) is in
@@ -89,10 +89,10 @@ describe("AuthClient passkey route handlers", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // POST /auth/passkey/signup-challenge
+  // POST /auth/passkey/register
   // ---------------------------------------------------------------------------
 
-  describe("POST /auth/passkey/signup-challenge", () => {
+  describe("POST /auth/passkey/register", () => {
     it("returns 200 with challenge on success", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
@@ -104,7 +104,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/register", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -136,7 +136,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/register", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({ email: "jane@example.com", name: "Jane Doe" }),
@@ -165,7 +165,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/register", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -188,7 +188,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/signup-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/register", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -204,10 +204,10 @@ describe("AuthClient passkey route handlers", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // POST /auth/passkey/login-challenge
+  // POST /auth/passkey/challenge
   // ---------------------------------------------------------------------------
 
-  describe("POST /auth/passkey/login-challenge", () => {
+  describe("POST /auth/passkey/challenge", () => {
     it("returns 200 with challenge on success", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
@@ -219,7 +219,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/challenge", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -232,35 +232,6 @@ describe("AuthClient passkey route handlers", () => {
       const body = await res.json();
       expect(body.authSession).toBe(DEFAULT.authSession);
       expect(body.authnParamsPublicKey).toEqual({ challenge: "login-abc" });
-    });
-
-    it("forwards username from request body", async () => {
-      let capturedBody: Record<string, unknown> = {};
-
-      server.use(
-        http.post(
-          `https://${DEFAULT.domain}/passkey/challenge`,
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              auth_session: DEFAULT.authSession,
-              authn_params_public_key: {}
-            });
-          }
-        )
-      );
-
-      const req = new NextRequest(
-        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
-        {
-          method: "POST",
-          body: JSON.stringify({ username: "user@example.com" }),
-          headers: { "Content-Type": "application/json" }
-        }
-      );
-
-      await authClient.handler(req);
-      expect(capturedBody.username).toBe("user@example.com");
     });
 
     it("returns 400 with Auth0 error details on API failure", async () => {
@@ -277,7 +248,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/challenge", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -299,7 +270,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/login-challenge", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/challenge", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({}),
@@ -315,10 +286,10 @@ describe("AuthClient passkey route handlers", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // POST /auth/passkey/verify
+  // POST /auth/passkey/get-token
   // ---------------------------------------------------------------------------
 
-  describe("POST /auth/passkey/verify", () => {
+  describe("POST /auth/passkey/get-token", () => {
     it("returns 200 with session cookie on successful verify", async () => {
       const idToken = await new jose.SignJWT({
         sub: DEFAULT.sub,
@@ -344,7 +315,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({
@@ -364,7 +335,7 @@ describe("AuthClient passkey route handlers", () => {
 
     it("returns 400 for missing authSession", async () => {
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({ authResponse: MOCK_AUTH_RESPONSE }),
@@ -380,7 +351,7 @@ describe("AuthClient passkey route handlers", () => {
 
     it("returns 400 for missing authResponse", async () => {
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({ authSession: DEFAULT.authSession }),
@@ -409,7 +380,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({
@@ -451,7 +422,7 @@ describe("AuthClient passkey route handlers", () => {
       );
 
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({
@@ -489,7 +460,7 @@ describe("AuthClient passkey route handlers", () => {
       });
 
       const req = new NextRequest(
-        new URL("/auth/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/auth/passkey/get-token", DEFAULT.appBaseUrl),
         {
           method: "POST",
           body: JSON.stringify({

--- a/src/server/passkey-server.flow.test.ts
+++ b/src/server/passkey-server.flow.test.ts
@@ -1,6 +1,6 @@
 /**
  * Flow tests for AuthClient passkey route handlers.
- * Tests handlePasskeySignupChallenge / handlePasskeyLoginChallenge /
+ * Tests handlePasskeyRegister / handlePasskeyChallenge /
  * handlePasskeyGetToken via authClient.handler() — the full HTTP dispatch layer.
  *
  * Core AuthClient passkey method tests live in passkey.flow.test.ts.

--- a/src/server/passkey.flow.test.ts
+++ b/src/server/passkey.flow.test.ts
@@ -131,9 +131,15 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await authClient.passkeySignupChallenge({ userDisplayName: "Jane Doe" });
+      await authClient.passkeySignupChallenge({
+        email: "jane@example.com",
+        name: "Jane Doe"
+      });
 
-      expect(capturedBody.user_display_name).toBe("Jane Doe");
+      expect(capturedBody.user_profile).toMatchObject({
+        email: "jane@example.com",
+        name: "Jane Doe"
+      });
     });
 
     it("maps snake_case response to camelCase SDK shape", async () => {
@@ -301,7 +307,7 @@ describe("AuthClient passkey methods", () => {
 
   describe("passkeyVerify", () => {
     it("sends auth_session and authn_response to /oauth/token", async () => {
-      let capturedParams: URLSearchParams = new URLSearchParams();
+      let capturedBody: Record<string, unknown> = {};
 
       const idToken = await new jose.SignJWT({
         sub: DEFAULT.sub,
@@ -318,7 +324,7 @@ describe("AuthClient passkey methods", () => {
         http.post(
           `https://${DEFAULT.domain}/oauth/token`,
           async ({ request }) => {
-            capturedParams = new URLSearchParams(await request.text());
+            capturedBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({
               access_token: DEFAULT.accessToken,
               token_type: "Bearer",
@@ -342,9 +348,9 @@ describe("AuthClient passkey methods", () => {
         resCookies
       );
 
-      expect(capturedParams.get("auth_session")).toBe(DEFAULT.authSession);
-      expect(capturedParams.get("authn_response")).toBeTruthy();
-      expect(capturedParams.get("grant_type")).toContain("webauthn");
+      expect(capturedBody.auth_session).toBe(DEFAULT.authSession);
+      expect(capturedBody.authn_response).toBeTruthy();
+      expect(String(capturedBody.grant_type)).toContain("webauthn");
       // Session cookie written to resCookies
       expect(resHeaders.get("set-cookie")).toMatch(/__session=/);
     });

--- a/src/server/passkey.flow.test.ts
+++ b/src/server/passkey.flow.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Flow tests for AuthClient passkey core methods.
+ * Tests the raw AuthClient.passkeySignupChallenge / passkeyLoginChallenge /
+ * passkeyVerify methods — no Next.js runtime or cookie layer involved.
+ *
+ * The route handler and ServerPasskeyClient layers are tested in
+ * passkey-server.flow.test.ts and passkey/server-passkey-client.test.ts.
+ */
+import * as jose from "jose";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createAuthorizationServerMetadata,
+  getDefaultRoutes,
+  setupMswLifecycle
+} from "../test/defaults.js";
+import { generateSecret } from "../test/utils.js";
+import { AuthClient } from "./auth-client.js";
+import { StatelessSessionStore } from "./session/stateless-session-store.js";
+import { TransactionStore } from "./transaction-store.js";
+
+const DEFAULT = {
+  domain: "auth0.local",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  sub: "passkeys|test-user-id",
+  sid: "test-sid",
+  authSession: "test-auth-session-token",
+  accessToken: "test-access-token",
+  refreshToken: "test-refresh-token"
+};
+
+const MOCK_AUTH_RESPONSE = {
+  id: "cred-id",
+  rawId: "cred-raw-id",
+  type: "public-key" as const,
+  response: {
+    clientDataJSON: "clientDataJSON-base64url",
+    attestationObject: "attestationObject-base64url"
+  }
+};
+
+let keyPair: jose.GenerateKeyPairResult;
+
+const authorizationServerMetadata = createAuthorizationServerMetadata(
+  DEFAULT.domain
+);
+
+const server = setupServer(
+  http.get(`https://${DEFAULT.domain}/.well-known/openid-configuration`, () =>
+    HttpResponse.json(authorizationServerMetadata)
+  ),
+  http.get(`https://${DEFAULT.domain}/.well-known/jwks.json`, async () => {
+    const jwk = await jose.exportJWK(keyPair.publicKey);
+    return HttpResponse.json({
+      keys: [{ ...jwk, kid: "test-key-1", alg: "RS256", use: "sig" }]
+    });
+  })
+);
+
+setupMswLifecycle(server);
+
+beforeAll(async () => {
+  keyPair = await jose.generateKeyPair("RS256");
+});
+
+describe("AuthClient passkey methods", () => {
+  let secret: string;
+  let authClient: AuthClient;
+
+  beforeEach(async () => {
+    secret = await generateSecret(32);
+    const transactionStore = new TransactionStore({ secret });
+    const sessionStore = new StatelessSessionStore({ secret });
+    authClient = new AuthClient({
+      domain: DEFAULT.domain,
+      clientId: DEFAULT.clientId,
+      clientSecret: DEFAULT.clientSecret,
+      appBaseUrl: DEFAULT.appBaseUrl,
+      secret,
+      transactionStore,
+      sessionStore,
+      routes: getDefaultRoutes()
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passkeySignupChallenge
+  // ---------------------------------------------------------------------------
+
+  describe("passkeySignupChallenge", () => {
+    it("sends client_id and client_secret in request body", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/register`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: { challenge: "abc" }
+            });
+          }
+        )
+      );
+
+      await authClient.passkeySignupChallenge();
+
+      expect(capturedBody.client_id).toBe(DEFAULT.clientId);
+      expect(capturedBody.client_secret).toBe(DEFAULT.clientSecret);
+      expect(capturedBody.user_display_name).toBeUndefined();
+    });
+
+    it("includes user_display_name when provided", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/register`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      await authClient.passkeySignupChallenge({ userDisplayName: "Jane Doe" });
+
+      expect(capturedBody.user_display_name).toBe("Jane Doe");
+    });
+
+    it("maps snake_case response to camelCase SDK shape", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {
+              rp: { id: "example.com" },
+              challenge: "xyz"
+            }
+          })
+        )
+      );
+
+      const result = await authClient.passkeySignupChallenge();
+
+      expect(result.authSession).toBe(DEFAULT.authSession);
+      expect(result.authnParamsPublicKey).toEqual({
+        rp: { id: "example.com" },
+        challenge: "xyz"
+      });
+    });
+
+    it("throws PasskeySignupChallengeError on Auth0 API error", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.json(
+            {
+              error: "passkeys_not_enabled",
+              error_description:
+                "Passkeys are not enabled for this application."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      await expect(authClient.passkeySignupChallenge()).rejects.toMatchObject({
+        name: "PasskeySignupChallengeError",
+        error: "passkeys_not_enabled",
+        error_description: "Passkeys are not enabled for this application."
+      });
+    });
+
+    it("throws PasskeySignupChallengeError with unexpected_error on network failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+          HttpResponse.error()
+        )
+      );
+
+      await expect(authClient.passkeySignupChallenge()).rejects.toMatchObject({
+        name: "PasskeySignupChallengeError",
+        error: "unexpected_error"
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passkeyLoginChallenge
+  // ---------------------------------------------------------------------------
+
+  describe("passkeyLoginChallenge", () => {
+    it("sends client_id and client_secret in request body", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/challenge`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      await authClient.passkeyLoginChallenge();
+
+      expect(capturedBody.client_id).toBe(DEFAULT.clientId);
+      expect(capturedBody.client_secret).toBe(DEFAULT.clientSecret);
+      expect(capturedBody.username).toBeUndefined();
+    });
+
+    it("includes username when provided", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/challenge`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      await authClient.passkeyLoginChallenge({ username: "user@example.com" });
+
+      expect(capturedBody.username).toBe("user@example.com");
+    });
+
+    it("maps snake_case response to camelCase SDK shape", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: { challenge: "login-xyz", timeout: 60000 }
+          })
+        )
+      );
+
+      const result = await authClient.passkeyLoginChallenge();
+
+      expect(result.authSession).toBe(DEFAULT.authSession);
+      expect(result.authnParamsPublicKey).toEqual({
+        challenge: "login-xyz",
+        timeout: 60000
+      });
+    });
+
+    it("throws PasskeyLoginChallengeError on Auth0 API error", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.json(
+            {
+              error: "passkeys_not_enabled",
+              error_description: "Passkeys are not enabled."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      await expect(authClient.passkeyLoginChallenge()).rejects.toMatchObject({
+        name: "PasskeyLoginChallengeError",
+        error: "passkeys_not_enabled",
+        error_description: "Passkeys are not enabled."
+      });
+    });
+
+    it("throws PasskeyLoginChallengeError with unexpected_error on network failure", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+          HttpResponse.error()
+        )
+      );
+
+      await expect(authClient.passkeyLoginChallenge()).rejects.toMatchObject({
+        name: "PasskeyLoginChallengeError",
+        error: "unexpected_error"
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // passkeyVerify
+  // ---------------------------------------------------------------------------
+
+  describe("passkeyVerify", () => {
+    it("sends auth_session and authn_response to /oauth/token", async () => {
+      let capturedParams: URLSearchParams = new URLSearchParams();
+
+      const idToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            capturedParams = new URLSearchParams(await request.text());
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              token_type: "Bearer",
+              expires_in: 86400,
+              scope: "openid profile email",
+              id_token: idToken
+            });
+          }
+        )
+      );
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resHeaders = new Headers();
+      const resCookies = new ResponseCookies(resHeaders);
+
+      await authClient.passkeyVerify(
+        { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
+        reqCookies,
+        resCookies
+      );
+
+      expect(capturedParams.get("auth_session")).toBe(DEFAULT.authSession);
+      expect(capturedParams.get("authn_response")).toBeTruthy();
+      expect(capturedParams.get("grant_type")).toContain("webauthn");
+      // Session cookie written to resCookies
+      expect(resHeaders.get("set-cookie")).toMatch(/__session=/);
+    });
+
+    it("throws PasskeyVerifyError on invalid_grant from Auth0", async () => {
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json(
+            {
+              error: "invalid_grant",
+              error_description: "Invalid passkey assertion."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resCookies = new ResponseCookies(new Headers());
+
+      await expect(
+        authClient.passkeyVerify(
+          {
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          },
+          reqCookies,
+          resCookies
+        )
+      ).rejects.toMatchObject({
+        name: "PasskeyVerifyError",
+        error: "invalid_grant",
+        error_description: "Invalid passkey assertion."
+      });
+    });
+
+    it("throws PasskeyVerifyError on discovery failure", async () => {
+      server.use(
+        http.get(
+          `https://${DEFAULT.domain}/.well-known/openid-configuration`,
+          () => HttpResponse.error()
+        )
+      );
+
+      const freshSecret = await generateSecret(32);
+      const freshClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: freshSecret,
+        transactionStore: new TransactionStore({ secret: freshSecret }),
+        sessionStore: new StatelessSessionStore({ secret: freshSecret }),
+        routes: getDefaultRoutes()
+      });
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resCookies = new ResponseCookies(new Headers());
+
+      await expect(
+        freshClient.passkeyVerify(
+          {
+            authSession: DEFAULT.authSession,
+            authResponse: MOCK_AUTH_RESPONSE
+          },
+          reqCookies,
+          resCookies
+        )
+      ).rejects.toMatchObject({
+        name: "PasskeyVerifyError",
+        error: "discovery_error"
+      });
+    });
+  });
+});

--- a/src/server/passkey.flow.test.ts
+++ b/src/server/passkey.flow.test.ts
@@ -1,7 +1,7 @@
 /**
  * Flow tests for AuthClient passkey core methods.
- * Tests the raw AuthClient.passkeySignupChallenge / passkeyLoginChallenge /
- * passkeyVerify methods — no Next.js runtime or cookie layer involved.
+ * Tests the raw AuthClient.passkeyRegister / passkeyChallenge /
+ * passkeyGetToken methods — no Next.js runtime or cookie layer involved.
  *
  * The route handler and ServerPasskeyClient layers are tested in
  * passkey-server.flow.test.ts and passkey/server-passkey-client.test.ts.
@@ -17,6 +17,7 @@ import {
   setupMswLifecycle
 } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
+import { generateDpopKeyPair } from "../utils/dpopRetry.js";
 import { AuthClient } from "./auth-client.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
@@ -88,10 +89,10 @@ describe("AuthClient passkey methods", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // passkeySignupChallenge
+  // passkeyRegister
   // ---------------------------------------------------------------------------
 
-  describe("passkeySignupChallenge", () => {
+  describe("passkeyRegister", () => {
     it("sends client_id and client_secret in request body", async () => {
       let capturedBody: Record<string, unknown> = {};
 
@@ -108,7 +109,7 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await authClient.passkeySignupChallenge();
+      await authClient.passkeyRegister();
 
       expect(capturedBody.client_id).toBe(DEFAULT.clientId);
       expect(capturedBody.client_secret).toBe(DEFAULT.clientSecret);
@@ -131,7 +132,7 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await authClient.passkeySignupChallenge({
+      await authClient.passkeyRegister({
         email: "jane@example.com",
         name: "Jane Doe"
       });
@@ -140,6 +141,33 @@ describe("AuthClient passkey methods", () => {
         email: "jane@example.com",
         name: "Jane Doe"
       });
+    });
+
+    it("places user_metadata at top level, not inside user_profile", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passkey/register`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            });
+          }
+        )
+      );
+
+      await authClient.passkeyRegister({
+        email: "jane@example.com",
+        userMetadata: { plan: "pro" }
+      });
+
+      expect(capturedBody.user_metadata).toEqual({ plan: "pro" });
+      expect(
+        (capturedBody.user_profile as Record<string, unknown>).user_metadata
+      ).toBeUndefined();
     });
 
     it("maps snake_case response to camelCase SDK shape", async () => {
@@ -155,7 +183,7 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      const result = await authClient.passkeySignupChallenge();
+      const result = await authClient.passkeyRegister();
 
       expect(result.authSession).toBe(DEFAULT.authSession);
       expect(result.authnParamsPublicKey).toEqual({
@@ -164,7 +192,7 @@ describe("AuthClient passkey methods", () => {
       });
     });
 
-    it("throws PasskeySignupChallengeError on Auth0 API error", async () => {
+    it("throws PasskeyRegisterError on Auth0 API error", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
           HttpResponse.json(
@@ -178,32 +206,32 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await expect(authClient.passkeySignupChallenge()).rejects.toMatchObject({
-        name: "PasskeySignupChallengeError",
+      await expect(authClient.passkeyRegister()).rejects.toMatchObject({
+        name: "PasskeyRegisterError",
         error: "passkeys_not_enabled",
         error_description: "Passkeys are not enabled for this application."
       });
     });
 
-    it("throws PasskeySignupChallengeError with unexpected_error on network failure", async () => {
+    it("throws PasskeyRegisterError with unexpected_error on network failure", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
           HttpResponse.error()
         )
       );
 
-      await expect(authClient.passkeySignupChallenge()).rejects.toMatchObject({
-        name: "PasskeySignupChallengeError",
+      await expect(authClient.passkeyRegister()).rejects.toMatchObject({
+        name: "PasskeyRegisterError",
         error: "unexpected_error"
       });
     });
   });
 
   // ---------------------------------------------------------------------------
-  // passkeyLoginChallenge
+  // passkeyChallenge
   // ---------------------------------------------------------------------------
 
-  describe("passkeyLoginChallenge", () => {
+  describe("passkeyChallenge", () => {
     it("sends client_id and client_secret in request body", async () => {
       let capturedBody: Record<string, unknown> = {};
 
@@ -220,32 +248,11 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await authClient.passkeyLoginChallenge();
+      await authClient.passkeyChallenge();
 
       expect(capturedBody.client_id).toBe(DEFAULT.clientId);
       expect(capturedBody.client_secret).toBe(DEFAULT.clientSecret);
       expect(capturedBody.username).toBeUndefined();
-    });
-
-    it("includes username when provided", async () => {
-      let capturedBody: Record<string, unknown> = {};
-
-      server.use(
-        http.post(
-          `https://${DEFAULT.domain}/passkey/challenge`,
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              auth_session: DEFAULT.authSession,
-              authn_params_public_key: {}
-            });
-          }
-        )
-      );
-
-      await authClient.passkeyLoginChallenge({ username: "user@example.com" });
-
-      expect(capturedBody.username).toBe("user@example.com");
     });
 
     it("maps snake_case response to camelCase SDK shape", async () => {
@@ -258,7 +265,7 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      const result = await authClient.passkeyLoginChallenge();
+      const result = await authClient.passkeyChallenge();
 
       expect(result.authSession).toBe(DEFAULT.authSession);
       expect(result.authnParamsPublicKey).toEqual({
@@ -267,7 +274,7 @@ describe("AuthClient passkey methods", () => {
       });
     });
 
-    it("throws PasskeyLoginChallengeError on Auth0 API error", async () => {
+    it("throws PasskeyChallengeError on Auth0 API error", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
           HttpResponse.json(
@@ -280,32 +287,32 @@ describe("AuthClient passkey methods", () => {
         )
       );
 
-      await expect(authClient.passkeyLoginChallenge()).rejects.toMatchObject({
-        name: "PasskeyLoginChallengeError",
+      await expect(authClient.passkeyChallenge()).rejects.toMatchObject({
+        name: "PasskeyChallengeError",
         error: "passkeys_not_enabled",
         error_description: "Passkeys are not enabled."
       });
     });
 
-    it("throws PasskeyLoginChallengeError with unexpected_error on network failure", async () => {
+    it("throws PasskeyChallengeError with unexpected_error on network failure", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
           HttpResponse.error()
         )
       );
 
-      await expect(authClient.passkeyLoginChallenge()).rejects.toMatchObject({
-        name: "PasskeyLoginChallengeError",
+      await expect(authClient.passkeyChallenge()).rejects.toMatchObject({
+        name: "PasskeyChallengeError",
         error: "unexpected_error"
       });
     });
   });
 
   // ---------------------------------------------------------------------------
-  // passkeyVerify
+  // passkeyGetToken
   // ---------------------------------------------------------------------------
 
-  describe("passkeyVerify", () => {
+  describe("passkeyGetToken", () => {
     it("sends auth_session and authn_response to /oauth/token", async () => {
       let capturedBody: Record<string, unknown> = {};
 
@@ -342,7 +349,7 @@ describe("AuthClient passkey methods", () => {
       const resHeaders = new Headers();
       const resCookies = new ResponseCookies(resHeaders);
 
-      await authClient.passkeyVerify(
+      await authClient.passkeyGetToken(
         { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
         reqCookies,
         resCookies
@@ -355,7 +362,7 @@ describe("AuthClient passkey methods", () => {
       expect(resHeaders.get("set-cookie")).toMatch(/__session=/);
     });
 
-    it("throws PasskeyVerifyError on invalid_grant from Auth0", async () => {
+    it("throws PasskeyGetTokenError on invalid_grant from Auth0", async () => {
       server.use(
         http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
           HttpResponse.json(
@@ -374,7 +381,7 @@ describe("AuthClient passkey methods", () => {
       const resCookies = new ResponseCookies(new Headers());
 
       await expect(
-        authClient.passkeyVerify(
+        authClient.passkeyGetToken(
           {
             authSession: DEFAULT.authSession,
             authResponse: MOCK_AUTH_RESPONSE
@@ -383,13 +390,228 @@ describe("AuthClient passkey methods", () => {
           resCookies
         )
       ).rejects.toMatchObject({
-        name: "PasskeyVerifyError",
+        name: "PasskeyGetTokenError",
         error: "invalid_grant",
         error_description: "Invalid passkey assertion."
       });
     });
 
-    it("throws PasskeyVerifyError on discovery failure", async () => {
+    it("does not send a DPoP header when useDPoP is not configured", async () => {
+      let capturedDpopHeader: string | null = null;
+
+      const idToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            capturedDpopHeader = request.headers.get("dpop");
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              token_type: "Bearer",
+              expires_in: 86400,
+              scope: "openid profile email",
+              id_token: idToken
+            });
+          }
+        )
+      );
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resCookies = new ResponseCookies(new Headers());
+
+      await authClient.passkeyGetToken(
+        { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
+        reqCookies,
+        resCookies
+      );
+
+      expect(capturedDpopHeader).toBeNull();
+    });
+
+    it("sends a DPoP proof header when useDPoP is true", async () => {
+      const dpopKeyPair = await generateDpopKeyPair();
+      const dpopSecret = await generateSecret(32);
+      const dpopClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: dpopSecret,
+        transactionStore: new TransactionStore({ secret: dpopSecret }),
+        sessionStore: new StatelessSessionStore({ secret: dpopSecret }),
+        routes: getDefaultRoutes(),
+        useDPoP: true,
+        dpopKeyPair
+      });
+
+      let capturedDpopHeader: string | null = null;
+
+      const idToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            capturedDpopHeader = request.headers.get("dpop");
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              token_type: "Bearer",
+              expires_in: 86400,
+              scope: "openid profile email",
+              id_token: idToken
+            });
+          }
+        )
+      );
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resCookies = new ResponseCookies(new Headers());
+
+      await dpopClient.passkeyGetToken(
+        { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
+        reqCookies,
+        resCookies
+      );
+
+      expect(capturedDpopHeader).not.toBeNull();
+
+      // Verify the DPoP JWT structure: header.payload.signature
+      const [, payloadB64] = capturedDpopHeader!.split(".");
+      const payload = JSON.parse(
+        Buffer.from(payloadB64, "base64url").toString()
+      );
+      expect(payload.htm).toBe("POST");
+      expect(payload.htu).toBe(`https://${DEFAULT.domain}/oauth/token`);
+      expect(payload.iat).toBeDefined();
+      expect(payload.jti).toBeDefined();
+    });
+
+    it("retries with server-supplied nonce on use_dpop_nonce and includes nonce on second attempt", async () => {
+      const dpopKeyPair = await generateDpopKeyPair();
+      const dpopSecret = await generateSecret(32);
+      const dpopClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: dpopSecret,
+        transactionStore: new TransactionStore({ secret: dpopSecret }),
+        sessionStore: new StatelessSessionStore({ secret: dpopSecret }),
+        routes: getDefaultRoutes(),
+        useDPoP: true,
+        dpopKeyPair
+      });
+
+      const idToken = await new jose.SignJWT({
+        sub: DEFAULT.sub,
+        sid: DEFAULT.sid
+      })
+        .setProtectedHeader({ alg: "RS256" })
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .sign(keyPair.privateKey);
+
+      const tokenRequests: Array<{ hasDPoP: boolean; dpopNonce?: string }> = [];
+      let callCount = 0;
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/oauth/token`,
+          async ({ request }) => {
+            callCount++;
+            const dpopHeader = request.headers.get("dpop");
+            let dpopNonce: string | undefined;
+
+            if (dpopHeader) {
+              try {
+                const [, payloadB64] = dpopHeader.split(".");
+                const payload = JSON.parse(
+                  Buffer.from(payloadB64, "base64url").toString()
+                );
+                dpopNonce = payload.nonce as string | undefined;
+              } catch {
+                // ignore parse errors
+              }
+            }
+
+            tokenRequests.push({ hasDPoP: !!dpopHeader, dpopNonce });
+
+            if (callCount === 1) {
+              return HttpResponse.json(
+                {
+                  error: "use_dpop_nonce",
+                  error_description:
+                    "Authorization server requires nonce in DPoP proof"
+                },
+                {
+                  status: 400,
+                  headers: { "dpop-nonce": "server-issued-nonce-xyz" }
+                }
+              );
+            }
+
+            return HttpResponse.json({
+              access_token: DEFAULT.accessToken,
+              token_type: "Bearer",
+              expires_in: 86400,
+              scope: "openid profile email",
+              id_token: idToken
+            });
+          }
+        )
+      );
+
+      const { RequestCookies, ResponseCookies } =
+        await import("@edge-runtime/cookies");
+      const reqCookies = new RequestCookies(new Headers());
+      const resCookies = new ResponseCookies(new Headers());
+
+      await dpopClient.passkeyGetToken(
+        { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
+        reqCookies,
+        resCookies
+      );
+
+      // Two requests: initial attempt + nonce retry
+      expect(callCount).toBe(2);
+
+      // Both carried a DPoP proof
+      expect(tokenRequests[0].hasDPoP).toBe(true);
+      expect(tokenRequests[1].hasDPoP).toBe(true);
+
+      // First attempt had no nonce (server hadn't issued one yet)
+      expect(tokenRequests[0].dpopNonce).toBeUndefined();
+
+      // Retry included the server-issued nonce
+      expect(tokenRequests[1].dpopNonce).toBe("server-issued-nonce-xyz");
+    });
+
+    it("throws PasskeyGetTokenError on discovery failure", async () => {
       server.use(
         http.get(
           `https://${DEFAULT.domain}/.well-known/openid-configuration`,
@@ -415,7 +637,7 @@ describe("AuthClient passkey methods", () => {
       const resCookies = new ResponseCookies(new Headers());
 
       await expect(
-        freshClient.passkeyVerify(
+        freshClient.passkeyGetToken(
           {
             authSession: DEFAULT.authSession,
             authResponse: MOCK_AUTH_RESPONSE
@@ -424,7 +646,7 @@ describe("AuthClient passkey methods", () => {
           resCookies
         )
       ).rejects.toMatchObject({
-        name: "PasskeyVerifyError",
+        name: "PasskeyGetTokenError",
         error: "discovery_error"
       });
     });

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -203,6 +203,94 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     expect(result.authSession).toBe(DEFAULT.authSession);
     expect(vi.mocked(cookies)).not.toHaveBeenCalled();
   });
+
+  it("sends realm when connection option is provided", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/register`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).signupChallenge({
+      email: "jane@example.com",
+      connection: "Username-Password-Authentication"
+    });
+
+    expect(capturedBody.realm).toBe("Username-Password-Authentication");
+  });
+
+  it("sends phone_number in user_profile when phoneNumber is provided", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/register`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).signupChallenge({ phoneNumber: "+1234567890" });
+
+    expect(capturedBody.user_profile.phone_number).toBe("+1234567890");
+  });
+
+  it("sends username in user_profile when username is provided", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/register`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (await makePasskeyClient()).signupChallenge({ username: "janedoe" });
+
+    expect(capturedBody.user_profile.username).toBe("janedoe");
+  });
+
+  it("throws PasskeySignupChallengeError when Auth0 rejects unknown user_profile field", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+        HttpResponse.json(
+          {
+            error: "invalid_request",
+            error_description: "Unknown user_profile field."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).signupChallenge({ email: "jane@example.com" })
+    ).rejects.toMatchObject({
+      name: "PasskeySignupChallengeError",
+      error: "invalid_request"
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -298,6 +386,53 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
     await (await makePasskeyClient()).loginChallenge(req);
 
     expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+  });
+
+  it("sends realm when connection option is provided", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/challenge`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).loginChallenge({
+      connection: "Username-Password-Authentication"
+    });
+
+    expect(capturedBody.realm).toBe("Username-Password-Authentication");
+  });
+
+  it("throws PasskeyLoginChallengeError when no passkey found for user", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+        HttpResponse.json(
+          {
+            error: "no_passkey_found",
+            error_description: "No passkey registered for this user."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).loginChallenge({
+        username: "no-passkey@example.com"
+      })
+    ).rejects.toMatchObject({
+      name: "PasskeyLoginChallengeError",
+      error: "no_passkey_found"
+    });
   });
 });
 
@@ -421,5 +556,88 @@ describe("ServerPasskeyClient.verify()", () => {
         })
       ).rejects.toThrow(TypeError);
     });
+  });
+
+  it("sends GRANT_TYPE_PASSKEY grant type in token request", async () => {
+    let capturedBody: any = null;
+    const idToken = await makeIdToken();
+
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/oauth/token`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            access_token: "new-access-token",
+            token_type: "Bearer",
+            expires_in: 86400,
+            scope: "openid profile email",
+            id_token: idToken
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).verify({
+      authSession: DEFAULT.authSession,
+      authResponse: MOCK_AUTH_RESPONSE
+    });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody["grant_type"]).toBe(
+      "urn:okta:params:oauth:grant-type:webauthn"
+    );
+  });
+
+  it("stores id_token claims (email, name) in session after verify", async () => {
+    const idToken = await makeIdToken({
+      email: "jane@example.com",
+      name: "Jane Doe"
+    });
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json({
+          access_token: "new-access-token",
+          token_type: "Bearer",
+          expires_in: 86400,
+          scope: "openid profile email",
+          id_token: idToken
+        })
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).verify({
+      authSession: DEFAULT.authSession,
+      authResponse: MOCK_AUTH_RESPONSE
+    });
+
+    const setCookie = mockCookieHeaders.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toMatch(/__session=/);
+  });
+
+  it("throws PasskeyVerifyError when id_token is missing from response", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json({
+          access_token: "access-only",
+          token_type: "Bearer",
+          expires_in: 86400,
+          scope: "openid profile email"
+        })
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).verify({
+        authSession: DEFAULT.authSession,
+        authResponse: MOCK_AUTH_RESPONSE
+      })
+    ).rejects.toThrow();
   });
 });

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -16,10 +16,8 @@ import {
   getDefaultRoutes,
   setupMswLifecycle
 } from "../../test/defaults.js";
-import { generateSecret } from "../../test/utils.js";
 import { AuthClientProvider } from "../auth-client-provider.js";
 import { AuthClient } from "../auth-client.js";
-import { encrypt } from "../cookies.js";
 import { StatelessSessionStore } from "../session/stateless-session-store.js";
 import { TransactionStore } from "../transaction-store.js";
 import { ServerPasskeyClient } from "./server-passkey-client.js";
@@ -39,8 +37,7 @@ const DEFAULT = {
   appBaseUrl: "http://localhost:3000",
   sub: "passkeys|test-user-id",
   sid: "test-sid",
-  authSession: "test-auth-session-token",
-  authenticationMethodId: "am_abc123"
+  authSession: "test-auth-session-token"
 };
 
 const MOCK_AUTH_RESPONSE = {
@@ -109,35 +106,6 @@ async function makePasskeyClient(
   } as unknown as AuthClientProvider);
 }
 
-async function makeSessionCookie(secret: string): Promise<string> {
-  const session = {
-    user: { sub: DEFAULT.sub },
-    tokenSet: {
-      accessToken: "existing-access-token",
-      refreshToken: "existing-refresh-token",
-      idToken: "existing-id-token",
-      expiresAt: Math.floor(Date.now() / 1000) + 3600,
-      scope: "openid profile email"
-    },
-    internal: { sid: DEFAULT.sid, createdAt: Math.floor(Date.now() / 1000) }
-  };
-  return encrypt(session, secret, Math.floor(Date.now() / 1000) + 3600);
-}
-
-/** Mock the token endpoint to return an access token for the me/ audience. */
-function mockMeAudienceTokenRefresh() {
-  server.use(
-    http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
-      HttpResponse.json({
-        access_token: "me-audience-access-token",
-        token_type: "Bearer",
-        expires_in: 86400,
-        scope: "openid profile email create:me:authentication_methods"
-      })
-    )
-  );
-}
-
 // ---------------------------------------------------------------------------
 // signupChallenge
 // ---------------------------------------------------------------------------
@@ -163,7 +131,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     expect(result.authnParamsPublicKey).toEqual({ challenge: "abc123" });
   });
 
-  it("passes userDisplayName in request body", async () => {
+  it("passes user_profile fields in request body", async () => {
     let capturedBody: any;
     server.use(
       http.post(
@@ -181,10 +149,14 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     await (
       await makePasskeyClient()
     ).signupChallenge({
-      userDisplayName: "Jane Doe"
+      email: "jane@example.com",
+      name: "Jane Doe"
     });
 
-    expect(capturedBody.user_display_name).toBe("Jane Doe");
+    expect(capturedBody.user_profile).toMatchObject({
+      email: "jane@example.com",
+      name: "Jane Doe"
+    });
   });
 
   it("throws PasskeySignupChallengeError on Auth0 failure", async () => {
@@ -449,214 +421,5 @@ describe("ServerPasskeyClient.verify()", () => {
         })
       ).rejects.toThrow(TypeError);
     });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// enrollmentChallenge
-// ---------------------------------------------------------------------------
-
-describe("ServerPasskeyClient.enrollmentChallenge()", () => {
-  let secret: string;
-
-  beforeEach(async () => {
-    secret = await generateSecret(32);
-    mockCookieHeaders = new Headers();
-  });
-
-  it("returns enrollment challenge when session is present (App Router)", async () => {
-    const sessionValue = await makeSessionCookie(secret);
-    mockCookieHeaders.set(
-      "set-cookie",
-      `__session=${sessionValue}; Path=/; HttpOnly`
-    );
-
-    mockMeAudienceTokenRefresh();
-
-    server.use(
-      http.post(`https://${DEFAULT.domain}/me/v1/authentication-methods`, () =>
-        HttpResponse.json(
-          {
-            auth_session: DEFAULT.authSession,
-            authn_params_public_key: { challenge: "enroll-challenge" }
-          },
-          {
-            status: 201,
-            headers: {
-              location: `/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}`
-            }
-          }
-        )
-      )
-    );
-
-    const client = new ServerPasskeyClient({
-      forRequest: async () =>
-        new AuthClient({
-          domain: DEFAULT.domain,
-          clientId: DEFAULT.clientId,
-          clientSecret: DEFAULT.clientSecret,
-          appBaseUrl: DEFAULT.appBaseUrl,
-          secret,
-          transactionStore: new TransactionStore({ secret }),
-          sessionStore: new StatelessSessionStore({ secret }),
-          routes: getDefaultRoutes()
-        }),
-      isResolverMode: false
-    } as unknown as AuthClientProvider);
-
-    const result = await client.enrollmentChallenge();
-
-    expect(result.authenticationMethodId).toBe(DEFAULT.authenticationMethodId);
-    expect(result.authSession).toBe(DEFAULT.authSession);
-    expect(result.authnParamsPublicKey).toEqual({
-      challenge: "enroll-challenge"
-    });
-  });
-
-  it("throws PasskeyEnrollmentChallengeError when no session", async () => {
-    // No session cookie — mockCookieHeaders is empty
-    await expect(
-      (await makePasskeyClient(secret)).enrollmentChallenge()
-    ).rejects.toMatchObject({
-      name: "PasskeyEnrollmentChallengeError",
-      error: "not_authenticated"
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// enrollVerify
-// ---------------------------------------------------------------------------
-
-describe("ServerPasskeyClient.enrollVerify()", () => {
-  let secret: string;
-
-  beforeEach(async () => {
-    secret = await generateSecret(32);
-    mockCookieHeaders = new Headers();
-  });
-
-  it("returns authentication method on success (App Router)", async () => {
-    const sessionValue = await makeSessionCookie(secret);
-    mockCookieHeaders.set(
-      "set-cookie",
-      `__session=${sessionValue}; Path=/; HttpOnly`
-    );
-
-    mockMeAudienceTokenRefresh();
-
-    server.use(
-      http.post(
-        `https://${DEFAULT.domain}/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}/verify`,
-        () =>
-          HttpResponse.json({
-            id: DEFAULT.authenticationMethodId,
-            type: "passkey",
-            name: "Touch ID",
-            created_at: "2024-01-01T00:00:00.000Z",
-            last_authenticated_at: "2024-01-01T00:00:00.000Z"
-          })
-      )
-    );
-
-    const client = new ServerPasskeyClient({
-      forRequest: async () =>
-        new AuthClient({
-          domain: DEFAULT.domain,
-          clientId: DEFAULT.clientId,
-          clientSecret: DEFAULT.clientSecret,
-          appBaseUrl: DEFAULT.appBaseUrl,
-          secret,
-          transactionStore: new TransactionStore({ secret }),
-          sessionStore: new StatelessSessionStore({ secret }),
-          routes: getDefaultRoutes()
-        }),
-      isResolverMode: false
-    } as unknown as AuthClientProvider);
-
-    const result = await client.enrollVerify({
-      authenticationMethodId: DEFAULT.authenticationMethodId,
-      authSession: DEFAULT.authSession,
-      authResponse: MOCK_AUTH_RESPONSE
-    });
-
-    expect(result.id).toBe(DEFAULT.authenticationMethodId);
-    expect(result.type).toBe("passkey");
-    expect(result.name).toBe("Touch ID");
-  });
-
-  it("throws PasskeyEnrollVerifyError when no session", async () => {
-    await expect(
-      (await makePasskeyClient(secret)).enrollVerify({
-        authenticationMethodId: DEFAULT.authenticationMethodId,
-        authSession: DEFAULT.authSession,
-        authResponse: MOCK_AUTH_RESPONSE
-      })
-    ).rejects.toMatchObject({
-      name: "PasskeyEnrollVerifyError",
-      error: "not_authenticated"
-    });
-  });
-
-  it("throws PasskeyEnrollVerifyError on API failure", async () => {
-    const sessionValue = await makeSessionCookie(secret);
-    mockCookieHeaders.set(
-      "set-cookie",
-      `__session=${sessionValue}; Path=/; HttpOnly`
-    );
-
-    mockMeAudienceTokenRefresh();
-
-    server.use(
-      http.post(
-        `https://${DEFAULT.domain}/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}/verify`,
-        () =>
-          HttpResponse.json(
-            {
-              error: "credential_already_registered",
-              error_description: "This passkey is already registered."
-            },
-            { status: 400 }
-          )
-      )
-    );
-
-    const client = new ServerPasskeyClient({
-      forRequest: async () =>
-        new AuthClient({
-          domain: DEFAULT.domain,
-          clientId: DEFAULT.clientId,
-          clientSecret: DEFAULT.clientSecret,
-          appBaseUrl: DEFAULT.appBaseUrl,
-          secret,
-          transactionStore: new TransactionStore({ secret }),
-          sessionStore: new StatelessSessionStore({ secret }),
-          routes: getDefaultRoutes()
-        }),
-      isResolverMode: false
-    } as unknown as AuthClientProvider);
-
-    await expect(
-      client.enrollVerify({
-        authenticationMethodId: DEFAULT.authenticationMethodId,
-        authSession: DEFAULT.authSession,
-        authResponse: MOCK_AUTH_RESPONSE
-      })
-    ).rejects.toMatchObject({
-      name: "PasskeyEnrollVerifyError",
-      error: "credential_already_registered"
-    });
-  });
-
-  it("throws TypeError when options missing (Pages Router guard)", async () => {
-    const req = new NextRequest(
-      new URL("/api/passkey/enroll-verify", DEFAULT.appBaseUrl),
-      { method: "POST" }
-    );
-
-    await expect(
-      (await makePasskeyClient(secret)).enrollVerify(req as any)
-    ).rejects.toThrow(TypeError);
   });
 });

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Unit tests for ServerPasskeyClient — App Router and Pages Router paths.
+ *
+ * next/headers is mocked at module level so App Router cookie reads/writes
+ * can be observed without a real Next.js runtime.
+ */
+import { NextRequest, NextResponse } from "next/server.js";
+import { ResponseCookies } from "@edge-runtime/cookies";
+import * as jose from "jose";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAuthorizationServerMetadata,
+  getDefaultRoutes,
+  setupMswLifecycle
+} from "../../test/defaults.js";
+import { generateSecret } from "../../test/utils.js";
+import { AuthClientProvider } from "../auth-client-provider.js";
+import { AuthClient } from "../auth-client.js";
+import { encrypt } from "../cookies.js";
+import { StatelessSessionStore } from "../session/stateless-session-store.js";
+import { TransactionStore } from "../transaction-store.js";
+import { ServerPasskeyClient } from "./server-passkey-client.js";
+
+// Shared mutable headers that the mocked next/headers cookies() returns.
+let mockCookieHeaders: Headers;
+
+vi.mock("next/headers.js", () => ({
+  cookies: vi.fn(async () => new ResponseCookies(mockCookieHeaders)),
+  headers: vi.fn(() => new Headers())
+}));
+
+const DEFAULT = {
+  domain: "auth0.local",
+  clientId: "test-client-id",
+  clientSecret: "test-client-secret",
+  appBaseUrl: "http://localhost:3000",
+  sub: "passkeys|test-user-id",
+  sid: "test-sid",
+  authSession: "test-auth-session-token",
+  authenticationMethodId: "am_abc123"
+};
+
+const MOCK_AUTH_RESPONSE = {
+  id: "cred-id",
+  rawId: "cred-raw-id",
+  type: "public-key" as const,
+  response: {
+    clientDataJSON: "clientDataJSON-base64url",
+    attestationObject: "attestationObject-base64url"
+  }
+};
+
+let keyPair: jose.GenerateKeyPairResult;
+
+const authorizationServerMetadata = createAuthorizationServerMetadata(
+  DEFAULT.domain
+);
+
+const server = setupServer(
+  http.get(`https://${DEFAULT.domain}/.well-known/openid-configuration`, () =>
+    HttpResponse.json(authorizationServerMetadata)
+  ),
+  http.get(`https://${DEFAULT.domain}/.well-known/jwks.json`, async () => {
+    const jwk = await jose.exportJWK(keyPair.publicKey);
+    return HttpResponse.json({
+      keys: [{ ...jwk, kid: "test-key-1", alg: "RS256", use: "sig" }]
+    });
+  })
+);
+
+setupMswLifecycle(server);
+
+beforeAll(async () => {
+  keyPair = await jose.generateKeyPair("RS256");
+});
+
+async function makeIdToken(
+  claims: Record<string, unknown> = {}
+): Promise<string> {
+  return new jose.SignJWT({ sub: DEFAULT.sub, sid: DEFAULT.sid, ...claims })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(`https://${DEFAULT.domain}`)
+    .setAudience(DEFAULT.clientId)
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(keyPair.privateKey);
+}
+
+async function makePasskeyClient(
+  secret?: string
+): Promise<ServerPasskeyClient> {
+  const s = secret ?? "test-secret-long-enough-for-hs256-algorithm";
+  return new ServerPasskeyClient({
+    forRequest: async () =>
+      new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret: s,
+        transactionStore: new TransactionStore({ secret: s }),
+        sessionStore: new StatelessSessionStore({ secret: s }),
+        routes: getDefaultRoutes()
+      }),
+    isResolverMode: false
+  } as unknown as AuthClientProvider);
+}
+
+async function makeSessionCookie(secret: string): Promise<string> {
+  const session = {
+    user: { sub: DEFAULT.sub },
+    tokenSet: {
+      accessToken: "existing-access-token",
+      refreshToken: "existing-refresh-token",
+      idToken: "existing-id-token",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      scope: "openid profile email"
+    },
+    internal: { sid: DEFAULT.sid, createdAt: Math.floor(Date.now() / 1000) }
+  };
+  return encrypt(session, secret, Math.floor(Date.now() / 1000) + 3600);
+}
+
+/** Mock the token endpoint to return an access token for the me/ audience. */
+function mockMeAudienceTokenRefresh() {
+  server.use(
+    http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+      HttpResponse.json({
+        access_token: "me-audience-access-token",
+        token_type: "Bearer",
+        expires_in: 86400,
+        scope: "openid profile email create:me:authentication_methods"
+      })
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// signupChallenge
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.signupChallenge()", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns challenge response on success (App Router)", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+        HttpResponse.json({
+          auth_session: DEFAULT.authSession,
+          authn_params_public_key: { challenge: "abc123" }
+        })
+      )
+    );
+
+    const result = await (await makePasskeyClient()).signupChallenge();
+
+    expect(result.authSession).toBe(DEFAULT.authSession);
+    expect(result.authnParamsPublicKey).toEqual({ challenge: "abc123" });
+  });
+
+  it("passes userDisplayName in request body", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/register`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).signupChallenge({
+      userDisplayName: "Jane Doe"
+    });
+
+    expect(capturedBody.user_display_name).toBe("Jane Doe");
+  });
+
+  it("throws PasskeySignupChallengeError on Auth0 failure", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+        HttpResponse.json(
+          {
+            error: "passkeys_not_enabled",
+            error_description: "Passkeys are not enabled for this application."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).signupChallenge()
+    ).rejects.toMatchObject({
+      name: "PasskeySignupChallengeError",
+      error: "passkeys_not_enabled"
+    });
+  });
+
+  it("returns challenge response via Pages Router overload", async () => {
+    const { cookies } = await import("next/headers.js");
+    vi.mocked(cookies).mockClear();
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
+        HttpResponse.json({
+          auth_session: DEFAULT.authSession,
+          authn_params_public_key: { challenge: "pages-router" }
+        })
+      )
+    );
+
+    const req = new NextRequest(
+      new URL("/api/passkey/signup-challenge", DEFAULT.appBaseUrl),
+      { method: "POST" }
+    );
+
+    const result = await (await makePasskeyClient()).signupChallenge(req);
+
+    expect(result.authSession).toBe(DEFAULT.authSession);
+    expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loginChallenge
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.loginChallenge()", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns challenge response on success (App Router)", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+        HttpResponse.json({
+          auth_session: DEFAULT.authSession,
+          authn_params_public_key: { challenge: "login-challenge" }
+        })
+      )
+    );
+
+    const result = await (await makePasskeyClient()).loginChallenge();
+
+    expect(result.authSession).toBe(DEFAULT.authSession);
+    expect(result.authnParamsPublicKey).toEqual({
+      challenge: "login-challenge"
+    });
+  });
+
+  it("passes username in request body", async () => {
+    let capturedBody: any;
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/passkey/challenge`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: {}
+          });
+        }
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).loginChallenge({
+      username: "user@example.com"
+    });
+
+    expect(capturedBody.username).toBe("user@example.com");
+  });
+
+  it("throws PasskeyLoginChallengeError on Auth0 failure", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+        HttpResponse.json(
+          {
+            error: "passkeys_not_enabled",
+            error_description: "Passkeys are not enabled."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).loginChallenge()
+    ).rejects.toMatchObject({
+      name: "PasskeyLoginChallengeError",
+      error: "passkeys_not_enabled"
+    });
+  });
+
+  it("returns challenge response via Pages Router overload", async () => {
+    const { cookies } = await import("next/headers.js");
+    vi.mocked(cookies).mockClear();
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
+        HttpResponse.json({
+          auth_session: DEFAULT.authSession,
+          authn_params_public_key: {}
+        })
+      )
+    );
+
+    const req = new NextRequest(
+      new URL("/api/passkey/login-challenge", DEFAULT.appBaseUrl),
+      { method: "POST" }
+    );
+
+    await (await makePasskeyClient()).loginChallenge(req);
+
+    expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.verify()", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("writes session cookie to next/headers on success (App Router)", async () => {
+    const idToken = await makeIdToken();
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json({
+          access_token: "new-access-token",
+          token_type: "Bearer",
+          expires_in: 86400,
+          scope: "openid profile email",
+          id_token: idToken
+        })
+      )
+    );
+
+    await (
+      await makePasskeyClient()
+    ).verify({
+      authSession: DEFAULT.authSession,
+      authResponse: MOCK_AUTH_RESPONSE
+    });
+
+    const setCookie = mockCookieHeaders.get("set-cookie");
+    expect(setCookie).toBeTruthy();
+    expect(setCookie).toMatch(/__session=/);
+  });
+
+  it("throws PasskeyVerifyError on token exchange failure", async () => {
+    server.use(
+      http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+        HttpResponse.json(
+          {
+            error: "invalid_grant",
+            error_description: "Invalid passkey assertion."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(
+      (await makePasskeyClient()).verify({
+        authSession: DEFAULT.authSession,
+        authResponse: MOCK_AUTH_RESPONSE
+      })
+    ).rejects.toMatchObject({
+      name: "PasskeyVerifyError",
+      error: "invalid_grant"
+    });
+
+    expect(mockCookieHeaders.get("set-cookie")).toBeNull();
+  });
+
+  it("throws TypeError when extra arguments passed (App Router guard)", async () => {
+    await expect(
+      ((await makePasskeyClient()).verify as any)(
+        { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
+        new NextResponse()
+      )
+    ).rejects.toThrow(TypeError);
+  });
+
+  describe("Pages Router overload (req, res, options)", () => {
+    it("writes session cookie to res and not to next/headers", async () => {
+      const { cookies } = await import("next/headers.js");
+      vi.mocked(cookies).mockClear();
+
+      const idToken = await makeIdToken();
+
+      server.use(
+        http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
+          HttpResponse.json({
+            access_token: "new-access-token",
+            token_type: "Bearer",
+            expires_in: 86400,
+            scope: "openid profile email",
+            id_token: idToken
+          })
+        )
+      );
+
+      const req = new NextRequest(
+        new URL("/api/passkey/verify", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+      const res = new NextResponse();
+
+      await (
+        await makePasskeyClient()
+      ).verify(req, res, {
+        authSession: DEFAULT.authSession,
+        authResponse: MOCK_AUTH_RESPONSE
+      });
+
+      expect(res.headers.get("set-cookie")).toBeTruthy();
+      expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+    });
+
+    it("throws TypeError when res is missing", async () => {
+      const req = new NextRequest(
+        new URL("/api/passkey/verify", DEFAULT.appBaseUrl),
+        { method: "POST" }
+      );
+
+      await expect(
+        ((await makePasskeyClient()).verify as any)(req, {
+          authSession: DEFAULT.authSession,
+          authResponse: MOCK_AUTH_RESPONSE
+        })
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrollmentChallenge
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.enrollmentChallenge()", () => {
+  let secret: string;
+
+  beforeEach(async () => {
+    secret = await generateSecret(32);
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns enrollment challenge when session is present (App Router)", async () => {
+    const sessionValue = await makeSessionCookie(secret);
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionValue}; Path=/; HttpOnly`
+    );
+
+    mockMeAudienceTokenRefresh();
+
+    server.use(
+      http.post(`https://${DEFAULT.domain}/me/v1/authentication-methods`, () =>
+        HttpResponse.json(
+          {
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: { challenge: "enroll-challenge" }
+          },
+          {
+            status: 201,
+            headers: {
+              location: `/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}`
+            }
+          }
+        )
+      )
+    );
+
+    const client = new ServerPasskeyClient({
+      forRequest: async () =>
+        new AuthClient({
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          secret,
+          transactionStore: new TransactionStore({ secret }),
+          sessionStore: new StatelessSessionStore({ secret }),
+          routes: getDefaultRoutes()
+        }),
+      isResolverMode: false
+    } as unknown as AuthClientProvider);
+
+    const result = await client.enrollmentChallenge();
+
+    expect(result.authenticationMethodId).toBe(DEFAULT.authenticationMethodId);
+    expect(result.authSession).toBe(DEFAULT.authSession);
+    expect(result.authnParamsPublicKey).toEqual({
+      challenge: "enroll-challenge"
+    });
+  });
+
+  it("throws PasskeyEnrollmentChallengeError when no session", async () => {
+    // No session cookie — mockCookieHeaders is empty
+    await expect(
+      (await makePasskeyClient(secret)).enrollmentChallenge()
+    ).rejects.toMatchObject({
+      name: "PasskeyEnrollmentChallengeError",
+      error: "not_authenticated"
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrollVerify
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.enrollVerify()", () => {
+  let secret: string;
+
+  beforeEach(async () => {
+    secret = await generateSecret(32);
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns authentication method on success (App Router)", async () => {
+    const sessionValue = await makeSessionCookie(secret);
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionValue}; Path=/; HttpOnly`
+    );
+
+    mockMeAudienceTokenRefresh();
+
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}/verify`,
+        () =>
+          HttpResponse.json({
+            id: DEFAULT.authenticationMethodId,
+            type: "passkey",
+            name: "Touch ID",
+            created_at: "2024-01-01T00:00:00.000Z",
+            last_authenticated_at: "2024-01-01T00:00:00.000Z"
+          })
+      )
+    );
+
+    const client = new ServerPasskeyClient({
+      forRequest: async () =>
+        new AuthClient({
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          secret,
+          transactionStore: new TransactionStore({ secret }),
+          sessionStore: new StatelessSessionStore({ secret }),
+          routes: getDefaultRoutes()
+        }),
+      isResolverMode: false
+    } as unknown as AuthClientProvider);
+
+    const result = await client.enrollVerify({
+      authenticationMethodId: DEFAULT.authenticationMethodId,
+      authSession: DEFAULT.authSession,
+      authResponse: MOCK_AUTH_RESPONSE
+    });
+
+    expect(result.id).toBe(DEFAULT.authenticationMethodId);
+    expect(result.type).toBe("passkey");
+    expect(result.name).toBe("Touch ID");
+  });
+
+  it("throws PasskeyEnrollVerifyError when no session", async () => {
+    await expect(
+      (await makePasskeyClient(secret)).enrollVerify({
+        authenticationMethodId: DEFAULT.authenticationMethodId,
+        authSession: DEFAULT.authSession,
+        authResponse: MOCK_AUTH_RESPONSE
+      })
+    ).rejects.toMatchObject({
+      name: "PasskeyEnrollVerifyError",
+      error: "not_authenticated"
+    });
+  });
+
+  it("throws PasskeyEnrollVerifyError on API failure", async () => {
+    const sessionValue = await makeSessionCookie(secret);
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionValue}; Path=/; HttpOnly`
+    );
+
+    mockMeAudienceTokenRefresh();
+
+    server.use(
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods/${DEFAULT.authenticationMethodId}/verify`,
+        () =>
+          HttpResponse.json(
+            {
+              error: "credential_already_registered",
+              error_description: "This passkey is already registered."
+            },
+            { status: 400 }
+          )
+      )
+    );
+
+    const client = new ServerPasskeyClient({
+      forRequest: async () =>
+        new AuthClient({
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          secret,
+          transactionStore: new TransactionStore({ secret }),
+          sessionStore: new StatelessSessionStore({ secret }),
+          routes: getDefaultRoutes()
+        }),
+      isResolverMode: false
+    } as unknown as AuthClientProvider);
+
+    await expect(
+      client.enrollVerify({
+        authenticationMethodId: DEFAULT.authenticationMethodId,
+        authSession: DEFAULT.authSession,
+        authResponse: MOCK_AUTH_RESPONSE
+      })
+    ).rejects.toMatchObject({
+      name: "PasskeyEnrollVerifyError",
+      error: "credential_already_registered"
+    });
+  });
+
+  it("throws TypeError when options missing (Pages Router guard)", async () => {
+    const req = new NextRequest(
+      new URL("/api/passkey/enroll-verify", DEFAULT.appBaseUrl),
+      { method: "POST" }
+    );
+
+    await expect(
+      (await makePasskeyClient(secret)).enrollVerify(req as any)
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -107,10 +107,10 @@ async function makePasskeyClient(
 }
 
 // ---------------------------------------------------------------------------
-// signupChallenge
+// register
 // ---------------------------------------------------------------------------
 
-describe("ServerPasskeyClient.signupChallenge()", () => {
+describe("ServerPasskeyClient.register()", () => {
   beforeEach(() => {
     mockCookieHeaders = new Headers();
   });
@@ -125,7 +125,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
       )
     );
 
-    const result = await (await makePasskeyClient()).signupChallenge();
+    const result = await (await makePasskeyClient()).register();
 
     expect(result.authSession).toBe(DEFAULT.authSession);
     expect(result.authnParamsPublicKey).toEqual({ challenge: "abc123" });
@@ -148,7 +148,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
 
     await (
       await makePasskeyClient()
-    ).signupChallenge({
+    ).register({
       email: "jane@example.com",
       name: "Jane Doe"
     });
@@ -159,7 +159,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     });
   });
 
-  it("throws PasskeySignupChallengeError on Auth0 failure", async () => {
+  it("throws PasskeyRegisterError on Auth0 failure", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
         HttpResponse.json(
@@ -172,10 +172,8 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
       )
     );
 
-    await expect(
-      (await makePasskeyClient()).signupChallenge()
-    ).rejects.toMatchObject({
-      name: "PasskeySignupChallengeError",
+    await expect((await makePasskeyClient()).register()).rejects.toMatchObject({
+      name: "PasskeyRegisterError",
       error: "passkeys_not_enabled"
     });
   });
@@ -194,11 +192,11 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     );
 
     const req = new NextRequest(
-      new URL("/api/passkey/signup-challenge", DEFAULT.appBaseUrl),
+      new URL("/api/passkey/register", DEFAULT.appBaseUrl),
       { method: "POST" }
     );
 
-    const result = await (await makePasskeyClient()).signupChallenge(req);
+    const result = await (await makePasskeyClient()).register(req);
 
     expect(result.authSession).toBe(DEFAULT.authSession);
     expect(vi.mocked(cookies)).not.toHaveBeenCalled();
@@ -221,7 +219,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
 
     await (
       await makePasskeyClient()
-    ).signupChallenge({
+    ).register({
       email: "jane@example.com",
       connection: "Username-Password-Authentication"
     });
@@ -244,9 +242,7 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
       )
     );
 
-    await (
-      await makePasskeyClient()
-    ).signupChallenge({ phoneNumber: "+1234567890" });
+    await (await makePasskeyClient()).register({ phoneNumber: "+1234567890" });
 
     expect(capturedBody.user_profile.phone_number).toBe("+1234567890");
   });
@@ -266,12 +262,12 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
       )
     );
 
-    await (await makePasskeyClient()).signupChallenge({ username: "janedoe" });
+    await (await makePasskeyClient()).register({ username: "janedoe" });
 
     expect(capturedBody.user_profile.username).toBe("janedoe");
   });
 
-  it("throws PasskeySignupChallengeError when Auth0 rejects unknown user_profile field", async () => {
+  it("throws PasskeyRegisterError when Auth0 rejects unknown user_profile field", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/passkey/register`, () =>
         HttpResponse.json(
@@ -285,19 +281,19 @@ describe("ServerPasskeyClient.signupChallenge()", () => {
     );
 
     await expect(
-      (await makePasskeyClient()).signupChallenge({ email: "jane@example.com" })
+      (await makePasskeyClient()).register({ email: "jane@example.com" })
     ).rejects.toMatchObject({
-      name: "PasskeySignupChallengeError",
+      name: "PasskeyRegisterError",
       error: "invalid_request"
     });
   });
 });
 
 // ---------------------------------------------------------------------------
-// loginChallenge
+// challenge
 // ---------------------------------------------------------------------------
 
-describe("ServerPasskeyClient.loginChallenge()", () => {
+describe("ServerPasskeyClient.challenge()", () => {
   beforeEach(() => {
     mockCookieHeaders = new Headers();
   });
@@ -312,7 +308,7 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
       )
     );
 
-    const result = await (await makePasskeyClient()).loginChallenge();
+    const result = await (await makePasskeyClient()).challenge();
 
     expect(result.authSession).toBe(DEFAULT.authSession);
     expect(result.authnParamsPublicKey).toEqual({
@@ -320,31 +316,7 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
     });
   });
 
-  it("passes username in request body", async () => {
-    let capturedBody: any;
-    server.use(
-      http.post(
-        `https://${DEFAULT.domain}/passkey/challenge`,
-        async ({ request }) => {
-          capturedBody = await request.json();
-          return HttpResponse.json({
-            auth_session: DEFAULT.authSession,
-            authn_params_public_key: {}
-          });
-        }
-      )
-    );
-
-    await (
-      await makePasskeyClient()
-    ).loginChallenge({
-      username: "user@example.com"
-    });
-
-    expect(capturedBody.username).toBe("user@example.com");
-  });
-
-  it("throws PasskeyLoginChallengeError on Auth0 failure", async () => {
+  it("throws PasskeyChallengeError on Auth0 failure", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
         HttpResponse.json(
@@ -357,12 +329,12 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
       )
     );
 
-    await expect(
-      (await makePasskeyClient()).loginChallenge()
-    ).rejects.toMatchObject({
-      name: "PasskeyLoginChallengeError",
-      error: "passkeys_not_enabled"
-    });
+    await expect((await makePasskeyClient()).challenge()).rejects.toMatchObject(
+      {
+        name: "PasskeyChallengeError",
+        error: "passkeys_not_enabled"
+      }
+    );
   });
 
   it("returns challenge response via Pages Router overload", async () => {
@@ -379,11 +351,11 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
     );
 
     const req = new NextRequest(
-      new URL("/api/passkey/login-challenge", DEFAULT.appBaseUrl),
+      new URL("/api/passkey/challenge", DEFAULT.appBaseUrl),
       { method: "POST" }
     );
 
-    await (await makePasskeyClient()).loginChallenge(req);
+    await (await makePasskeyClient()).challenge(req);
 
     expect(vi.mocked(cookies)).not.toHaveBeenCalled();
   });
@@ -405,14 +377,14 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
 
     await (
       await makePasskeyClient()
-    ).loginChallenge({
+    ).challenge({
       connection: "Username-Password-Authentication"
     });
 
     expect(capturedBody.realm).toBe("Username-Password-Authentication");
   });
 
-  it("throws PasskeyLoginChallengeError when no passkey found for user", async () => {
+  it("throws PasskeyChallengeError when no passkey found for user", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/passkey/challenge`, () =>
         HttpResponse.json(
@@ -425,14 +397,12 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
       )
     );
 
-    await expect(
-      (await makePasskeyClient()).loginChallenge({
-        username: "no-passkey@example.com"
-      })
-    ).rejects.toMatchObject({
-      name: "PasskeyLoginChallengeError",
-      error: "no_passkey_found"
-    });
+    await expect((await makePasskeyClient()).challenge()).rejects.toMatchObject(
+      {
+        name: "PasskeyChallengeError",
+        error: "no_passkey_found"
+      }
+    );
   });
 });
 
@@ -440,7 +410,7 @@ describe("ServerPasskeyClient.loginChallenge()", () => {
 // verify
 // ---------------------------------------------------------------------------
 
-describe("ServerPasskeyClient.verify()", () => {
+describe("ServerPasskeyClient.getToken()", () => {
   beforeEach(() => {
     mockCookieHeaders = new Headers();
   });
@@ -462,7 +432,7 @@ describe("ServerPasskeyClient.verify()", () => {
 
     await (
       await makePasskeyClient()
-    ).verify({
+    ).getToken({
       authSession: DEFAULT.authSession,
       authResponse: MOCK_AUTH_RESPONSE
     });
@@ -472,7 +442,7 @@ describe("ServerPasskeyClient.verify()", () => {
     expect(setCookie).toMatch(/__session=/);
   });
 
-  it("throws PasskeyVerifyError on token exchange failure", async () => {
+  it("throws PasskeyGetTokenError on token exchange failure", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
         HttpResponse.json(
@@ -486,12 +456,12 @@ describe("ServerPasskeyClient.verify()", () => {
     );
 
     await expect(
-      (await makePasskeyClient()).verify({
+      (await makePasskeyClient()).getToken({
         authSession: DEFAULT.authSession,
         authResponse: MOCK_AUTH_RESPONSE
       })
     ).rejects.toMatchObject({
-      name: "PasskeyVerifyError",
+      name: "PasskeyGetTokenError",
       error: "invalid_grant"
     });
 
@@ -500,7 +470,7 @@ describe("ServerPasskeyClient.verify()", () => {
 
   it("throws TypeError when extra arguments passed (App Router guard)", async () => {
     await expect(
-      ((await makePasskeyClient()).verify as any)(
+      ((await makePasskeyClient()).getToken as any)(
         { authSession: DEFAULT.authSession, authResponse: MOCK_AUTH_RESPONSE },
         new NextResponse()
       )
@@ -527,14 +497,14 @@ describe("ServerPasskeyClient.verify()", () => {
       );
 
       const req = new NextRequest(
-        new URL("/api/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/api/passkey/get-token", DEFAULT.appBaseUrl),
         { method: "POST" }
       );
       const res = new NextResponse();
 
       await (
         await makePasskeyClient()
-      ).verify(req, res, {
+      ).getToken(req, res, {
         authSession: DEFAULT.authSession,
         authResponse: MOCK_AUTH_RESPONSE
       });
@@ -545,12 +515,12 @@ describe("ServerPasskeyClient.verify()", () => {
 
     it("throws TypeError when res is missing", async () => {
       const req = new NextRequest(
-        new URL("/api/passkey/verify", DEFAULT.appBaseUrl),
+        new URL("/api/passkey/get-token", DEFAULT.appBaseUrl),
         { method: "POST" }
       );
 
       await expect(
-        ((await makePasskeyClient()).verify as any)(req, {
+        ((await makePasskeyClient()).getToken as any)(req, {
           authSession: DEFAULT.authSession,
           authResponse: MOCK_AUTH_RESPONSE
         })
@@ -580,7 +550,7 @@ describe("ServerPasskeyClient.verify()", () => {
 
     await (
       await makePasskeyClient()
-    ).verify({
+    ).getToken({
       authSession: DEFAULT.authSession,
       authResponse: MOCK_AUTH_RESPONSE
     });
@@ -611,7 +581,7 @@ describe("ServerPasskeyClient.verify()", () => {
 
     await (
       await makePasskeyClient()
-    ).verify({
+    ).getToken({
       authSession: DEFAULT.authSession,
       authResponse: MOCK_AUTH_RESPONSE
     });
@@ -621,7 +591,7 @@ describe("ServerPasskeyClient.verify()", () => {
     expect(setCookie).toMatch(/__session=/);
   });
 
-  it("throws PasskeyVerifyError when id_token is missing from response", async () => {
+  it("throws PasskeyGetTokenError when id_token is missing from response", async () => {
     server.use(
       http.post(`https://${DEFAULT.domain}/oauth/token`, () =>
         HttpResponse.json({
@@ -634,7 +604,7 @@ describe("ServerPasskeyClient.verify()", () => {
     );
 
     await expect(
-      (await makePasskeyClient()).verify({
+      (await makePasskeyClient()).getToken({
         authSession: DEFAULT.authSession,
         authResponse: MOCK_AUTH_RESPONSE
       })

--- a/src/server/passkey/server-passkey-client.ts
+++ b/src/server/passkey/server-passkey-client.ts
@@ -2,11 +2,8 @@ import { cookies as getCookies } from "next/headers.js";
 import { NextRequest, NextResponse } from "next/server.js";
 
 import type {
-  PasskeyAuthenticationMethod,
   PasskeyChallengeResponse,
   PasskeyClient,
-  PasskeyEnrollmentChallengeResponse,
-  PasskeyEnrollVerifyOptions,
   PasskeyLoginChallengeOptions,
   PasskeySignupChallengeOptions,
   PasskeyVerifyOptions
@@ -23,11 +20,6 @@ import type { AuthClient } from "../auth-client.js";
  * 1. Call signupChallenge() or loginChallenge() to get the WebAuthn options.
  * 2. In the browser: pass authnParamsPublicKey to navigator.credentials.create/get().
  * 3. Call verify() with authSession + serialised credential to create the session.
- *
- * Enrollment flow (add passkey to an existing authenticated account):
- * 1. Call enrollmentChallenge() to get the WebAuthn creation options.
- * 2. In the browser: pass authnParamsPublicKey to navigator.credentials.create().
- * 3. Call enrollVerify() with authenticationMethodId + authSession + credential.
  *
  * @example App Router — signup
  * ```typescript
@@ -155,56 +147,5 @@ export class ServerPasskeyClient implements PasskeyClient {
         cookiesLib as any
       );
     }
-  }
-
-  // ---------------------------------------------------------------------------
-  // enrollmentChallenge
-  // ---------------------------------------------------------------------------
-
-  /** App Router overload. */
-  async enrollmentChallenge(): Promise<PasskeyEnrollmentChallengeResponse>;
-
-  /** Pages Router / Middleware overload. */
-  async enrollmentChallenge(
-    req: NextRequest
-  ): Promise<PasskeyEnrollmentChallengeResponse>;
-
-  async enrollmentChallenge(
-    req?: NextRequest
-  ): Promise<PasskeyEnrollmentChallengeResponse> {
-    const authClient = await this.getAuthClient(req);
-    return authClient.passkeyEnrollmentChallenge(req);
-  }
-
-  // ---------------------------------------------------------------------------
-  // enrollVerify
-  // ---------------------------------------------------------------------------
-
-  /** App Router overload. */
-  async enrollVerify(
-    options: PasskeyEnrollVerifyOptions
-  ): Promise<PasskeyAuthenticationMethod>;
-
-  /** Pages Router / Middleware overload. */
-  async enrollVerify(
-    req: NextRequest,
-    options: PasskeyEnrollVerifyOptions
-  ): Promise<PasskeyAuthenticationMethod>;
-
-  async enrollVerify(
-    arg1: PasskeyEnrollVerifyOptions | NextRequest,
-    arg2?: PasskeyEnrollVerifyOptions
-  ): Promise<PasskeyAuthenticationMethod> {
-    if (arg1 instanceof NextRequest) {
-      if (!arg2) {
-        throw new TypeError(
-          "enrollVerify(req, options): options argument is required"
-        );
-      }
-      const authClient = await this.getAuthClient(arg1);
-      return authClient.passkeyEnrollVerify(arg2, arg1);
-    }
-    const authClient = await this.getAuthClient();
-    return authClient.passkeyEnrollVerify(arg1);
   }
 }

--- a/src/server/passkey/server-passkey-client.ts
+++ b/src/server/passkey/server-passkey-client.ts
@@ -2,11 +2,12 @@ import { cookies as getCookies } from "next/headers.js";
 import { NextRequest, NextResponse } from "next/server.js";
 
 import type {
+  PasskeyChallengeOptions,
   PasskeyChallengeResponse,
   PasskeyClient,
-  PasskeyLoginChallengeOptions,
-  PasskeySignupChallengeOptions,
-  PasskeyVerifyOptions
+  PasskeyGetTokenOptions,
+  PasskeyRegisterOptions,
+  PasskeyRegisterResponse
 } from "../../types/index.js";
 import type { AuthClientProvider } from "../auth-client-provider.js";
 import type { AuthClient } from "../auth-client.js";
@@ -17,27 +18,27 @@ import type { AuthClient } from "../auth-client.js";
  * Provides overload support for App Router and Pages Router.
  *
  * Authentication flow (signup / login):
- * 1. Call signupChallenge() or loginChallenge() to get the WebAuthn options.
+ * 1. Call register() or challenge() to get the WebAuthn options.
  * 2. In the browser: pass authnParamsPublicKey to navigator.credentials.create/get().
- * 3. Call verify() with authSession + serialised credential to create the session.
+ * 3. Call getToken() with authSession + serialised credential to create the session.
  *
  * @example App Router — signup
  * ```typescript
  * import { auth0 } from '@/lib/auth0';
  *
  * export async function POST(req: NextRequest) {
- *   const challenge = await auth0.passkey.signupChallenge();
+ *   const challenge = await auth0.passkey.register();
  *   return NextResponse.json(challenge);
  * }
  * ```
  *
- * @example App Router — verify
+ * @example App Router — getToken
  * ```typescript
  * import { auth0 } from '@/lib/auth0';
  *
  * export async function POST(req: NextRequest) {
  *   const { authSession, authResponse } = await req.json();
- *   await auth0.passkey.verify({ authSession, authResponse });
+ *   await auth0.passkey.getToken({ authSession, authResponse });
  *   return new Response(null, { status: 204 });
  * }
  * ```
@@ -53,99 +54,95 @@ export class ServerPasskeyClient implements PasskeyClient {
   }
 
   // ---------------------------------------------------------------------------
-  // signupChallenge
+  // register
   // ---------------------------------------------------------------------------
 
   /** App Router overload. */
-  async signupChallenge(
-    options?: PasskeySignupChallengeOptions
-  ): Promise<PasskeyChallengeResponse>;
+  async register(
+    options?: PasskeyRegisterOptions
+  ): Promise<PasskeyRegisterResponse>;
 
   /** Pages Router / Middleware overload. */
-  async signupChallenge(
+  async register(
     req: NextRequest,
-    options?: PasskeySignupChallengeOptions
-  ): Promise<PasskeyChallengeResponse>;
+    options?: PasskeyRegisterOptions
+  ): Promise<PasskeyRegisterResponse>;
 
-  async signupChallenge(
-    arg1?: PasskeySignupChallengeOptions | NextRequest,
-    arg2?: PasskeySignupChallengeOptions
-  ): Promise<PasskeyChallengeResponse> {
+  async register(
+    arg1?: PasskeyRegisterOptions | NextRequest,
+    arg2?: PasskeyRegisterOptions
+  ): Promise<PasskeyRegisterResponse> {
     if (arg1 instanceof NextRequest) {
       const authClient = await this.getAuthClient(arg1);
-      return authClient.passkeySignupChallenge(arg2);
+      return authClient.passkeyRegister(arg2);
     }
     const authClient = await this.getAuthClient();
-    return authClient.passkeySignupChallenge(arg1);
+    return authClient.passkeyRegister(arg1);
   }
 
   // ---------------------------------------------------------------------------
-  // loginChallenge
+  // challenge
   // ---------------------------------------------------------------------------
 
   /** App Router overload. */
-  async loginChallenge(
-    options?: PasskeyLoginChallengeOptions
+  async challenge(
+    options?: PasskeyChallengeOptions
   ): Promise<PasskeyChallengeResponse>;
 
   /** Pages Router / Middleware overload. */
-  async loginChallenge(
+  async challenge(
     req: NextRequest,
-    options?: PasskeyLoginChallengeOptions
+    options?: PasskeyChallengeOptions
   ): Promise<PasskeyChallengeResponse>;
 
-  async loginChallenge(
-    arg1?: PasskeyLoginChallengeOptions | NextRequest,
-    arg2?: PasskeyLoginChallengeOptions
+  async challenge(
+    arg1?: PasskeyChallengeOptions | NextRequest,
+    arg2?: PasskeyChallengeOptions
   ): Promise<PasskeyChallengeResponse> {
     if (arg1 instanceof NextRequest) {
       const authClient = await this.getAuthClient(arg1);
-      return authClient.passkeyLoginChallenge(arg2);
+      return authClient.passkeyChallenge(arg2);
     }
     const authClient = await this.getAuthClient();
-    return authClient.passkeyLoginChallenge(arg1);
+    return authClient.passkeyChallenge(arg1);
   }
 
   // ---------------------------------------------------------------------------
-  // verify
+  // getToken
   // ---------------------------------------------------------------------------
 
   /** App Router overload — reads and writes cookies from next/headers. */
-  async verify(options: PasskeyVerifyOptions): Promise<void>;
+  async getToken(options: PasskeyGetTokenOptions): Promise<void>;
 
   /** Pages Router / Middleware overload — explicit req/res. */
-  async verify(
+  async getToken(
     req: NextRequest,
     res: NextResponse,
-    options: PasskeyVerifyOptions
+    options: PasskeyGetTokenOptions
   ): Promise<void>;
 
-  async verify(
-    arg1: PasskeyVerifyOptions | NextRequest,
+  async getToken(
+    arg1: PasskeyGetTokenOptions | NextRequest,
     arg2?: NextResponse,
-    arg3?: PasskeyVerifyOptions
+    arg3?: PasskeyGetTokenOptions
   ): Promise<void> {
     if (arg1 instanceof NextRequest) {
       if (!arg2 || !arg3) {
         throw new TypeError(
-          "verify(req, res, options): All three arguments required for Pages Router"
+          "getToken(req, res, options): All three arguments required for Pages Router"
         );
       }
       const authClient = await this.getAuthClient(arg1);
-      await authClient.passkeyVerify(arg3, arg1.cookies, arg2.cookies);
+      await authClient.passkeyGetToken(arg3, arg1.cookies, arg2.cookies);
     } else {
       if (arg2 !== undefined || arg3 !== undefined) {
         throw new TypeError(
-          "verify(options): Only one argument allowed for App Router"
+          "getToken(options): Only one argument allowed for App Router"
         );
       }
       const authClient = await this.getAuthClient();
       const cookiesLib = await getCookies();
-      await authClient.passkeyVerify(
-        arg1,
-        cookiesLib as any,
-        cookiesLib as any
-      );
+      await authClient.passkeyGetToken(arg1, cookiesLib, cookiesLib);
     }
   }
 }

--- a/src/server/passkey/server-passkey-client.ts
+++ b/src/server/passkey/server-passkey-client.ts
@@ -1,0 +1,210 @@
+import { cookies as getCookies } from "next/headers.js";
+import { NextRequest, NextResponse } from "next/server.js";
+
+import type {
+  PasskeyAuthenticationMethod,
+  PasskeyChallengeResponse,
+  PasskeyClient,
+  PasskeyEnrollmentChallengeResponse,
+  PasskeyEnrollVerifyOptions,
+  PasskeyLoginChallengeOptions,
+  PasskeySignupChallengeOptions,
+  PasskeyVerifyOptions
+} from "../../types/index.js";
+import type { AuthClientProvider } from "../auth-client-provider.js";
+import type { AuthClient } from "../auth-client.js";
+
+/**
+ * Server-side passkey authentication API.
+ * Delegates all operations to AuthClient business logic.
+ * Provides overload support for App Router and Pages Router.
+ *
+ * Authentication flow (signup / login):
+ * 1. Call signupChallenge() or loginChallenge() to get the WebAuthn options.
+ * 2. In the browser: pass authnParamsPublicKey to navigator.credentials.create/get().
+ * 3. Call verify() with authSession + serialised credential to create the session.
+ *
+ * Enrollment flow (add passkey to an existing authenticated account):
+ * 1. Call enrollmentChallenge() to get the WebAuthn creation options.
+ * 2. In the browser: pass authnParamsPublicKey to navigator.credentials.create().
+ * 3. Call enrollVerify() with authenticationMethodId + authSession + credential.
+ *
+ * @example App Router — signup
+ * ```typescript
+ * import { auth0 } from '@/lib/auth0';
+ *
+ * export async function POST(req: NextRequest) {
+ *   const challenge = await auth0.passkey.signupChallenge();
+ *   return NextResponse.json(challenge);
+ * }
+ * ```
+ *
+ * @example App Router — verify
+ * ```typescript
+ * import { auth0 } from '@/lib/auth0';
+ *
+ * export async function POST(req: NextRequest) {
+ *   const { authSession, authResponse } = await req.json();
+ *   await auth0.passkey.verify({ authSession, authResponse });
+ *   return new Response(null, { status: 204 });
+ * }
+ * ```
+ */
+export class ServerPasskeyClient implements PasskeyClient {
+  constructor(private provider: AuthClientProvider) {}
+
+  private async getAuthClient(req?: NextRequest): Promise<AuthClient> {
+    const { headers } = await import("next/headers.js");
+    const reqHeaders = req ? req.headers : await headers();
+    const url = req?.nextUrl;
+    return this.provider.forRequest(reqHeaders, url);
+  }
+
+  // ---------------------------------------------------------------------------
+  // signupChallenge
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async signupChallenge(
+    options?: PasskeySignupChallengeOptions
+  ): Promise<PasskeyChallengeResponse>;
+
+  /** Pages Router / Middleware overload. */
+  async signupChallenge(
+    req: NextRequest,
+    options?: PasskeySignupChallengeOptions
+  ): Promise<PasskeyChallengeResponse>;
+
+  async signupChallenge(
+    arg1?: PasskeySignupChallengeOptions | NextRequest,
+    arg2?: PasskeySignupChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    if (arg1 instanceof NextRequest) {
+      const authClient = await this.getAuthClient(arg1);
+      return authClient.passkeySignupChallenge(arg2);
+    }
+    const authClient = await this.getAuthClient();
+    return authClient.passkeySignupChallenge(arg1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // loginChallenge
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async loginChallenge(
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyChallengeResponse>;
+
+  /** Pages Router / Middleware overload. */
+  async loginChallenge(
+    req: NextRequest,
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyChallengeResponse>;
+
+  async loginChallenge(
+    arg1?: PasskeyLoginChallengeOptions | NextRequest,
+    arg2?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    if (arg1 instanceof NextRequest) {
+      const authClient = await this.getAuthClient(arg1);
+      return authClient.passkeyLoginChallenge(arg2);
+    }
+    const authClient = await this.getAuthClient();
+    return authClient.passkeyLoginChallenge(arg1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // verify
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload — reads and writes cookies from next/headers. */
+  async verify(options: PasskeyVerifyOptions): Promise<void>;
+
+  /** Pages Router / Middleware overload — explicit req/res. */
+  async verify(
+    req: NextRequest,
+    res: NextResponse,
+    options: PasskeyVerifyOptions
+  ): Promise<void>;
+
+  async verify(
+    arg1: PasskeyVerifyOptions | NextRequest,
+    arg2?: NextResponse,
+    arg3?: PasskeyVerifyOptions
+  ): Promise<void> {
+    if (arg1 instanceof NextRequest) {
+      if (!arg2 || !arg3) {
+        throw new TypeError(
+          "verify(req, res, options): All three arguments required for Pages Router"
+        );
+      }
+      const authClient = await this.getAuthClient(arg1);
+      await authClient.passkeyVerify(arg3, arg1.cookies, arg2.cookies);
+    } else {
+      if (arg2 !== undefined || arg3 !== undefined) {
+        throw new TypeError(
+          "verify(options): Only one argument allowed for App Router"
+        );
+      }
+      const authClient = await this.getAuthClient();
+      const cookiesLib = await getCookies();
+      await authClient.passkeyVerify(
+        arg1,
+        cookiesLib as any,
+        cookiesLib as any
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // enrollmentChallenge
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async enrollmentChallenge(): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  /** Pages Router / Middleware overload. */
+  async enrollmentChallenge(
+    req: NextRequest
+  ): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  async enrollmentChallenge(
+    req?: NextRequest
+  ): Promise<PasskeyEnrollmentChallengeResponse> {
+    const authClient = await this.getAuthClient(req);
+    return authClient.passkeyEnrollmentChallenge(req);
+  }
+
+  // ---------------------------------------------------------------------------
+  // enrollVerify
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async enrollVerify(
+    options: PasskeyEnrollVerifyOptions
+  ): Promise<PasskeyAuthenticationMethod>;
+
+  /** Pages Router / Middleware overload. */
+  async enrollVerify(
+    req: NextRequest,
+    options: PasskeyEnrollVerifyOptions
+  ): Promise<PasskeyAuthenticationMethod>;
+
+  async enrollVerify(
+    arg1: PasskeyEnrollVerifyOptions | NextRequest,
+    arg2?: PasskeyEnrollVerifyOptions
+  ): Promise<PasskeyAuthenticationMethod> {
+    if (arg1 instanceof NextRequest) {
+      if (!arg2) {
+        throw new TypeError(
+          "enrollVerify(req, options): options argument is required"
+        );
+      }
+      const authClient = await this.getAuthClient(arg1);
+      return authClient.passkeyEnrollVerify(arg2, arg1);
+    }
+    const authClient = await this.getAuthClient();
+    return authClient.passkeyEnrollVerify(arg1);
+  }
+}

--- a/src/test/defaults.ts
+++ b/src/test/defaults.ts
@@ -27,14 +27,15 @@ export function getDefaultRoutes(): Routes {
     passwordlessVerify:
       process.env.NEXT_PUBLIC_PASSWORDLESS_VERIFY_ROUTE ||
       "/auth/passwordless/verify",
-    passkeySignupChallenge:
-      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
-      "/auth/passkey/signup-challenge",
-    passkeyLoginChallenge:
-      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
-      "/auth/passkey/login-challenge",
-    passkeyVerify:
-      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
+    passkeyRegister:
+      process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE ||
+      "/auth/passkey/register",
+    passkeyChallenge:
+      process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE ||
+      "/auth/passkey/challenge",
+    passkeyGetToken:
+      process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE ||
+      "/auth/passkey/get-token"
   };
 }
 

--- a/src/test/defaults.ts
+++ b/src/test/defaults.ts
@@ -26,7 +26,15 @@ export function getDefaultRoutes(): Routes {
       "/auth/passwordless/start",
     passwordlessVerify:
       process.env.NEXT_PUBLIC_PASSWORDLESS_VERIFY_ROUTE ||
-      "/auth/passwordless/verify"
+      "/auth/passwordless/verify",
+    passkeySignupChallenge:
+      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
+      "/auth/passkey/signup-challenge",
+    passkeyLoginChallenge:
+      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
+      "/auth/passkey/login-challenge",
+    passkeyVerify:
+      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
   };
 }
 

--- a/src/test/mcd-test-fixtures.ts
+++ b/src/test/mcd-test-fixtures.ts
@@ -50,9 +50,9 @@ export const TEST_DEFAULT_ROUTES: Routes = {
   mfaAssociate: "/auth/mfa/associate",
   passwordlessStart: "/auth/passwordless/start",
   passwordlessVerify: "/auth/passwordless/verify",
-  passkeySignupChallenge: "/auth/passkey/signup-challenge",
-  passkeyLoginChallenge: "/auth/passkey/login-challenge",
-  passkeyVerify: "/auth/passkey/verify"
+  passkeyRegister: "/auth/passkey/register",
+  passkeyChallenge: "/auth/passkey/challenge",
+  passkeyGetToken: "/auth/passkey/get-token"
 };
 
 /**

--- a/src/test/mcd-test-fixtures.ts
+++ b/src/test/mcd-test-fixtures.ts
@@ -49,7 +49,10 @@ export const TEST_DEFAULT_ROUTES: Routes = {
   mfaVerify: "/auth/mfa/verify",
   mfaAssociate: "/auth/mfa/associate",
   passwordlessStart: "/auth/passwordless/start",
-  passwordlessVerify: "/auth/passwordless/verify"
+  passwordlessVerify: "/auth/passwordless/verify",
+  passkeySignupChallenge: "/auth/passkey/signup-challenge",
+  passkeyLoginChallenge: "/auth/passkey/login-challenge",
+  passkeyVerify: "/auth/passkey/verify"
 };
 
 /**


### PR DESCRIPTION
- All new/changed/fixed functionality is covered by tests 
- I have added documentation for all new/changed functionality

  📋 Changes

  Adds server-side passkey business logic and route handlers to AuthClient, and ServerPasskeyClient for App Router / Pages Router usage.

  src/server/auth-client.ts:
  - passkeySignupChallenge() — POST /passkey/register, builds user_profile from flat identity fields
  - passkeyLoginChallenge() — POST /passkey/challenge
  - passkeyVerify() — token exchange via POST /oauth/token using Content-Type: application/json (required by Auth0 — authn_response must be a nested object, not a URL-encoded string)
  - handlePasskeySignupChallenge(), handlePasskeyLoginChallenge(), handlePasskeyVerify() — route handlers dispatched by auth0.handler
  - Routes registered: /auth/passkey/signup-challenge, /auth/passkey/login-challenge, /auth/passkey/verify

  src/server/passkey/server-passkey-client.ts:
  - ServerPasskeyClient implements PasskeyClient with App Router and Pages Router overloads for all three methods
 

  🎯 Testing

  Unit tests in src/server/passkey.flow.test.ts, src/server/passkey-server.flow.test.ts, and src/server/passkey/server-passkey-client.test.ts cover challenge requests, token
  exchange, route dispatch, and both router overloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passkey (WebAuthn) support: register, challenge, and token-exchange flows with session persistence and configurable server routes; server-side passkey client supports both App Router and Pages Router.
* **Tests**
  * Added extensive tests covering passkey flows, token exchange, DPoP behavior, error mappings, and cookie/session handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->