### PR TITLE
Passkey client logic implementation

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -16,3 +16,4 @@ export { mfa } from "./mfa/index.js";
 export type { ChallengeWithPopupOptions } from "./mfa/index.js";
 export type { AccessTokenResponse } from "./helpers/get-access-token.js";
 export { passwordless } from "./passwordless/index.js";
+export { passkey } from "./passkey/index.js";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -16,4 +16,4 @@ export { mfa } from "./mfa/index.js";
 export type { ChallengeWithPopupOptions } from "./mfa/index.js";
 export type { AccessTokenResponse } from "./helpers/get-access-token.js";
 export { passwordless } from "./passwordless/index.js";
-export { passkey } from "./passkey/index.js";
+export { passkey, serializeCredential } from "./passkey/index.js";

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -1,0 +1,386 @@
+import {
+  PasskeyLoginChallengeError,
+  PasskeySignupChallengeError,
+  PasskeyVerifyError
+} from "../../errors/index.js";
+import type {
+  PasskeyAuthResponse,
+  PasskeyBrowserClient,
+  PasskeyChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeySignupChallengeOptions,
+  PasskeyVerifyOptions
+} from "../../types/index.js";
+import { normalizeWithBasePath } from "../../utils/pathUtils.js";
+
+// ---------------------------------------------------------------------------
+// base64url helpers (no external deps, works in all modern browsers)
+// ---------------------------------------------------------------------------
+
+function base64urlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function base64urlDecode(value: string): ArrayBuffer {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (padded.length % 4)) % 4;
+  const base64 = padded + "=".repeat(padding);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+// ---------------------------------------------------------------------------
+// WebAuthn options normalisation
+// Converts base64url-encoded strings from Auth0 back into ArrayBuffers
+// so they can be passed to navigator.credentials.create/get.
+// ---------------------------------------------------------------------------
+
+function decodeCreationOptions(
+  raw: Record<string, unknown>
+): PublicKeyCredentialCreationOptions {
+  const opts = raw as any;
+  return {
+    ...opts,
+    challenge: base64urlDecode(opts.challenge),
+    user: {
+      ...opts.user,
+      id: base64urlDecode(opts.user.id)
+    },
+    excludeCredentials: (opts.excludeCredentials ?? []).map((c: any) => ({
+      ...c,
+      id: base64urlDecode(c.id)
+    }))
+  };
+}
+
+function decodeRequestOptions(
+  raw: Record<string, unknown>
+): PublicKeyCredentialRequestOptions {
+  const opts = raw as any;
+  return {
+    ...opts,
+    challenge: base64urlDecode(opts.challenge),
+    allowCredentials: (opts.allowCredentials ?? []).map((c: any) => ({
+      ...c,
+      id: base64urlDecode(c.id)
+    }))
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Serialise PublicKeyCredential → PasskeyAuthResponse
+// Converts all ArrayBuffers back to base64url strings for JSON transport.
+// ---------------------------------------------------------------------------
+
+function serializeCredential(
+  credential: PublicKeyCredential
+): PasskeyAuthResponse {
+  const response = credential.response as any;
+  return {
+    id: credential.id,
+    rawId: base64urlEncode(credential.rawId),
+    type: "public-key",
+    authenticatorAttachment: credential.authenticatorAttachment ?? null,
+    response: {
+      clientDataJSON: base64urlEncode(response.clientDataJSON),
+      ...(response.attestationObject !== undefined && {
+        attestationObject: base64urlEncode(response.attestationObject)
+      }),
+      ...(response.authenticatorData !== undefined && {
+        authenticatorData: base64urlEncode(response.authenticatorData)
+      }),
+      ...(response.signature !== undefined && {
+        signature: base64urlEncode(response.signature)
+      }),
+      ...(response.userHandle !== undefined && {
+        userHandle: response.userHandle
+          ? base64urlEncode(response.userHandle)
+          : null
+      })
+    },
+    clientExtensionResults: credential.getClientExtensionResults() as Record<
+      string,
+      unknown
+    >
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({
+      error: "client_error",
+      error_description: "Failed to parse error response"
+    }));
+    return Promise.reject(err);
+  }
+
+  return response.json();
+}
+
+// ---------------------------------------------------------------------------
+// ClientPasskeyClient
+// ---------------------------------------------------------------------------
+
+/**
+ * Client-side passkey (WebAuthn) authentication singleton.
+ *
+ * Handles the signup and login flows — fetches the challenge from the SDK route
+ * handler, calls navigator.credentials.create/get, then posts the serialised
+ * credential back to the verify route to create a session.
+ *
+ * All ArrayBuffer ↔ base64url conversion is handled internally.
+ *
+ * @example Signup
+ * ```typescript
+ * 'use client';
+ * import { passkey } from '@auth0/nextjs-auth0/client';
+ *
+ * await passkey.signup();
+ * window.location.href = '/dashboard';
+ * ```
+ *
+ * @example Login
+ * ```typescript
+ * 'use client';
+ * import { passkey } from '@auth0/nextjs-auth0/client';
+ *
+ * await passkey.login();
+ * window.location.href = '/dashboard';
+ * ```
+ *
+ * @example Step-by-step (full control)
+ * ```typescript
+ * 'use client';
+ * import { passkey } from '@auth0/nextjs-auth0/client';
+ *
+ * const challenge = await passkey.signupChallenge();
+ * const credential = await navigator.credentials.create({ publicKey: ... });
+ * await passkey.verify({ authSession: challenge.authSession, authResponse: credential });
+ * ```
+ */
+class ClientPasskeyClient implements PasskeyBrowserClient {
+  // ---------------------------------------------------------------------------
+  // One-call convenience methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Complete a full passkey signup in one call.
+   * Fetches the challenge, runs navigator.credentials.create(), then verifies.
+   *
+   * @throws {PasskeySignupChallengeError} If the challenge request fails
+   * @throws {PasskeyVerifyError} If the WebAuthn ceremony or token exchange fails
+   */
+  async signup(options?: PasskeySignupChallengeOptions): Promise<void> {
+    const challengeUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
+        "/auth/passkey/signup-challenge"
+    );
+
+    let challenge: PasskeyChallengeResponse;
+    try {
+      challenge = await postJson<PasskeyChallengeResponse>(
+        challengeUrl,
+        options ?? {}
+      );
+    } catch (err: any) {
+      throw new PasskeySignupChallengeError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Failed to get passkey signup challenge",
+        err?.error ? err : undefined
+      );
+    }
+
+    let credential: PublicKeyCredential | null;
+    try {
+      credential = (await navigator.credentials.create({
+        publicKey: decodeCreationOptions(challenge.authnParamsPublicKey)
+      })) as PublicKeyCredential | null;
+    } catch (err: any) {
+      throw new PasskeyVerifyError(
+        "webauthn_error",
+        err?.message ?? "WebAuthn credential creation failed",
+        undefined
+      );
+    }
+
+    if (!credential) {
+      throw new PasskeyVerifyError(
+        "webauthn_error",
+        "navigator.credentials.create returned null",
+        undefined
+      );
+    }
+
+    await this._verify(challenge.authSession, credential);
+  }
+
+  /**
+   * Complete a full passkey login in one call.
+   * Fetches the challenge, runs navigator.credentials.get(), then verifies.
+   *
+   * @throws {PasskeyLoginChallengeError} If the challenge request fails
+   * @throws {PasskeyVerifyError} If the WebAuthn ceremony or token exchange fails
+   */
+  async login(options?: PasskeyLoginChallengeOptions): Promise<void> {
+    const challengeUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
+        "/auth/passkey/login-challenge"
+    );
+
+    let challenge: PasskeyChallengeResponse;
+    try {
+      challenge = await postJson<PasskeyChallengeResponse>(
+        challengeUrl,
+        options ?? {}
+      );
+    } catch (err: any) {
+      throw new PasskeyLoginChallengeError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Failed to get passkey login challenge",
+        err?.error ? err : undefined
+      );
+    }
+
+    let credential: PublicKeyCredential | null;
+    try {
+      credential = (await navigator.credentials.get({
+        publicKey: decodeRequestOptions(challenge.authnParamsPublicKey)
+      })) as PublicKeyCredential | null;
+    } catch (err: any) {
+      throw new PasskeyVerifyError(
+        "webauthn_error",
+        err?.message ?? "WebAuthn credential assertion failed",
+        undefined
+      );
+    }
+
+    if (!credential) {
+      throw new PasskeyVerifyError(
+        "webauthn_error",
+        "navigator.credentials.get returned null",
+        undefined
+      );
+    }
+
+    await this._verify(challenge.authSession, credential);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Individual step methods — for callers who want full control
+  // ---------------------------------------------------------------------------
+
+  async signupChallenge(
+    options?: PasskeySignupChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    const url = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
+        "/auth/passkey/signup-challenge"
+    );
+    try {
+      return await postJson<PasskeyChallengeResponse>(url, options ?? {});
+    } catch (err: any) {
+      throw new PasskeySignupChallengeError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Failed to get passkey signup challenge",
+        err?.error ? err : undefined
+      );
+    }
+  }
+
+  async loginChallenge(
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyChallengeResponse> {
+    const url = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
+        "/auth/passkey/login-challenge"
+    );
+    try {
+      return await postJson<PasskeyChallengeResponse>(url, options ?? {});
+    } catch (err: any) {
+      throw new PasskeyLoginChallengeError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Failed to get passkey login challenge",
+        err?.error ? err : undefined
+      );
+    }
+  }
+
+  async verify(options: PasskeyVerifyOptions): Promise<void> {
+    const url = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
+    );
+    try {
+      await postJson(url, options);
+    } catch (err: any) {
+      throw new PasskeyVerifyError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Passkey verification failed",
+        err?.error ? err : undefined
+      );
+    }
+  }
+
+  // Shared verify step used by both signup() and login()
+  private async _verify(
+    authSession: string,
+    credential: PublicKeyCredential
+  ): Promise<void> {
+    const verifyUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
+    );
+
+    try {
+      await postJson(verifyUrl, {
+        authSession,
+        authResponse: serializeCredential(credential)
+      });
+    } catch (err: any) {
+      throw new PasskeyVerifyError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Passkey verification failed",
+        err?.error ? err : undefined
+      );
+    }
+  }
+}
+
+/**
+ * Client-side passkey (WebAuthn) singleton.
+ *
+ * @example
+ * ```typescript
+ * import { passkey } from '@auth0/nextjs-auth0/client';
+ *
+ * // One-call signup
+ * await passkey.signup();
+ *
+ * // One-call login
+ * await passkey.login();
+ *
+ * // Step-by-step (full control)
+ * const challenge = await passkey.signupChallenge();
+ * // ... run navigator.credentials.create() yourself ...
+ * await passkey.verify({ authSession: challenge.authSession, authResponse: credential });
+ * ```
+ */
+export const passkey: PasskeyBrowserClient = new ClientPasskeyClient();

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -1,23 +1,22 @@
 import {
+  PasskeyChallengeError,
   PasskeyEnrollmentChallengeError,
-  PasskeyEnrollVerifyError,
-  PasskeyLoginChallengeError,
-  PasskeySignupChallengeError,
-  PasskeyVerifyError
+  PasskeyEnrollmentVerifyError,
+  PasskeyGetTokenError,
+  PasskeyRegisterError
 } from "../../errors/index.js";
 import type {
-  PasskeyAuthenticationMethod,
   PasskeyAuthResponse,
   PasskeyBrowserClient,
+  PasskeyChallengeOptions,
   PasskeyChallengeResponse,
   PasskeyCreationOptionsJSON,
   PasskeyEnrollmentChallengeOptions,
   PasskeyEnrollmentChallengeResponse,
-  PasskeyEnrollVerifyOptions,
-  PasskeyLoginChallengeOptions,
-  PasskeyRequestOptionsJSON,
-  PasskeySignupChallengeOptions,
-  PasskeyVerifyOptions
+  PasskeyEnrollmentVerifyOptions,
+  PasskeyEnrollmentVerifyResponse,
+  PasskeyRegisterOptions,
+  PasskeyRequestOptionsJSON
 } from "../../types/index.js";
 import { normalizeWithBasePath } from "../../utils/pathUtils.js";
 
@@ -176,14 +175,14 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
  * window.location.href = '/dashboard';
  * ```
  *
- * @example Step-by-step (full control)
+ * @example Enroll a passkey for an existing user
  * ```typescript
  * 'use client';
  * import { passkey } from '@auth0/nextjs-auth0/client';
  *
- * const challenge = await passkey.signupChallenge();
- * const credential = await navigator.credentials.create({ publicKey: ... });
- * await passkey.verify({ authSession: challenge.authSession, authResponse: credential });
+ * const challenge = await passkey.enrollmentChallenge();
+ * const credential = await navigator.credentials.create({ publicKey: challenge.authnParamsPublicKey });
+ * await passkey.enrollmentVerify({ authenticationMethodId: challenge.authenticationMethodId, authSession: challenge.authSession, authResponse: credential });
  * ```
  */
 class ClientPasskeyClient implements PasskeyBrowserClient {
@@ -195,13 +194,12 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
    * Complete a full passkey signup in one call.
    * Fetches the challenge, runs navigator.credentials.create(), then verifies.
    *
-   * @throws {PasskeySignupChallengeError} If the challenge request fails
-   * @throws {PasskeyVerifyError} If the WebAuthn ceremony or token exchange fails
+   * @throws {PasskeyRegisterError} If the challenge request fails
+   * @throws {PasskeyGetTokenError} If the WebAuthn ceremony or token exchange fails
    */
-  async signup(options?: PasskeySignupChallengeOptions): Promise<void> {
+  async signup(options?: PasskeyRegisterOptions): Promise<void> {
     const challengeUrl = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
-        "/auth/passkey/signup-challenge"
+      process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE || "/auth/passkey/register"
     );
 
     let challenge: PasskeyChallengeResponse;
@@ -211,7 +209,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
         options ?? {}
       );
     } catch (err: any) {
-      throw new PasskeySignupChallengeError(
+      throw new PasskeyRegisterError(
         err?.error ?? "client_error",
         err?.error_description ?? "Failed to get passkey signup challenge",
         err?.error ? err : undefined
@@ -226,7 +224,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
         )
       })) as PublicKeyCredential | null;
     } catch (err: any) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "webauthn_error",
         err?.message ?? "WebAuthn credential creation failed",
         undefined
@@ -234,7 +232,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     }
 
     if (!credential) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "webauthn_error",
         "navigator.credentials.create returned null",
         undefined
@@ -248,13 +246,13 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
    * Complete a full passkey login in one call.
    * Fetches the challenge, runs navigator.credentials.get(), then verifies.
    *
-   * @throws {PasskeyLoginChallengeError} If the challenge request fails
-   * @throws {PasskeyVerifyError} If the WebAuthn ceremony or token exchange fails
+   * @throws {PasskeyChallengeError} If the challenge request fails
+   * @throws {PasskeyGetTokenError} If the WebAuthn ceremony or token exchange fails
    */
-  async login(options?: PasskeyLoginChallengeOptions): Promise<void> {
+  async login(options?: PasskeyChallengeOptions): Promise<void> {
     const challengeUrl = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
-        "/auth/passkey/login-challenge"
+      process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE ||
+        "/auth/passkey/challenge"
     );
 
     let challenge: PasskeyChallengeResponse;
@@ -264,7 +262,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
         options ?? {}
       );
     } catch (err: any) {
-      throw new PasskeyLoginChallengeError(
+      throw new PasskeyChallengeError(
         err?.error ?? "client_error",
         err?.error_description ?? "Failed to get passkey login challenge",
         err?.error ? err : undefined
@@ -279,7 +277,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
         )
       })) as PublicKeyCredential | null;
     } catch (err: any) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "webauthn_error",
         err?.message ?? "WebAuthn credential assertion failed",
         undefined
@@ -287,7 +285,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     }
 
     if (!credential) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         "webauthn_error",
         "navigator.credentials.get returned null",
         undefined
@@ -295,61 +293,6 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     }
 
     await this._verify(challenge.authSession, credential);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Individual step methods — for callers who want full control
-  // ---------------------------------------------------------------------------
-
-  async signupChallenge(
-    options?: PasskeySignupChallengeOptions
-  ): Promise<PasskeyChallengeResponse> {
-    const url = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE ||
-        "/auth/passkey/signup-challenge"
-    );
-    try {
-      return await postJson<PasskeyChallengeResponse>(url, options ?? {});
-    } catch (err: any) {
-      throw new PasskeySignupChallengeError(
-        err?.error ?? "client_error",
-        err?.error_description ?? "Failed to get passkey signup challenge",
-        err?.error ? err : undefined
-      );
-    }
-  }
-
-  async loginChallenge(
-    options?: PasskeyLoginChallengeOptions
-  ): Promise<PasskeyChallengeResponse> {
-    const url = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE ||
-        "/auth/passkey/login-challenge"
-    );
-    try {
-      return await postJson<PasskeyChallengeResponse>(url, options ?? {});
-    } catch (err: any) {
-      throw new PasskeyLoginChallengeError(
-        err?.error ?? "client_error",
-        err?.error_description ?? "Failed to get passkey login challenge",
-        err?.error ? err : undefined
-      );
-    }
-  }
-
-  async verify(options: PasskeyVerifyOptions): Promise<void> {
-    const url = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
-    );
-    try {
-      await postJson(url, options);
-    } catch (err: any) {
-      throw new PasskeyVerifyError(
-        err?.error ?? "client_error",
-        err?.error_description ?? "Passkey verification failed",
-        err?.error ? err : undefined
-      );
-    }
   }
 
   // Shared verify step used by both signup() and login()
@@ -367,7 +310,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
         authResponse: serializeCredential(credential)
       });
     } catch (err: any) {
-      throw new PasskeyVerifyError(
+      throw new PasskeyGetTokenError(
         err?.error ?? "client_error",
         err?.error_description ?? "Passkey verification failed",
         err?.error ? err : undefined
@@ -389,27 +332,26 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
       );
     } catch (err: any) {
       throw new PasskeyEnrollmentChallengeError(
-        err?.error ?? "client_error",
-        err?.error_description ?? "Failed to get passkey enrollment challenge",
-        err?.error ? err : undefined
+        err?.error_description ?? "Failed to get passkey enrollment challenge"
       );
     }
   }
 
-  async enrollVerify(
-    options: PasskeyEnrollVerifyOptions
-  ): Promise<PasskeyAuthenticationMethod> {
+  async enrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse> {
     const verifyUrl = normalizeWithBasePath(
       process.env.NEXT_PUBLIC_PASSKEY_ENROLL_VERIFY_ROUTE ||
         "/auth/passkey/enroll-verify"
     );
     try {
-      return await postJson<PasskeyAuthenticationMethod>(verifyUrl, options);
+      return await postJson<PasskeyEnrollmentVerifyResponse>(
+        verifyUrl,
+        options
+      );
     } catch (err: any) {
-      throw new PasskeyEnrollVerifyError(
-        err?.error ?? "client_error",
-        err?.error_description ?? "Passkey enrollment verification failed",
-        err?.error ? err : undefined
+      throw new PasskeyEnrollmentVerifyError(
+        err?.error_description ?? "Passkey enrollment verification failed"
       );
     }
   }
@@ -428,10 +370,10 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
  * // One-call login
  * await passkey.login();
  *
- * // Step-by-step (full control)
- * const challenge = await passkey.signupChallenge();
+ * // Enroll a passkey for an authenticated user
+ * const challenge = await passkey.enrollmentChallenge();
  * // ... run navigator.credentials.create() yourself ...
- * await passkey.verify({ authSession: challenge.authSession, authResponse: credential });
+ * await passkey.enrollmentVerify({ authenticationMethodId: challenge.authenticationMethodId, authSession: challenge.authSession, authResponse: credential });
  * ```
  */
 export const passkey: PasskeyBrowserClient = new ClientPasskeyClient();

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -16,6 +16,7 @@ import type {
   PasskeyEnrollmentVerifyOptions,
   PasskeyEnrollmentVerifyResponse,
   PasskeyRegisterOptions,
+  PasskeyRegisterResponse,
   PasskeyRequestOptionsJSON
 } from "../../types/index.js";
 import { normalizeWithBasePath } from "../../utils/pathUtils.js";
@@ -202,9 +203,9 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
       process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE || "/auth/passkey/register"
     );
 
-    let challenge: PasskeyChallengeResponse;
+    let challenge: PasskeyRegisterResponse;
     try {
-      challenge = await postJson<PasskeyChallengeResponse>(
+      challenge = await postJson<PasskeyRegisterResponse>(
         challengeUrl,
         options ?? {}
       );

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -1,13 +1,21 @@
 import {
+  PasskeyEnrollmentChallengeError,
+  PasskeyEnrollVerifyError,
   PasskeyLoginChallengeError,
   PasskeySignupChallengeError,
   PasskeyVerifyError
 } from "../../errors/index.js";
 import type {
+  PasskeyAuthenticationMethod,
   PasskeyAuthResponse,
   PasskeyBrowserClient,
   PasskeyChallengeResponse,
+  PasskeyCreationOptionsJSON,
+  PasskeyEnrollmentChallengeOptions,
+  PasskeyEnrollmentChallengeResponse,
+  PasskeyEnrollVerifyOptions,
   PasskeyLoginChallengeOptions,
+  PasskeyRequestOptionsJSON,
   PasskeySignupChallengeOptions,
   PasskeyVerifyOptions
 } from "../../types/index.js";
@@ -45,7 +53,7 @@ function base64urlDecode(value: string): ArrayBuffer {
 // ---------------------------------------------------------------------------
 
 function decodeCreationOptions(
-  raw: Record<string, unknown>
+  raw: PasskeyCreationOptionsJSON
 ): PublicKeyCredentialCreationOptions {
   const opts = raw as any;
   return {
@@ -63,7 +71,7 @@ function decodeCreationOptions(
 }
 
 function decodeRequestOptions(
-  raw: Record<string, unknown>
+  raw: PasskeyRequestOptionsJSON
 ): PublicKeyCredentialRequestOptions {
   const opts = raw as any;
   return {
@@ -213,7 +221,9 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     let credential: PublicKeyCredential | null;
     try {
       credential = (await navigator.credentials.create({
-        publicKey: decodeCreationOptions(challenge.authnParamsPublicKey)
+        publicKey: decodeCreationOptions(
+          challenge.authnParamsPublicKey as PasskeyCreationOptionsJSON
+        )
       })) as PublicKeyCredential | null;
     } catch (err: any) {
       throw new PasskeyVerifyError(
@@ -264,7 +274,9 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     let credential: PublicKeyCredential | null;
     try {
       credential = (await navigator.credentials.get({
-        publicKey: decodeRequestOptions(challenge.authnParamsPublicKey)
+        publicKey: decodeRequestOptions(
+          challenge.authnParamsPublicKey as PasskeyRequestOptionsJSON
+        )
       })) as PublicKeyCredential | null;
     } catch (err: any) {
       throw new PasskeyVerifyError(
@@ -358,6 +370,45 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
       throw new PasskeyVerifyError(
         err?.error ?? "client_error",
         err?.error_description ?? "Passkey verification failed",
+        err?.error ? err : undefined
+      );
+    }
+  }
+
+  async enrollmentChallenge(
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse> {
+    const challengeUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_CHALLENGE_ROUTE ||
+        "/auth/passkey/enrollment-challenge"
+    );
+    try {
+      return await postJson<PasskeyEnrollmentChallengeResponse>(
+        challengeUrl,
+        options ?? {}
+      );
+    } catch (err: any) {
+      throw new PasskeyEnrollmentChallengeError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Failed to get passkey enrollment challenge",
+        err?.error ? err : undefined
+      );
+    }
+  }
+
+  async enrollVerify(
+    options: PasskeyEnrollVerifyOptions
+  ): Promise<PasskeyAuthenticationMethod> {
+    const verifyUrl = normalizeWithBasePath(
+      process.env.NEXT_PUBLIC_PASSKEY_ENROLL_VERIFY_ROUTE ||
+        "/auth/passkey/enroll-verify"
+    );
+    try {
+      return await postJson<PasskeyAuthenticationMethod>(verifyUrl, options);
+    } catch (err: any) {
+      throw new PasskeyEnrollVerifyError(
+        err?.error ?? "client_error",
+        err?.error_description ?? "Passkey enrollment verification failed",
         err?.error ? err : undefined
       );
     }

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -89,7 +89,7 @@ function decodeRequestOptions(
 // Converts all ArrayBuffers back to base64url strings for JSON transport.
 // ---------------------------------------------------------------------------
 
-function serializeCredential(
+export function serializeCredential(
   credential: PublicKeyCredential
 ): PasskeyAuthResponse {
   const response = credential.response as any;
@@ -142,6 +142,10 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     return Promise.reject(err);
   }
 
+  if (response.status === 204) {
+    return undefined as unknown as T;
+  }
+
   return response.json();
 }
 
@@ -179,14 +183,33 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
  * @example Enroll a passkey for an existing user
  * ```typescript
  * 'use client';
- * import { passkey } from '@auth0/nextjs-auth0/client';
+ * import { passkey, serializeCredential } from '@auth0/nextjs-auth0/client';
  *
  * const challenge = await passkey.enrollmentChallenge();
- * const credential = await navigator.credentials.create({ publicKey: challenge.authnParamsPublicKey });
- * await passkey.enrollmentVerify({ authenticationMethodId: challenge.authenticationMethodId, authSession: challenge.authSession, authResponse: credential });
+ * const rawCredential = await navigator.credentials.create({ publicKey: challenge.authnParamsPublicKey });
+ * await passkey.enrollmentVerify({
+ *   authenticationMethodId: challenge.authenticationMethodId,
+ *   authSession: challenge.authSession,
+ *   authResponse: serializeCredential(rawCredential as PublicKeyCredential)
+ * });
  * ```
  */
 class ClientPasskeyClient implements PasskeyBrowserClient {
+  private assertWebAuthnSupported(): void {
+    if (
+      typeof window === "undefined" ||
+      !window.PublicKeyCredential ||
+      typeof navigator?.credentials?.create !== "function" ||
+      typeof navigator?.credentials?.get !== "function"
+    ) {
+      throw new PasskeyGetTokenError(
+        "webauthn_not_supported",
+        "WebAuthn is not supported in this browser",
+        undefined
+      );
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // One-call convenience methods
   // ---------------------------------------------------------------------------
@@ -195,10 +218,12 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
    * Complete a full passkey signup in one call.
    * Fetches the challenge, runs navigator.credentials.create(), then verifies.
    *
+   * @throws {PasskeyGetTokenError} If WebAuthn is not supported in this browser
    * @throws {PasskeyRegisterError} If the challenge request fails
    * @throws {PasskeyGetTokenError} If the WebAuthn ceremony or token exchange fails
    */
   async signup(options?: PasskeyRegisterOptions): Promise<void> {
+    this.assertWebAuthnSupported();
     const challengeUrl = normalizeWithBasePath(
       process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE || "/auth/passkey/register"
     );
@@ -247,10 +272,12 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
    * Complete a full passkey login in one call.
    * Fetches the challenge, runs navigator.credentials.get(), then verifies.
    *
+   * @throws {PasskeyGetTokenError} If WebAuthn is not supported in this browser
    * @throws {PasskeyChallengeError} If the challenge request fails
    * @throws {PasskeyGetTokenError} If the WebAuthn ceremony or token exchange fails
    */
   async login(options?: PasskeyChallengeOptions): Promise<void> {
+    this.assertWebAuthnSupported();
     const challengeUrl = normalizeWithBasePath(
       process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE ||
         "/auth/passkey/challenge"

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -301,7 +301,8 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     credential: PublicKeyCredential
   ): Promise<void> {
     const verifyUrl = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE || "/auth/passkey/verify"
+      process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE ||
+        "/auth/passkey/get-token"
     );
 
     try {

--- a/src/client/passkey/passkey-client.flow.test.ts
+++ b/src/client/passkey/passkey-client.flow.test.ts
@@ -17,7 +17,7 @@ const BASE_URL = "http://localhost:3000";
 
 const REGISTER_URL = `${BASE_URL}/auth/passkey/register`;
 const CHALLENGE_URL = `${BASE_URL}/auth/passkey/challenge`;
-const VERIFY_URL = `${BASE_URL}/auth/passkey/verify`;
+const VERIFY_URL = `${BASE_URL}/auth/passkey/get-token`;
 
 // Minimal fake challenge payload returned by the SDK route handler (camelCase —
 // the handler transforms Auth0's snake_case response before returning JSON).
@@ -88,7 +88,7 @@ beforeAll(() => {
 
   process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE = REGISTER_URL;
   process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE = CHALLENGE_URL;
-  process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE = VERIFY_URL;
+  process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE = VERIFY_URL;
 
   // jsdom does not implement navigator.credentials — define a stub so vi.spyOn works
   if (!navigator.credentials) {
@@ -114,7 +114,7 @@ afterEach(() => {
 afterAll(() => {
   delete process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE;
   delete process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE;
-  delete process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE;
+  delete process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE;
   server.close();
 });
 

--- a/src/client/passkey/passkey-client.flow.test.ts
+++ b/src/client/passkey/passkey-client.flow.test.ts
@@ -15,8 +15,8 @@ import {
 
 const BASE_URL = "http://localhost:3000";
 
-const SIGNUP_CHALLENGE_URL = `${BASE_URL}/auth/passkey/signup-challenge`;
-const LOGIN_CHALLENGE_URL = `${BASE_URL}/auth/passkey/login-challenge`;
+const REGISTER_URL = `${BASE_URL}/auth/passkey/register`;
+const CHALLENGE_URL = `${BASE_URL}/auth/passkey/challenge`;
 const VERIFY_URL = `${BASE_URL}/auth/passkey/verify`;
 
 // Minimal fake challenge payload returned by the SDK route handler (camelCase —
@@ -86,8 +86,8 @@ const server = setupServer();
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
 
-  process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE = SIGNUP_CHALLENGE_URL;
-  process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE = LOGIN_CHALLENGE_URL;
+  process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE = REGISTER_URL;
+  process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE = CHALLENGE_URL;
   process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE = VERIFY_URL;
 
   // jsdom does not implement navigator.credentials — define a stub so vi.spyOn works
@@ -112,8 +112,8 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  delete process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE;
-  delete process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE;
+  delete process.env.NEXT_PUBLIC_PASSKEY_REGISTER_ROUTE;
+  delete process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE;
   delete process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE;
   server.close();
 });
@@ -136,7 +136,7 @@ describe("ClientPasskeyClient", () => {
       let capturedVerifyBody: Record<string, unknown> = {};
 
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, async ({ request }) => {
+        http.post(REGISTER_URL, async ({ request }) => {
           capturedChallengeBody = (await request.json()) as Record<
             string,
             unknown
@@ -173,7 +173,7 @@ describe("ClientPasskeyClient", () => {
       let capturedChallengeBody: unknown = undefined;
 
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, async ({ request }) => {
+        http.post(REGISTER_URL, async ({ request }) => {
           capturedChallengeBody = await request.json();
           return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
         }),
@@ -189,9 +189,9 @@ describe("ClientPasskeyClient", () => {
       expect(capturedChallengeBody).toEqual({});
     });
 
-    it("throws PasskeySignupChallengeError when challenge request fails", async () => {
+    it("throws PasskeyRegisterError when challenge request fails", async () => {
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, () =>
+        http.post(REGISTER_URL, () =>
           HttpResponse.json(
             {
               error: "passkeys_not_enabled",
@@ -205,25 +205,25 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.signup().catch((e) => e);
 
-      expect(err.name).toBe("PasskeySignupChallengeError");
+      expect(err.name).toBe("PasskeyRegisterError");
       expect(err.error).toBe("passkeys_not_enabled");
       expect(err.error_description).toBe(
         "Passkeys are not enabled for this application."
       );
     });
 
-    it("throws PasskeySignupChallengeError on network failure during challenge", async () => {
-      server.use(http.post(SIGNUP_CHALLENGE_URL, () => HttpResponse.error()));
+    it("throws PasskeyRegisterError on network failure during challenge", async () => {
+      server.use(http.post(REGISTER_URL, () => HttpResponse.error()));
 
       const err = await client.signup().catch((e) => e);
 
-      expect(err.name).toBe("PasskeySignupChallengeError");
+      expect(err.name).toBe("PasskeyRegisterError");
       expect(err.error).toBe("client_error");
     });
 
-    it("throws PasskeyVerifyError when navigator.credentials.create throws", async () => {
+    it("throws PasskeyGetTokenError when navigator.credentials.create throws", async () => {
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, () =>
+        http.post(REGISTER_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         )
       );
@@ -234,13 +234,13 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.signup().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.name).toBe("PasskeyGetTokenError");
       expect(err.error).toBe("webauthn_error");
     });
 
-    it("throws PasskeyVerifyError when credentials.create returns null", async () => {
+    it("throws PasskeyGetTokenError when credentials.create returns null", async () => {
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, () =>
+        http.post(REGISTER_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         )
       );
@@ -249,13 +249,13 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.signup().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.name).toBe("PasskeyGetTokenError");
       expect(err.error).toBe("webauthn_error");
     });
 
-    it("throws PasskeyVerifyError when verify route returns an error", async () => {
+    it("throws PasskeyGetTokenError when verify route returns an error", async () => {
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, () =>
+        http.post(REGISTER_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         ),
         http.post(VERIFY_URL, () =>
@@ -275,7 +275,7 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.signup().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.name).toBe("PasskeyGetTokenError");
       expect(err.error).toBe("invalid_grant");
     });
 
@@ -283,7 +283,7 @@ describe("ClientPasskeyClient", () => {
       let capturedVerifyBody: Record<string, any> = {};
 
       server.use(
-        http.post(SIGNUP_CHALLENGE_URL, () =>
+        http.post(REGISTER_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         ),
         http.post(VERIFY_URL, async ({ request }) => {
@@ -317,7 +317,7 @@ describe("ClientPasskeyClient", () => {
       let capturedVerifyBody: Record<string, unknown> = {};
 
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, async ({ request }) => {
+        http.post(CHALLENGE_URL, async ({ request }) => {
           capturedChallengeBody = (await request.json()) as Record<
             string,
             unknown
@@ -337,10 +337,10 @@ describe("ClientPasskeyClient", () => {
         makeFakeAssertionCredential()
       );
 
-      await client.login({ username: "user@example.com" });
+      await client.login({ connection: "Username-Password-Authentication" });
 
       expect(capturedChallengeBody).toMatchObject({
-        username: "user@example.com"
+        connection: "Username-Password-Authentication"
       });
       expect(navigator.credentials.get).toHaveBeenCalledOnce();
       expect(capturedVerifyBody).toMatchObject({
@@ -352,7 +352,7 @@ describe("ClientPasskeyClient", () => {
       let capturedChallengeBody: unknown = undefined;
 
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, async ({ request }) => {
+        http.post(CHALLENGE_URL, async ({ request }) => {
           capturedChallengeBody = await request.json();
           return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
         }),
@@ -368,9 +368,9 @@ describe("ClientPasskeyClient", () => {
       expect(capturedChallengeBody).toEqual({});
     });
 
-    it("throws PasskeyLoginChallengeError when challenge request fails", async () => {
+    it("throws PasskeyChallengeError when challenge request fails", async () => {
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, () =>
+        http.post(CHALLENGE_URL, () =>
           HttpResponse.json(
             {
               error: "no_passkey_registered",
@@ -383,22 +383,22 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.login().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyLoginChallengeError");
+      expect(err.name).toBe("PasskeyChallengeError");
       expect(err.error).toBe("no_passkey_registered");
     });
 
-    it("throws PasskeyLoginChallengeError on network failure during challenge", async () => {
-      server.use(http.post(LOGIN_CHALLENGE_URL, () => HttpResponse.error()));
+    it("throws PasskeyChallengeError on network failure during challenge", async () => {
+      server.use(http.post(CHALLENGE_URL, () => HttpResponse.error()));
 
       const err = await client.login().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyLoginChallengeError");
+      expect(err.name).toBe("PasskeyChallengeError");
       expect(err.error).toBe("client_error");
     });
 
-    it("throws PasskeyVerifyError when navigator.credentials.get throws", async () => {
+    it("throws PasskeyGetTokenError when navigator.credentials.get throws", async () => {
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, () =>
+        http.post(CHALLENGE_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         )
       );
@@ -409,13 +409,13 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.login().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.name).toBe("PasskeyGetTokenError");
       expect(err.error).toBe("webauthn_error");
     });
 
-    it("throws PasskeyVerifyError when credentials.get returns null", async () => {
+    it("throws PasskeyGetTokenError when credentials.get returns null", async () => {
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, () =>
+        http.post(CHALLENGE_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         )
       );
@@ -424,7 +424,7 @@ describe("ClientPasskeyClient", () => {
 
       const err = await client.login().catch((e) => e);
 
-      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.name).toBe("PasskeyGetTokenError");
       expect(err.error).toBe("webauthn_error");
     });
 
@@ -432,7 +432,7 @@ describe("ClientPasskeyClient", () => {
       let capturedVerifyBody: Record<string, any> = {};
 
       server.use(
-        http.post(LOGIN_CHALLENGE_URL, () =>
+        http.post(CHALLENGE_URL, () =>
           HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
         ),
         http.post(VERIFY_URL, async ({ request }) => {

--- a/src/client/passkey/passkey-client.flow.test.ts
+++ b/src/client/passkey/passkey-client.flow.test.ts
@@ -1,0 +1,458 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url": "http://localhost:3000"}
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from "vitest";
+
+const BASE_URL = "http://localhost:3000";
+
+const SIGNUP_CHALLENGE_URL = `${BASE_URL}/auth/passkey/signup-challenge`;
+const LOGIN_CHALLENGE_URL = `${BASE_URL}/auth/passkey/login-challenge`;
+const VERIFY_URL = `${BASE_URL}/auth/passkey/verify`;
+
+// Minimal fake challenge payload returned by the SDK route handler (camelCase —
+// the handler transforms Auth0's snake_case response before returning JSON).
+const FAKE_CHALLENGE_RESPONSE = {
+  authSession: "fake-auth-session-token",
+  authnParamsPublicKey: {
+    challenge: "Y2hhbGxlbmdl", // base64url("challenge")
+    rp: { name: "Test App", id: "localhost" },
+    user: {
+      id: "dXNlcklk", // base64url("userId")
+      name: "user@example.com",
+      displayName: "Test User"
+    },
+    pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+    timeout: 60000,
+    excludeCredentials: [],
+    authenticatorSelection: { residentKey: "required" },
+    attestation: "none"
+  }
+};
+
+// Minimal fake credential returned by navigator.credentials.create/get
+function makeFakeCredential(): PublicKeyCredential {
+  const encoder = new TextEncoder();
+  const clientDataJSON = encoder.encode(
+    JSON.stringify({ type: "webauthn.create", challenge: "Y2hhbGxlbmdl" })
+  );
+  const attestationObject = encoder.encode("fake-attestation");
+
+  return {
+    id: "credential-id",
+    rawId: encoder.encode("credential-id").buffer,
+    type: "public-key",
+    response: {
+      clientDataJSON: clientDataJSON.buffer,
+      attestationObject: attestationObject.buffer
+    } as AuthenticatorAttestationResponse,
+    getClientExtensionResults: () => ({})
+  } as unknown as PublicKeyCredential;
+}
+
+function makeFakeAssertionCredential(): PublicKeyCredential {
+  const encoder = new TextEncoder();
+  const clientDataJSON = encoder.encode(
+    JSON.stringify({ type: "webauthn.get", challenge: "Y2hhbGxlbmdl" })
+  );
+  const authenticatorData = encoder.encode("fake-auth-data");
+  const signature = encoder.encode("fake-signature");
+
+  return {
+    id: "credential-id",
+    rawId: encoder.encode("credential-id").buffer,
+    type: "public-key",
+    response: {
+      clientDataJSON: clientDataJSON.buffer,
+      authenticatorData: authenticatorData.buffer,
+      signature: signature.buffer,
+      userHandle: null
+    } as AuthenticatorAssertionResponse,
+    getClientExtensionResults: () => ({})
+  } as unknown as PublicKeyCredential;
+}
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+
+  process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE = SIGNUP_CHALLENGE_URL;
+  process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE = LOGIN_CHALLENGE_URL;
+  process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE = VERIFY_URL;
+
+  // jsdom does not implement navigator.credentials — define a stub so vi.spyOn works
+  if (!navigator.credentials) {
+    Object.defineProperty(navigator, "credentials", {
+      value: { create: vi.fn(), get: vi.fn() },
+      writable: true,
+      configurable: true
+    });
+  }
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  vi.restoreAllMocks();
+  // Re-stub navigator.credentials after restoreAllMocks wipes it
+  Object.defineProperty(navigator, "credentials", {
+    value: { create: vi.fn(), get: vi.fn() },
+    writable: true,
+    configurable: true
+  });
+});
+
+afterAll(() => {
+  delete process.env.NEXT_PUBLIC_PASSKEY_SIGNUP_CHALLENGE_ROUTE;
+  delete process.env.NEXT_PUBLIC_PASSKEY_LOGIN_CHALLENGE_ROUTE;
+  delete process.env.NEXT_PUBLIC_PASSKEY_VERIFY_ROUTE;
+  server.close();
+});
+
+describe("ClientPasskeyClient", () => {
+  let client: typeof import("./index.js").passkey;
+
+  beforeEach(async () => {
+    const mod = await import("./index.js");
+    client = mod.passkey;
+  });
+
+  // ---------------------------------------------------------------------------
+  // signup()
+  // ---------------------------------------------------------------------------
+
+  describe("signup", () => {
+    it("requests signup challenge, calls credentials.create, then posts to verify", async () => {
+      let capturedChallengeBody: Record<string, unknown> = {};
+      let capturedVerifyBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, async ({ request }) => {
+          capturedChallengeBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+          return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
+        }),
+        http.post(VERIFY_URL, async ({ request }) => {
+          capturedVerifyBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockResolvedValue(
+        makeFakeCredential()
+      );
+
+      await client.signup({ email: "user@example.com", name: "Test User" });
+
+      expect(capturedChallengeBody).toMatchObject({
+        email: "user@example.com",
+        name: "Test User"
+      });
+      expect(navigator.credentials.create).toHaveBeenCalledOnce();
+      expect(capturedVerifyBody).toMatchObject({
+        authSession: FAKE_CHALLENGE_RESPONSE.authSession
+      });
+      expect(capturedVerifyBody.authResponse).toBeDefined();
+    });
+
+    it("passes empty body when no options provided", async () => {
+      let capturedChallengeBody: unknown = undefined;
+
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, async ({ request }) => {
+          capturedChallengeBody = await request.json();
+          return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
+        }),
+        http.post(VERIFY_URL, () => HttpResponse.json({ success: true }))
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockResolvedValue(
+        makeFakeCredential()
+      );
+
+      await client.signup();
+
+      expect(capturedChallengeBody).toEqual({});
+    });
+
+    it("throws PasskeySignupChallengeError when challenge request fails", async () => {
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, () =>
+          HttpResponse.json(
+            {
+              error: "passkeys_not_enabled",
+              error_description:
+                "Passkeys are not enabled for this application."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const err = await client.signup().catch((e) => e);
+
+      expect(err.name).toBe("PasskeySignupChallengeError");
+      expect(err.error).toBe("passkeys_not_enabled");
+      expect(err.error_description).toBe(
+        "Passkeys are not enabled for this application."
+      );
+    });
+
+    it("throws PasskeySignupChallengeError on network failure during challenge", async () => {
+      server.use(http.post(SIGNUP_CHALLENGE_URL, () => HttpResponse.error()));
+
+      const err = await client.signup().catch((e) => e);
+
+      expect(err.name).toBe("PasskeySignupChallengeError");
+      expect(err.error).toBe("client_error");
+    });
+
+    it("throws PasskeyVerifyError when navigator.credentials.create throws", async () => {
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        )
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockRejectedValue(
+        new DOMException("The operation was aborted.", "AbortError")
+      );
+
+      const err = await client.signup().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.error).toBe("webauthn_error");
+    });
+
+    it("throws PasskeyVerifyError when credentials.create returns null", async () => {
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        )
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockResolvedValue(null);
+
+      const err = await client.signup().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.error).toBe("webauthn_error");
+    });
+
+    it("throws PasskeyVerifyError when verify route returns an error", async () => {
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        ),
+        http.post(VERIFY_URL, () =>
+          HttpResponse.json(
+            {
+              error: "invalid_grant",
+              error_description: "Invalid passkey credential."
+            },
+            { status: 403 }
+          )
+        )
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockResolvedValue(
+        makeFakeCredential()
+      );
+
+      const err = await client.signup().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.error).toBe("invalid_grant");
+    });
+
+    it("serialises credential ArrayBuffers as base64url strings", async () => {
+      let capturedVerifyBody: Record<string, any> = {};
+
+      server.use(
+        http.post(SIGNUP_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        ),
+        http.post(VERIFY_URL, async ({ request }) => {
+          capturedVerifyBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      vi.spyOn(navigator.credentials, "create").mockResolvedValue(
+        makeFakeCredential()
+      );
+
+      await client.signup();
+
+      const authResponse = capturedVerifyBody.authResponse;
+      expect(typeof authResponse.id).toBe("string");
+      expect(typeof authResponse.rawId).toBe("string");
+      expect(authResponse.type).toBe("public-key");
+      expect(typeof authResponse.response.clientDataJSON).toBe("string");
+      expect(typeof authResponse.response.attestationObject).toBe("string");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // login()
+  // ---------------------------------------------------------------------------
+
+  describe("login", () => {
+    it("requests login challenge, calls credentials.get, then posts to verify", async () => {
+      let capturedChallengeBody: Record<string, unknown> = {};
+      let capturedVerifyBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, async ({ request }) => {
+          capturedChallengeBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+          return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
+        }),
+        http.post(VERIFY_URL, async ({ request }) => {
+          capturedVerifyBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      vi.spyOn(navigator.credentials, "get").mockResolvedValue(
+        makeFakeAssertionCredential()
+      );
+
+      await client.login({ username: "user@example.com" });
+
+      expect(capturedChallengeBody).toMatchObject({
+        username: "user@example.com"
+      });
+      expect(navigator.credentials.get).toHaveBeenCalledOnce();
+      expect(capturedVerifyBody).toMatchObject({
+        authSession: FAKE_CHALLENGE_RESPONSE.authSession
+      });
+    });
+
+    it("passes empty body when no options provided", async () => {
+      let capturedChallengeBody: unknown = undefined;
+
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, async ({ request }) => {
+          capturedChallengeBody = await request.json();
+          return HttpResponse.json(FAKE_CHALLENGE_RESPONSE);
+        }),
+        http.post(VERIFY_URL, () => HttpResponse.json({ success: true }))
+      );
+
+      vi.spyOn(navigator.credentials, "get").mockResolvedValue(
+        makeFakeAssertionCredential()
+      );
+
+      await client.login();
+
+      expect(capturedChallengeBody).toEqual({});
+    });
+
+    it("throws PasskeyLoginChallengeError when challenge request fails", async () => {
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, () =>
+          HttpResponse.json(
+            {
+              error: "no_passkey_registered",
+              error_description: "No passkey registered for this user."
+            },
+            { status: 400 }
+          )
+        )
+      );
+
+      const err = await client.login().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyLoginChallengeError");
+      expect(err.error).toBe("no_passkey_registered");
+    });
+
+    it("throws PasskeyLoginChallengeError on network failure during challenge", async () => {
+      server.use(http.post(LOGIN_CHALLENGE_URL, () => HttpResponse.error()));
+
+      const err = await client.login().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyLoginChallengeError");
+      expect(err.error).toBe("client_error");
+    });
+
+    it("throws PasskeyVerifyError when navigator.credentials.get throws", async () => {
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        )
+      );
+
+      vi.spyOn(navigator.credentials, "get").mockRejectedValue(
+        new DOMException("NotAllowedError")
+      );
+
+      const err = await client.login().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.error).toBe("webauthn_error");
+    });
+
+    it("throws PasskeyVerifyError when credentials.get returns null", async () => {
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        )
+      );
+
+      vi.spyOn(navigator.credentials, "get").mockResolvedValue(null);
+
+      const err = await client.login().catch((e) => e);
+
+      expect(err.name).toBe("PasskeyVerifyError");
+      expect(err.error).toBe("webauthn_error");
+    });
+
+    it("serialises assertion credential ArrayBuffers as base64url strings", async () => {
+      let capturedVerifyBody: Record<string, any> = {};
+
+      server.use(
+        http.post(LOGIN_CHALLENGE_URL, () =>
+          HttpResponse.json(FAKE_CHALLENGE_RESPONSE)
+        ),
+        http.post(VERIFY_URL, async ({ request }) => {
+          capturedVerifyBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ success: true });
+        })
+      );
+
+      vi.spyOn(navigator.credentials, "get").mockResolvedValue(
+        makeFakeAssertionCredential()
+      );
+
+      await client.login();
+
+      const authResponse = capturedVerifyBody.authResponse;
+      expect(authResponse.type).toBe("public-key");
+      expect(typeof authResponse.response.clientDataJSON).toBe("string");
+      expect(typeof authResponse.response.authenticatorData).toBe("string");
+      expect(typeof authResponse.response.signature).toBe("string");
+      expect(authResponse.response.userHandle).toBeNull();
+    });
+  });
+});

--- a/src/client/passkey/passkey-client.flow.test.ts
+++ b/src/client/passkey/passkey-client.flow.test.ts
@@ -90,7 +90,14 @@ beforeAll(() => {
   process.env.NEXT_PUBLIC_PASSKEY_CHALLENGE_ROUTE = CHALLENGE_URL;
   process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE = VERIFY_URL;
 
-  // jsdom does not implement navigator.credentials — define a stub so vi.spyOn works
+  // jsdom does not implement PublicKeyCredential or navigator.credentials — stub both
+  if (!window.PublicKeyCredential) {
+    Object.defineProperty(window, "PublicKeyCredential", {
+      value: class PublicKeyCredential {},
+      writable: true,
+      configurable: true
+    });
+  }
   if (!navigator.credentials) {
     Object.defineProperty(navigator, "credentials", {
       value: { create: vi.fn(), get: vi.fn() },

--- a/src/types/passkey.ts
+++ b/src/types/passkey.ts
@@ -354,4 +354,24 @@ export interface PasskeyBrowserClient {
    * @param options - Optional connection or organization.
    */
   login(options?: PasskeyChallengeOptions): Promise<void>;
+
+  /**
+   * Request a passkey enrollment challenge for an already-authenticated user.
+   * Calls Auth0 MyAccount `POST /me/v1/authentication-methods`.
+   *
+   * @param options - Optional connection or identity user ID.
+   */
+  enrollmentChallenge(
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  /**
+   * Verify and complete a passkey enrollment.
+   * Calls Auth0 MyAccount `POST /me/v1/authentication-methods/{id}/verify`.
+   *
+   * @param options - Authentication method ID, auth session, and serialised credential.
+   */
+  enrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse>;
 }


### PR DESCRIPTION
- All new/changed/fixed functionality is covered by tests (or N/A)
  - I have added documentation for all new/changed functionality (or N/A)

  📋 Changes

  Adds the client-side passkey singleton exported from @auth0/nextjs-auth0/client.

  src/client/passkey/index.ts:
  - ClientPasskeyClient implements PasskeyBrowserClient
  - signup(options?) — fetches challenge → navigator.credentials.create() → verifies
  - login(options?) — fetches challenge → navigator.credentials.get() → verifies
  - signupChallenge(), loginChallenge(), verify() — individual step methods for full control
  - All ArrayBuffer ↔ base64url conversion handled internally
  - export const passkey: PasskeyBrowserClient

  src/client/index.ts:
  - export { passkey } from "./passkey/index.js"
  

  🎯 Testing

  src/client/passkey/passkey-client.flow.test.ts covers signup, login, step-by-step flows, error cases (challenge failure,  WebAuthn cancellation, verify failure), and network errors using MSW + jsdom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passkey-based signup and login support for users.
  * Enrollment flow with challenge and verification steps.
  * Passkey client exposed as a new public entry point.

* **Tests**
  * End-to-end flow tests covering signup, login, enrollment, serialization, and error mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->