### PR TITLE
docs: show returnTo pattern in middleware and clarify automatic behav…

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -517,9 +517,14 @@ export async function middleware(request: NextRequest) {
 
   if (!session) {
     // user is not authenticated, redirect to login page
-    return NextResponse.redirect(
-      new URL("/auth/login", request.nextUrl.origin)
+    // preserve the URL the user was trying to reach so they land back there after login
+    // returnTo must be a relative path — absolute external URLs are rejected to prevent open redirects
+    const loginUrl = new URL("/auth/login", request.nextUrl.origin);
+    loginUrl.searchParams.set(
+      "returnTo",
+      request.nextUrl.pathname + request.nextUrl.search
     );
+    return NextResponse.redirect(loginUrl);
   }
 
   // the headers from the auth middleware should always be returned
@@ -544,6 +549,8 @@ export default function Profile({ user }) {
   return <div>Hello {user.name}</div>;
 }
 
+// withPageAuthRequired automatically uses ctx.resolvedUrl as returnTo, so the user
+// is redirected back to the exact page (including query string) they tried to visit.
 // You can optionally pass your own `getServerSideProps` function into
 // `withPageAuthRequired` and the props will be merged with the `user` prop
 export const getServerSideProps = auth0.withPageAuthRequired();
@@ -564,7 +571,8 @@ export default auth0.withPageAuthRequired(
   },
   { returnTo: "/profile" }
 );
-// You need to provide a `returnTo` since Server Components aren't aware of the page's URL
+// returnTo is required for App Router — Server Components don't know their own URL.
+// For dynamic routes, pass a function: returnTo({ params }) { return `/profile/${params.id}`; }
 ```
 
 ## Protecting a Client-Side Rendered (CSR) Page


### PR DESCRIPTION
 Closes [#2655](https://github.com/auth0/nextjs-auth0/issues/2655)
 
Updates the middleware example to forward the current URL as returnTo so users land back on the page they tried to visit after login. Also adds comments clarifying that
Page Router handles this automatically, and that App Router requires an explicit returnTo.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved examples and guidance for redirect flows, showing how to preserve the original path and query as a relative returnTo to avoid open-redirect risks
  * Clarified automatic return-to behavior for server-rendered patterns and noted that dynamic routes should supply a returnTo builder to ensure correct return paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->