### PR TITLE
Passkey enroll implementation (myaccount)

### DIFF
--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -361,6 +361,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
       );
     } catch (err: any) {
       throw new PasskeyEnrollmentChallengeError(
+        err?.error ?? "unknown_error",
         err?.error_description ?? "Failed to get passkey enrollment challenge"
       );
     }
@@ -380,6 +381,7 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
       );
     } catch (err: any) {
       throw new PasskeyEnrollmentVerifyError(
+        err?.error ?? "unknown_error",
         err?.error_description ?? "Passkey enrollment verification failed"
       );
     }

--- a/src/client/passkey/index.ts
+++ b/src/client/passkey/index.ts
@@ -370,8 +370,8 @@ class ClientPasskeyClient implements PasskeyBrowserClient {
     options: PasskeyEnrollmentVerifyOptions
   ): Promise<PasskeyEnrollmentVerifyResponse> {
     const verifyUrl = normalizeWithBasePath(
-      process.env.NEXT_PUBLIC_PASSKEY_ENROLL_VERIFY_ROUTE ||
-        "/auth/passkey/enroll-verify"
+      process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_VERIFY_ROUTE ||
+        "/auth/passkey/enrollment-verify"
     );
     try {
       return await postJson<PasskeyEnrollmentVerifyResponse>(

--- a/src/errors/passkey-errors.ts
+++ b/src/errors/passkey-errors.ts
@@ -128,13 +128,24 @@ export class PasskeyGetTokenError extends PasskeyError {
  * - Insufficient scope (requires create:me:authentication_methods)
  * - Passkeys not enabled for the tenant
  */
-export class PasskeyEnrollmentChallengeError extends SdkError {
-  public readonly code: string = "passkey_enrollment_challenge_error";
+export class PasskeyEnrollmentChallengeError extends PasskeyError {
+  public readonly error: string;
+  public readonly error_description: string;
   public readonly cause?: MyAccountApiError;
 
-  constructor(message: string, cause?: MyAccountApiError) {
-    super(message);
+  public get code(): string {
+    return "passkey_enrollment_challenge_error";
+  }
+
+  constructor(
+    error: string,
+    error_description: string,
+    cause?: MyAccountApiError
+  ) {
+    super(error_description);
     this.name = "PasskeyEnrollmentChallengeError";
+    this.error = error;
+    this.error_description = error_description;
     this.cause = cause;
     Object.setPrototypeOf(this, PasskeyEnrollmentChallengeError.prototype);
   }
@@ -149,13 +160,24 @@ export class PasskeyEnrollmentChallengeError extends SdkError {
  * - Credential creation rejected
  * - Duplicate passkey (already registered)
  */
-export class PasskeyEnrollmentVerifyError extends SdkError {
-  public readonly code: string = "passkey_enrollment_verify_error";
+export class PasskeyEnrollmentVerifyError extends PasskeyError {
+  public readonly error: string;
+  public readonly error_description: string;
   public readonly cause?: MyAccountApiError;
 
-  constructor(message: string, cause?: MyAccountApiError) {
-    super(message);
+  public get code(): string {
+    return "passkey_enrollment_verify_error";
+  }
+
+  constructor(
+    error: string,
+    error_description: string,
+    cause?: MyAccountApiError
+  ) {
+    super(error_description);
     this.name = "PasskeyEnrollmentVerifyError";
+    this.error = error;
+    this.error_description = error_description;
     this.cause = cause;
     Object.setPrototypeOf(this, PasskeyEnrollmentVerifyError.prototype);
   }

--- a/src/errors/passkey-errors.ts
+++ b/src/errors/passkey-errors.ts
@@ -1,4 +1,3 @@
-import { MyAccountApiError } from "./my-account-errors.js";
 import { SdkError } from "./sdk-error.js";
 
 /**
@@ -131,7 +130,7 @@ export class PasskeyGetTokenError extends PasskeyError {
 export class PasskeyEnrollmentChallengeError extends PasskeyError {
   public readonly error: string;
   public readonly error_description: string;
-  public readonly cause?: MyAccountApiError;
+  public readonly cause?: Record<string, unknown>;
 
   public get code(): string {
     return "passkey_enrollment_challenge_error";
@@ -140,7 +139,7 @@ export class PasskeyEnrollmentChallengeError extends PasskeyError {
   constructor(
     error: string,
     error_description: string,
-    cause?: MyAccountApiError
+    cause?: Record<string, unknown>
   ) {
     super(error_description);
     this.name = "PasskeyEnrollmentChallengeError";
@@ -153,7 +152,6 @@ export class PasskeyEnrollmentChallengeError extends PasskeyError {
 
 /**
  * Thrown when verifying a passkey enrollment fails.
- * The MyAccount API returns errors in RFC 7807 problem detail format.
  *
  * Common causes:
  * - Invalid or expired auth_session
@@ -163,7 +161,7 @@ export class PasskeyEnrollmentChallengeError extends PasskeyError {
 export class PasskeyEnrollmentVerifyError extends PasskeyError {
   public readonly error: string;
   public readonly error_description: string;
-  public readonly cause?: MyAccountApiError;
+  public readonly cause?: Record<string, unknown>;
 
   public get code(): string {
     return "passkey_enrollment_verify_error";
@@ -172,7 +170,7 @@ export class PasskeyEnrollmentVerifyError extends PasskeyError {
   constructor(
     error: string,
     error_description: string,
-    cause?: MyAccountApiError
+    cause?: Record<string, unknown>
   ) {
     super(error_description);
     this.name = "PasskeyEnrollmentVerifyError";

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -35,6 +35,8 @@ import {
   MyAccountApiError,
   OAuth2Error,
   PasskeyChallengeError,
+  PasskeyEnrollmentChallengeError,
+  PasskeyEnrollmentVerifyError,
   PasskeyGetTokenError,
   PasskeyRegisterError,
   PasswordlessStartError,
@@ -76,6 +78,10 @@ import {
   MfaVerifyResponse,
   PasskeyChallengeOptions,
   PasskeyChallengeResponse,
+  PasskeyEnrollmentChallengeOptions,
+  PasskeyEnrollmentChallengeResponse,
+  PasskeyEnrollmentVerifyOptions,
+  PasskeyEnrollmentVerifyResponse,
   PasskeyGetTokenOptions,
   PasskeyRegisterOptions,
   PasskeyRegisterResponse,
@@ -250,6 +256,8 @@ export interface Routes {
   passkeyRegister: string;
   passkeyChallenge: string;
   passkeyGetToken: string;
+  passkeyEnrollmentChallenge: string;
+  passkeyEnrollmentVerify: string;
 }
 export type RoutesOptions = Partial<Routes>;
 
@@ -655,6 +663,16 @@ export class AuthClient {
       sanitizedPathname === this.routes.passkeyGetToken
     ) {
       return this.handlePasskeyGetToken(req);
+    } else if (
+      method === "POST" &&
+      sanitizedPathname === this.routes.passkeyEnrollmentChallenge
+    ) {
+      return this.handlePasskeyEnrollmentChallenge(req);
+    } else if (
+      method === "POST" &&
+      sanitizedPathname === this.routes.passkeyEnrollmentVerify
+    ) {
+      return this.handlePasskeyEnrollmentVerify(req);
     } else if (sanitizedPathname.startsWith("/me/")) {
       return this.handleMyAccount(req);
     } else if (sanitizedPathname.startsWith("/my-org/")) {
@@ -4340,6 +4358,254 @@ export class AuthClient {
       return NextResponse.json(
         { error: "server_error", error_description: "Internal server error" },
         { status: 500 }
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Passkey enrollment route handlers
+  // ---------------------------------------------------------------------------
+
+  async handlePasskeyEnrollmentChallenge(
+    req: NextRequest
+  ): Promise<NextResponse> {
+    try {
+      const body = await parseJsonBody(req);
+      const bodyRecord = body as Record<string, any>;
+      const options: PasskeyEnrollmentChallengeOptions = {};
+      if (typeof bodyRecord.connection === "string")
+        options.connection = bodyRecord.connection;
+      if (typeof bodyRecord.userIdentityId === "string")
+        options.userIdentityId = bodyRecord.userIdentityId;
+      const challenge = await this.passkeyEnrollmentChallenge(
+        req.cookies,
+        options
+      );
+      return NextResponse.json(challenge);
+    } catch (e) {
+      if (e instanceof PasskeyEnrollmentChallengeError) {
+        const msg = e.message;
+        if (msg === "not_authenticated" || msg === "token_error") {
+          return NextResponse.json(
+            { error: msg, error_description: e.message },
+            { status: 401 }
+          );
+        }
+        if (msg === "unexpected_error") {
+          return NextResponse.json(
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
+            { status: 500 }
+          );
+        }
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      if (e instanceof SdkError) {
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json(
+        { error: "server_error", error_description: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  async handlePasskeyEnrollmentVerify(req: NextRequest): Promise<NextResponse> {
+    try {
+      const body = await parseJsonBody(req);
+      const bodyRecord = body as Record<string, any>;
+      const authenticationMethodId = validateStringFieldAndThrow(
+        bodyRecord.authenticationMethodId,
+        "authenticationMethodId"
+      );
+      const authSession = validateStringFieldAndThrow(
+        bodyRecord.authSession,
+        "authSession"
+      );
+      if (
+        !bodyRecord.authResponse ||
+        typeof bodyRecord.authResponse !== "object"
+      ) {
+        return NextResponse.json(
+          {
+            error: "invalid_request",
+            error_description: "authResponse is required"
+          },
+          { status: 400 }
+        );
+      }
+      const options: PasskeyEnrollmentVerifyOptions = {
+        authenticationMethodId,
+        authSession,
+        authResponse: bodyRecord.authResponse
+      };
+      const result = await this.passkeyEnrollmentVerify(options, req.cookies);
+      return NextResponse.json(result);
+    } catch (e) {
+      if (e instanceof PasskeyEnrollmentVerifyError) {
+        const msg = e.message;
+        if (msg === "not_authenticated" || msg === "token_error") {
+          return NextResponse.json(
+            { error: msg, error_description: e.message },
+            { status: 401 }
+          );
+        }
+        if (msg === "unexpected_error") {
+          return NextResponse.json(
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
+            { status: 500 }
+          );
+        }
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      if (e instanceof SdkError) {
+        return NextResponse.json(
+          { error: e.code, error_description: e.message },
+          { status: 400 }
+        );
+      }
+      return NextResponse.json(
+        { error: "server_error", error_description: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Passkey enrollment core methods (MyAccount)
+  // ---------------------------------------------------------------------------
+
+  async passkeyEnrollmentChallenge(
+    reqCookies: RequestCookies,
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse> {
+    const { error: sessionError, session } =
+      await this.getSessionWithDomainCheck(reqCookies);
+    if (sessionError || !session) {
+      throw new PasskeyEnrollmentChallengeError(
+        sessionError?.message ?? "The user does not have an active session."
+      );
+    }
+    const [tokenSetError, tokenSetResponse] = await this.getTokenSet(session, {
+      audience: `${this.issuer}me/`,
+      scope: "create:authentication_methods"
+    });
+    if (tokenSetError) {
+      throw new PasskeyEnrollmentChallengeError(
+        "Failed to retrieve MyAccount access token."
+      );
+    }
+    const { tokenSet } = tokenSetResponse;
+    const url = new URL(
+      "/me/v1/authentication-methods",
+      this.issuer
+    ).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+    httpOptions.headers.set("Authorization", `Bearer ${tokenSet.accessToken}`);
+    const body: Record<string, unknown> = { type: "passkey" };
+    if (options?.connection) body.connection = options.connection;
+    if (options?.userIdentityId) body.identity = options.userIdentityId;
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify(body),
+        ...httpOptions
+      });
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error_description: "Failed to get passkey enrollment challenge"
+        }));
+        throw new PasskeyEnrollmentChallengeError(
+          errorBody.error_description ||
+            "Failed to get passkey enrollment challenge"
+        );
+      }
+      const locationHeader = response.headers.get("Location") ?? "";
+      const authenticationMethodId = locationHeader.split("/").pop() ?? "";
+      if (!authenticationMethodId) {
+        throw new PasskeyEnrollmentChallengeError(
+          "No authentication method ID in Location header."
+        );
+      }
+      const result = await response.json();
+      return {
+        authenticationMethodId,
+        authSession: result.auth_session,
+        authnParamsPublicKey: result.authn_params_public_key
+      };
+    } catch (e) {
+      if (e instanceof PasskeyEnrollmentChallengeError) throw e;
+      throw new PasskeyEnrollmentChallengeError(
+        "Unexpected error during passkey enrollment challenge."
+      );
+    }
+  }
+
+  async passkeyEnrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions,
+    reqCookies: RequestCookies
+  ): Promise<PasskeyEnrollmentVerifyResponse> {
+    const { error: sessionError, session } =
+      await this.getSessionWithDomainCheck(reqCookies);
+    if (sessionError || !session) {
+      throw new PasskeyEnrollmentVerifyError(
+        sessionError?.message ?? "The user does not have an active session."
+      );
+    }
+    const [tokenSetError, tokenSetResponse] = await this.getTokenSet(session, {
+      audience: `${this.issuer}me/`,
+      scope: "create:authentication_methods"
+    });
+    if (tokenSetError) {
+      throw new PasskeyEnrollmentVerifyError(
+        "Failed to retrieve MyAccount access token."
+      );
+    }
+    const { tokenSet } = tokenSetResponse;
+    const url = new URL(
+      `/me/v1/authentication-methods/${options.authenticationMethodId}/verify`,
+      this.issuer
+    ).toString();
+    const httpOptions = this.httpOptions();
+    httpOptions.headers.set("Content-Type", "application/json");
+    httpOptions.headers.set("Authorization", `Bearer ${tokenSet.accessToken}`);
+    try {
+      const response = await this.fetch(url, {
+        method: "POST",
+        body: JSON.stringify({
+          auth_session: options.authSession,
+          authn_response: options.authResponse
+        }),
+        ...httpOptions
+      });
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({
+          error_description: "Failed to verify passkey enrollment"
+        }));
+        throw new PasskeyEnrollmentVerifyError(
+          errorBody.error_description || "Failed to verify passkey enrollment"
+        );
+      }
+      return (await response.json()) as PasskeyEnrollmentVerifyResponse;
+    } catch (e) {
+      if (e instanceof PasskeyEnrollmentVerifyError) throw e;
+      throw new PasskeyEnrollmentVerifyError(
+        "Unexpected error during passkey enrollment verification."
       );
     }
   }

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -4384,26 +4384,16 @@ export class AuthClient {
       return NextResponse.json(challenge);
     } catch (e) {
       if (e instanceof PasskeyEnrollmentChallengeError) {
-        const msg = e.message;
-        if (msg === "not_authenticated" || msg === "token_error") {
-          return NextResponse.json(
-            { error: msg, error_description: e.message },
-            { status: 401 }
-          );
+        if (e.error === "not_authenticated" || e.error === "token_error") {
+          return NextResponse.json(e.toJSON(), { status: 401 });
         }
-        if (msg === "unexpected_error") {
+        if (e.error === "unexpected_error") {
           return NextResponse.json(
-            {
-              error: "server_error",
-              error_description: "Internal server error"
-            },
+            { error: "server_error", error_description: "Internal server error" },
             { status: 500 }
           );
         }
-        return NextResponse.json(
-          { error: e.code, error_description: e.message },
-          { status: 400 }
-        );
+        return NextResponse.json(e.toJSON(), { status: 400 });
       }
       if (e instanceof SdkError) {
         return NextResponse.json(
@@ -4451,26 +4441,16 @@ export class AuthClient {
       return NextResponse.json(result);
     } catch (e) {
       if (e instanceof PasskeyEnrollmentVerifyError) {
-        const msg = e.message;
-        if (msg === "not_authenticated" || msg === "token_error") {
-          return NextResponse.json(
-            { error: msg, error_description: e.message },
-            { status: 401 }
-          );
+        if (e.error === "not_authenticated" || e.error === "token_error") {
+          return NextResponse.json(e.toJSON(), { status: 401 });
         }
-        if (msg === "unexpected_error") {
+        if (e.error === "unexpected_error") {
           return NextResponse.json(
-            {
-              error: "server_error",
-              error_description: "Internal server error"
-            },
+            { error: "server_error", error_description: "Internal server error" },
             { status: 500 }
           );
         }
-        return NextResponse.json(
-          { error: e.code, error_description: e.message },
-          { status: 400 }
-        );
+        return NextResponse.json(e.toJSON(), { status: 400 });
       }
       if (e instanceof SdkError) {
         return NextResponse.json(
@@ -4497,6 +4477,7 @@ export class AuthClient {
       await this.getSessionWithDomainCheck(reqCookies);
     if (sessionError || !session) {
       throw new PasskeyEnrollmentChallengeError(
+        "not_authenticated",
         sessionError?.message ?? "The user does not have an active session."
       );
     }
@@ -4506,6 +4487,7 @@ export class AuthClient {
     });
     if (tokenSetError) {
       throw new PasskeyEnrollmentChallengeError(
+        "token_error",
         "Failed to retrieve MyAccount access token."
       );
     }
@@ -4531,14 +4513,17 @@ export class AuthClient {
           error_description: "Failed to get passkey enrollment challenge"
         }));
         throw new PasskeyEnrollmentChallengeError(
+          errorBody.error || "unknown_error",
           errorBody.error_description ||
-            "Failed to get passkey enrollment challenge"
+            "Failed to get passkey enrollment challenge",
+          errorBody.error ? errorBody : undefined
         );
       }
       const locationHeader = response.headers.get("Location") ?? "";
       const authenticationMethodId = locationHeader.split("/").pop() ?? "";
       if (!authenticationMethodId) {
         throw new PasskeyEnrollmentChallengeError(
+          "unexpected_error",
           "No authentication method ID in Location header."
         );
       }
@@ -4551,6 +4536,7 @@ export class AuthClient {
     } catch (e) {
       if (e instanceof PasskeyEnrollmentChallengeError) throw e;
       throw new PasskeyEnrollmentChallengeError(
+        "unexpected_error",
         "Unexpected error during passkey enrollment challenge."
       );
     }
@@ -4564,6 +4550,7 @@ export class AuthClient {
       await this.getSessionWithDomainCheck(reqCookies);
     if (sessionError || !session) {
       throw new PasskeyEnrollmentVerifyError(
+        "not_authenticated",
         sessionError?.message ?? "The user does not have an active session."
       );
     }
@@ -4573,6 +4560,7 @@ export class AuthClient {
     });
     if (tokenSetError) {
       throw new PasskeyEnrollmentVerifyError(
+        "token_error",
         "Failed to retrieve MyAccount access token."
       );
     }
@@ -4598,13 +4586,16 @@ export class AuthClient {
           error_description: "Failed to verify passkey enrollment"
         }));
         throw new PasskeyEnrollmentVerifyError(
-          errorBody.error_description || "Failed to verify passkey enrollment"
+          errorBody.error || "unknown_error",
+          errorBody.error_description || "Failed to verify passkey enrollment",
+          errorBody.error ? errorBody : undefined
         );
       }
       return (await response.json()) as PasskeyEnrollmentVerifyResponse;
     } catch (e) {
       if (e instanceof PasskeyEnrollmentVerifyError) throw e;
       throw new PasskeyEnrollmentVerifyError(
+        "unexpected_error",
         "Unexpected error during passkey enrollment verification."
       );
     }

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -4389,7 +4389,10 @@ export class AuthClient {
         }
         if (e.error === "unexpected_error") {
           return NextResponse.json(
-            { error: "server_error", error_description: "Internal server error" },
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
             { status: 500 }
           );
         }
@@ -4446,7 +4449,10 @@ export class AuthClient {
         }
         if (e.error === "unexpected_error") {
           return NextResponse.json(
-            { error: "server_error", error_description: "Internal server error" },
+            {
+              error: "server_error",
+              error_description: "Internal server error"
+            },
             { status: 500 }
           );
         }

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -4502,7 +4502,7 @@ export class AuthClient {
     }
     const [tokenSetError, tokenSetResponse] = await this.getTokenSet(session, {
       audience: `${this.issuer}me/`,
-      scope: "create:authentication_methods"
+      scope: "create:me:authentication_methods"
     });
     if (tokenSetError) {
       throw new PasskeyEnrollmentChallengeError(
@@ -4569,7 +4569,7 @@ export class AuthClient {
     }
     const [tokenSetError, tokenSetResponse] = await this.getTokenSet(session, {
       audience: `${this.issuer}me/`,
-      scope: "create:authentication_methods"
+      scope: "create:me:authentication_methods"
     });
     if (tokenSetError) {
       throw new PasskeyEnrollmentVerifyError(

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -619,6 +619,12 @@ export class Auth0Client {
       passkeyGetToken:
         process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE ||
         "/auth/passkey/get-token",
+      passkeyEnrollmentChallenge:
+        process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_CHALLENGE_ROUTE ||
+        "/auth/passkey/enrollment-challenge",
+      passkeyEnrollmentVerify:
+        process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_VERIFY_ROUTE ||
+        "/auth/passkey/enrollment-verify",
       ...options.routes
     };
 

--- a/src/server/dynamic-base-url.test.ts
+++ b/src/server/dynamic-base-url.test.ts
@@ -27,7 +27,9 @@ const defaultRoutes = {
   passwordlessVerify: "/auth/passwordless/verify",
   passkeyRegister: "/auth/passkey/register",
   passkeyChallenge: "/auth/passkey/challenge",
-  passkeyGetToken: "/auth/passkey/get-token"
+  passkeyGetToken: "/auth/passkey/get-token",
+  passkeyEnrollmentChallenge: "/auth/passkey/enrollment-challenge",
+  passkeyEnrollmentVerify: "/auth/passkey/enrollment-verify"
 };
 
 describe("APP_BASE_URL Configuration", () => {

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -644,7 +644,7 @@ const myAccountTokenHandler = http.post(
       access_token: "myaccount-access-token",
       token_type: "Bearer",
       expires_in: 86400,
-      scope: "create:authentication_methods"
+      scope: "create:me:authentication_methods"
     })
 );
 

--- a/src/server/passkey/server-passkey-client.test.ts
+++ b/src/server/passkey/server-passkey-client.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../test/defaults.js";
 import { AuthClientProvider } from "../auth-client-provider.js";
 import { AuthClient } from "../auth-client.js";
+import { encrypt } from "../cookies.js";
 import { StatelessSessionStore } from "../session/stateless-session-store.js";
 import { TransactionStore } from "../transaction-store.js";
 import { ServerPasskeyClient } from "./server-passkey-client.js";
@@ -609,5 +610,323 @@ describe("ServerPasskeyClient.getToken()", () => {
         authResponse: MOCK_AUTH_RESPONSE
       })
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enrollment helpers
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = "test-secret-long-enough-for-hs256-algorithm";
+
+async function makeSessionCookie(): Promise<string> {
+  const session = {
+    user: { sub: DEFAULT.sub },
+    tokenSet: {
+      accessToken: "main-access-token",
+      refreshToken: "main-refresh-token",
+      idToken: "mock-id-token",
+      scope: "openid profile email",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      token_type: "Bearer" as const
+    },
+    internal: { sid: DEFAULT.sid, createdAt: Math.floor(Date.now() / 1000) }
+  };
+  const expiration = Math.floor(Date.now() / 1000) + 3600;
+  return encrypt(session, TEST_SECRET, expiration);
+}
+
+// MSW handler that returns a new MyAccount access token on /oauth/token
+const myAccountTokenHandler = http.post(
+  `https://${DEFAULT.domain}/oauth/token`,
+  () =>
+    HttpResponse.json({
+      access_token: "myaccount-access-token",
+      token_type: "Bearer",
+      expires_in: 86400,
+      scope: "create:authentication_methods"
+    })
+);
+
+// ---------------------------------------------------------------------------
+// enrollmentChallenge
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.enrollmentChallenge()", () => {
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns enrollment challenge on success (App Router)", async () => {
+    const sessionCookie = await makeSessionCookie();
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionCookie}; Path=/; HttpOnly`
+    );
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(`https://${DEFAULT.domain}/me/v1/authentication-methods`, () =>
+        HttpResponse.json(
+          {
+            auth_session: DEFAULT.authSession,
+            authn_params_public_key: { challenge: "enroll-challenge" }
+          },
+          {
+            headers: {
+              Location: `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_abc123`
+            }
+          }
+        )
+      )
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    const result = await client.enrollmentChallenge();
+
+    expect(result.authenticationMethodId).toBe("amth_abc123");
+    expect(result.authSession).toBe(DEFAULT.authSession);
+    expect(result.authnParamsPublicKey).toEqual({
+      challenge: "enroll-challenge"
+    });
+  });
+
+  it("passes connection and identity options in request body", async () => {
+    const sessionCookie = await makeSessionCookie();
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionCookie}; Path=/; HttpOnly`
+    );
+
+    let capturedBody: any;
+    server.use(
+      myAccountTokenHandler,
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(
+            {
+              auth_session: DEFAULT.authSession,
+              authn_params_public_key: {}
+            },
+            {
+              headers: {
+                Location: `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_opts`
+              }
+            }
+          );
+        }
+      )
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    await client.enrollmentChallenge({
+      connection: "Username-Password-Authentication",
+      userIdentityId: "identity-user-id"
+    });
+
+    expect(capturedBody.connection).toBe("Username-Password-Authentication");
+    expect(capturedBody.identity).toBe("identity-user-id");
+  });
+
+  it("throws PasskeyEnrollmentChallengeError when not authenticated", async () => {
+    // No session cookie — empty mockCookieHeaders
+    const client = await makePasskeyClient(TEST_SECRET);
+
+    await expect(client.enrollmentChallenge()).rejects.toMatchObject({
+      name: "PasskeyEnrollmentChallengeError",
+      code: "passkey_enrollment_challenge_error"
+    });
+  });
+
+  it("throws PasskeyEnrollmentChallengeError on Auth0 API failure", async () => {
+    const sessionCookie = await makeSessionCookie();
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionCookie}; Path=/; HttpOnly`
+    );
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(`https://${DEFAULT.domain}/me/v1/authentication-methods`, () =>
+        HttpResponse.json(
+          {
+            error: "passkeys_not_enabled",
+            error_description: "Passkeys are not enabled."
+          },
+          { status: 400 }
+        )
+      )
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    await expect(client.enrollmentChallenge()).rejects.toMatchObject({
+      name: "PasskeyEnrollmentChallengeError",
+      code: "passkey_enrollment_challenge_error"
+    });
+  });
+
+  it("returns enrollment challenge via Pages Router overload", async () => {
+    const { cookies } = await import("next/headers.js");
+    vi.mocked(cookies).mockClear();
+
+    const sessionCookie = await makeSessionCookie();
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(`https://${DEFAULT.domain}/me/v1/authentication-methods`, () =>
+        HttpResponse.json(
+          { auth_session: DEFAULT.authSession, authn_params_public_key: {} },
+          {
+            headers: {
+              Location: `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_pages`
+            }
+          }
+        )
+      )
+    );
+
+    const req = new NextRequest(
+      new URL("/api/passkey/enrollment-challenge", DEFAULT.appBaseUrl),
+      {
+        method: "POST",
+        headers: { cookie: `__session=${sessionCookie}` }
+      }
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    const result = await client.enrollmentChallenge(req);
+
+    expect(result.authenticationMethodId).toBe("amth_pages");
+    expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrollmentVerify
+// ---------------------------------------------------------------------------
+
+describe("ServerPasskeyClient.enrollmentVerify()", () => {
+  const MOCK_ENROLL_VERIFY_OPTIONS = {
+    authenticationMethodId: "amth_abc123",
+    authSession: "enroll-auth-session",
+    authResponse: MOCK_AUTH_RESPONSE
+  };
+
+  const MOCK_AUTHENTICATION_METHOD = {
+    id: "amth_abc123",
+    type: "passkey",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    keyId: "key-id-abc"
+  };
+
+  beforeEach(() => {
+    mockCookieHeaders = new Headers();
+  });
+
+  it("returns authentication method on success (App Router)", async () => {
+    const sessionCookie = await makeSessionCookie();
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionCookie}; Path=/; HttpOnly`
+    );
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_abc123/verify`,
+        () => HttpResponse.json(MOCK_AUTHENTICATION_METHOD)
+      )
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    const result = await client.enrollmentVerify(MOCK_ENROLL_VERIFY_OPTIONS);
+
+    expect(result.id).toBe("amth_abc123");
+    expect(result.type).toBe("passkey");
+  });
+
+  it("throws PasskeyEnrollmentVerifyError when not authenticated", async () => {
+    const client = await makePasskeyClient(TEST_SECRET);
+
+    await expect(
+      client.enrollmentVerify(MOCK_ENROLL_VERIFY_OPTIONS)
+    ).rejects.toMatchObject({
+      name: "PasskeyEnrollmentVerifyError",
+      code: "passkey_enrollment_verify_error"
+    });
+  });
+
+  it("throws PasskeyEnrollmentVerifyError on Auth0 API failure", async () => {
+    const sessionCookie = await makeSessionCookie();
+    mockCookieHeaders.set(
+      "set-cookie",
+      `__session=${sessionCookie}; Path=/; HttpOnly`
+    );
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_abc123/verify`,
+        () =>
+          HttpResponse.json(
+            { error: "invalid_grant", error_description: "Invalid assertion." },
+            { status: 400 }
+          )
+      )
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    await expect(
+      client.enrollmentVerify(MOCK_ENROLL_VERIFY_OPTIONS)
+    ).rejects.toMatchObject({
+      name: "PasskeyEnrollmentVerifyError",
+      code: "passkey_enrollment_verify_error"
+    });
+  });
+
+  it("returns authentication method via Pages Router overload", async () => {
+    const { cookies } = await import("next/headers.js");
+    vi.mocked(cookies).mockClear();
+
+    const sessionCookie = await makeSessionCookie();
+
+    server.use(
+      myAccountTokenHandler,
+      http.post(
+        `https://${DEFAULT.domain}/me/v1/authentication-methods/amth_abc123/verify`,
+        () => HttpResponse.json(MOCK_AUTHENTICATION_METHOD)
+      )
+    );
+
+    const req = new NextRequest(
+      new URL("/api/passkey/enrollment-verify", DEFAULT.appBaseUrl),
+      {
+        method: "POST",
+        headers: { cookie: `__session=${sessionCookie}` }
+      }
+    );
+
+    const client = await makePasskeyClient(TEST_SECRET);
+    const result = await client.enrollmentVerify(
+      req,
+      MOCK_ENROLL_VERIFY_OPTIONS
+    );
+
+    expect(result.id).toBe("amth_abc123");
+    expect(vi.mocked(cookies)).not.toHaveBeenCalled();
+  });
+
+  it("throws TypeError when options are missing for Pages Router", async () => {
+    const client = await makePasskeyClient(TEST_SECRET);
+    const req = new NextRequest(
+      new URL("/api/passkey/enrollment-verify", DEFAULT.appBaseUrl),
+      { method: "POST" }
+    );
+
+    await expect((client.enrollmentVerify as any)(req)).rejects.toThrow(
+      TypeError
+    );
   });
 });

--- a/src/server/passkey/server-passkey-client.ts
+++ b/src/server/passkey/server-passkey-client.ts
@@ -5,6 +5,10 @@ import type {
   PasskeyChallengeOptions,
   PasskeyChallengeResponse,
   PasskeyClient,
+  PasskeyEnrollmentChallengeOptions,
+  PasskeyEnrollmentChallengeResponse,
+  PasskeyEnrollmentVerifyOptions,
+  PasskeyEnrollmentVerifyResponse,
   PasskeyGetTokenOptions,
   PasskeyRegisterOptions,
   PasskeyRegisterResponse
@@ -144,5 +148,66 @@ export class ServerPasskeyClient implements PasskeyClient {
       const cookiesLib = await getCookies();
       await authClient.passkeyGetToken(arg1, cookiesLib, cookiesLib);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // enrollmentChallenge
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async enrollmentChallenge(
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  /** Pages Router / Middleware overload. */
+  async enrollmentChallenge(
+    req: NextRequest,
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  async enrollmentChallenge(
+    arg1?: PasskeyEnrollmentChallengeOptions | NextRequest,
+    arg2?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse> {
+    if (arg1 instanceof NextRequest) {
+      const authClient = await this.getAuthClient(arg1);
+      return authClient.passkeyEnrollmentChallenge(arg1.cookies, arg2);
+    }
+    const authClient = await this.getAuthClient();
+    const cookiesLib = await getCookies();
+    return authClient.passkeyEnrollmentChallenge(cookiesLib as any, arg1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // enrollmentVerify
+  // ---------------------------------------------------------------------------
+
+  /** App Router overload. */
+  async enrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse>;
+
+  /** Pages Router / Middleware overload. */
+  async enrollmentVerify(
+    req: NextRequest,
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse>;
+
+  async enrollmentVerify(
+    arg1: PasskeyEnrollmentVerifyOptions | NextRequest,
+    arg2?: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse> {
+    if (arg1 instanceof NextRequest) {
+      if (!arg2) {
+        throw new TypeError(
+          "enrollmentVerify(req, options): Both arguments required for Pages Router"
+        );
+      }
+      const authClient = await this.getAuthClient(arg1);
+      return authClient.passkeyEnrollmentVerify(arg2, arg1.cookies);
+    }
+    const authClient = await this.getAuthClient();
+    const cookiesLib = await getCookies();
+    return authClient.passkeyEnrollmentVerify(arg1, cookiesLib as any);
   }
 }

--- a/src/test/defaults.ts
+++ b/src/test/defaults.ts
@@ -35,7 +35,13 @@ export function getDefaultRoutes(): Routes {
       "/auth/passkey/challenge",
     passkeyGetToken:
       process.env.NEXT_PUBLIC_PASSKEY_GET_TOKEN_ROUTE ||
-      "/auth/passkey/get-token"
+      "/auth/passkey/get-token",
+    passkeyEnrollmentChallenge:
+      process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_CHALLENGE_ROUTE ||
+      "/auth/passkey/enrollment-challenge",
+    passkeyEnrollmentVerify:
+      process.env.NEXT_PUBLIC_PASSKEY_ENROLLMENT_VERIFY_ROUTE ||
+      "/auth/passkey/enrollment-verify"
   };
 }
 

--- a/src/test/mcd-test-fixtures.ts
+++ b/src/test/mcd-test-fixtures.ts
@@ -52,7 +52,9 @@ export const TEST_DEFAULT_ROUTES: Routes = {
   passwordlessVerify: "/auth/passwordless/verify",
   passkeyRegister: "/auth/passkey/register",
   passkeyChallenge: "/auth/passkey/challenge",
-  passkeyGetToken: "/auth/passkey/get-token"
+  passkeyGetToken: "/auth/passkey/get-token",
+  passkeyEnrollmentChallenge: "/auth/passkey/enrollment-challenge",
+  passkeyEnrollmentVerify: "/auth/passkey/enrollment-verify"
 };
 
 /**

--- a/src/types/passkey.ts
+++ b/src/types/passkey.ts
@@ -331,6 +331,25 @@ export interface PasskeyClient {
    * @param options - `authSession` from the challenge + serialised credential.
    */
   getToken(options: PasskeyGetTokenOptions): Promise<void>;
+
+  /**
+   * Request a WebAuthn credential creation challenge to enroll a new passkey
+   * for the currently authenticated user.
+   * Calls Auth0 MyAccount `POST /me/v1/authentication-methods`.
+   * Requires an active session.
+   */
+  enrollmentChallenge(
+    options?: PasskeyEnrollmentChallengeOptions
+  ): Promise<PasskeyEnrollmentChallengeResponse>;
+
+  /**
+   * Complete a passkey enrollment by verifying the WebAuthn attestation.
+   * Calls Auth0 MyAccount `POST /me/v1/authentication-methods/{id}/verify`.
+   * Requires an active session.
+   */
+  enrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<PasskeyEnrollmentVerifyResponse>;
 }
 
 /**


### PR DESCRIPTION
---
  📋 Changes
  
  Adds passkey enrollment support for authenticated users via the Auth0 MyAccount API (/me/v1/authentication-methods).

  New route handlers (src/server/auth-client.ts):
  - POST /auth/passkey/enrollment-challenge — requests a WebAuthn credential creation challenge for the current user; uses MRRT
  (forceTokenRefresh: true) to exchange the session refresh token for a create:me:authentication_methods-scoped MyAccount access token
  - POST /auth/passkey/enroll-verify — verifies the WebAuthn attestation and completes enrollment; returns the registered
  PasskeyAuthenticationMethod
  
  Type fixes (src/types/passkey.ts):
  - PasskeyAuthenticationMethod fields renamed from camelCase to snake_case (key_id, created_at, credential_device_type, etc.) to match
  the Auth0 MyAccount wire format
  - PasskeyEnrollmentChallengeOptions.identity renamed to userIdentityId for consistency with SDK naming conventions

  ProxyOptions (src/types/index.ts):
  - Added forceTokenRefresh?: boolean to allow enrollment to force a fresh MRRT exchange at call time rather than reusing a cached token
  
  📎 References

  - Auth0 MyAccount API: POST /me/v1/authentication-methods, POST /me/v1/authentication-methods/{id}/verify

  🎯 Testing

  Unit tests cover all new paths in src/server/passkey/server-passkey-client.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passkey enrollment: users can register new passkeys via challenge and verification flows.

* **Bug Fixes**
  * Enrollment error responses now provide consistent error codes/defaults (falls back to "unknown_error") for clearer error reporting.

* **Chores**
  * Updated enrollment route configuration and environment variable usage for verification endpoints.

* **Tests**
  * Extended unit tests covering enrollment flows, routing, and error mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/nextjs-auth0/pull/2680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->