### PR TITLE
docs: add Protecting Server Actions section explaining middleware red…

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -27,6 +27,7 @@
 - [Protect an API Route](#protect-an-api-route)
   - [Page Router](#page-router-1)
   - [App Router](#app-router-1)
+- [Protecting Server Actions](#protecting-server-actions)
 - [Accessing the idToken](#accessing-the-idtoken)
 - [Updating the session](#updating-the-session)
   - [On the server (App Router)](#on-the-server-app-router-1)
@@ -692,7 +693,7 @@ The fix requires two things working together.
 
 **Step 1 — Let the Server Action request through middleware.**
 
-Detect the `Next-Action` header and skip the redirect for server action requests. Instead, return `NextResponse.next()` so the request reaches your server action function body.
+Detect the `Next-Action` header and skip the redirect for server action requests. Return `authResponse` (the response from `auth0.middleware()`) so that session cookies and other headers set by the SDK are preserved, and the request proceeds to your server action.
 
 ```ts
 // middleware.ts
@@ -716,7 +717,7 @@ export async function middleware(request: NextRequest) {
     // login page HTML as a server action result. Let the request through so
     // the redirect() call inside the server action can fire instead.
     if (request.headers.has("next-action")) {
-      return NextResponse.next();
+      return authResponse;
     }
 
     return NextResponse.redirect(new URL("/auth/login", request.url), {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -671,6 +671,123 @@ export default withPageAuthRequired(function Products() {
 });
 ```
 
+## Protecting Server Actions
+
+Next.js [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) are invoked via an internal `POST` request with a `Next-Action` header. This means they pass through your middleware just like any other request — and this creates a subtle but important pitfall when protecting them against expired sessions.
+
+### Why `NextResponse.redirect()` in middleware does not work for Server Actions
+
+When a regular page navigation hits an expired session, returning a `303` redirect from middleware works perfectly: the browser follows the redirect and navigates to the login page.
+
+However, when a Server Action is invoked, React's internal fetch runner sends a `POST` with a `Next-Action` header. The browser's `fetch` API **automatically follows any `3xx` redirect at the network layer** — before React ever sees the response. The redirect is consumed silently: `fetch` sends a `GET` to `/auth/login`, receives back the login page HTML, and hands that HTML to the React runtime as the "result" of the server action. React discards it. The action appears to do nothing and the user stays on the same page with no feedback.
+
+What you see in the browser network tab is:
+- `POST /protected-page` → `303`
+- `GET /auth/login` → `200`
+- *(no navigation)*
+
+### The correct pattern
+
+The fix requires two things working together.
+
+**Step 1 — Let the Server Action request through middleware.**
+
+Detect the `Next-Action` header and skip the redirect for server action requests. Instead, return `NextResponse.next()` so the request reaches your server action function body.
+
+```ts
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth0 } from "@/lib/auth0";
+
+export async function middleware(request: NextRequest) {
+  const authResponse = await auth0.middleware(request);
+
+  if (request.nextUrl.pathname.startsWith("/auth")) {
+    return authResponse;
+  }
+
+  const session = await auth0.getSession(request);
+  const isProtectedRoute = !request.nextUrl.pathname.startsWith("/public");
+
+  if (!session && isProtectedRoute) {
+    // Server Actions are POST requests with a Next-Action header.
+    // Returning a 303 redirect here does NOT navigate the browser — React's
+    // internal fetch runner follows the redirect silently and discards the
+    // login page HTML as a server action result. Let the request through so
+    // the redirect() call inside the server action can fire instead.
+    if (request.headers.has("next-action")) {
+      return NextResponse.next();
+    }
+
+    return NextResponse.redirect(new URL("/auth/login", request.url), {
+      status: 303,
+    });
+  }
+
+  return authResponse;
+}
+```
+
+**Step 2 — Call `redirect()` from `next/navigation` inside the Server Action.**
+
+`redirect()` from `next/navigation` does **not** issue an HTTP redirect. It throws a special internal `NEXT_REDIRECT` error that Next.js encodes into the React Flight response. The client-side React runtime reads the redirect instruction and calls `router.push()` — this is the mechanism that actually navigates the browser.
+
+```ts
+// app/actions.ts
+"use server";
+
+import { redirect } from "next/navigation";
+import { auth0 } from "@/lib/auth0";
+
+export async function myProtectedAction(formData: FormData) {
+  // Check session BEFORE any try/catch block (see warning below).
+  const session = await auth0.getSession();
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  // ... rest of your action
+}
+```
+
+> [!WARNING]
+> **Do not call `redirect()` inside a `try/catch` block.**
+>
+> `redirect()` works by throwing a special `NEXT_REDIRECT` error internally. If it is called inside a `try/catch`, that error will be caught and swallowed — the redirect will silently fail and the user will not be navigated. Always check the session and call `redirect()` before entering any `try/catch` block.
+>
+> ```ts
+> // ❌ Wrong — redirect() is called inside catch and will be swallowed
+> export async function myAction() {
+>   try {
+>     const session = await auth0.getSession();
+>     if (!session) throw new Error("No session");
+>     // ...
+>   } catch (error) {
+>     redirect("/auth/login"); // never fires — caught then discarded
+>   }
+> }
+>
+> // ✅ Correct — session check is outside try/catch
+> export async function myAction() {
+>   const session = await auth0.getSession();
+>   if (!session) {
+>     redirect("/auth/login"); // fires correctly
+>   }
+>
+>   try {
+>     // ... rest of action
+>   } catch (error) {
+>     return { error: "Something went wrong" };
+>   }
+> }
+> ```
+
+### Why this is not an SDK bug
+
+The Auth0 SDK does not issue `303` redirects for server action requests — that logic lives entirely in user-written middleware code. The SDK's `auth0.middleware()` only handles `/auth/*` routes and rolling session cookie refresh; it never redirects based on session state. The redirect in the buggy pattern is always user code.
+
+The SDK's `auth0.getSession()` works correctly inside server actions. The issue is purely about how the redirect is triggered and which mechanism is capable of navigating the browser from within a server action context.
+
 ## Accessing the idToken
 
 `idToken` can be accessed from the session in the following way:


### PR DESCRIPTION
## Summary

  Closes #1934

  Adds a new **Protecting Server Actions** section to `EXAMPLES.md` documenting why `NextResponse.redirect()` in middleware silently fails for Server
  Action requests and the correct two-step pattern to handle expired sessions.

  ## Problem

  When a session expires and a user triggers a Server Action, user middleware correctly detects `session === null` and issues a `303` redirect. The browser never navigates. This is because Server Actions use internal `POST` requests with a `Next-Action` header — the browser's `fetch` API follows the `303` automatically at the network layer, hands the login page HTML back to React as the action result, and React silently discards it.

  A secondary pitfall compounds this: calling `redirect()` from `next/navigation` inside a `try/catch` block also silently fails because `redirect()` works by throwing a special `NEXT_REDIRECT` error, which the `catch` block swallows.

  Neither of these is an SDK bug — `auth0.getSession()` and `auth0.middleware()` behave correctly throughout.

  ## Changes

  - `EXAMPLES.md` — new `## Protecting Server Actions` section (inserted after `## Protect an API Route`) covering:
    - Why `303` redirects don't work for Server Action `POST` requests
    - The correct fix: detect `next-action` header in middleware + call `redirect()` from `next/navigation` inside the action
    - Warning block explaining the `try/catch` pitfall with wrong/correct examples
    - A note confirming this is not an SDK bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Protecting Server Actions” section explaining how middleware-issued redirects can be consumed by internal Server Action requests without triggering browser navigation, and how to handle it by bypassing middleware redirects for those requests and enforcing navigation from the Server Action after session checks. Includes guidance to avoid calling redirects inside `try/catch` blocks and clarifies the behavior relates to middleware redirect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->