### PR TITLE
fix: persist per-request max_age in TransactionState to enforce auth_…

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -2356,6 +2356,133 @@ ca/T0LLtgmbMmxSv/MmzIg==
       );
     });
 
+    it("should store per-request maxAge in transaction state when not set in SDK config", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+      loginUrl.searchParams.set("max_age", "900");
+      const request = new NextRequest(loginUrl, { method: "GET" });
+
+      const response = await authClient.handleLogin(request);
+      const authorizationUrl = new URL(response.headers.get("Location")!);
+
+      expect(authorizationUrl.searchParams.get("max_age")).toEqual("900");
+
+      const transactionCookie = response.cookies.get(
+        `__txn_${authorizationUrl.searchParams.get("state")}`
+      );
+      expect(transactionCookie).toBeDefined();
+      expect(
+        (
+          (await decrypt(
+            transactionCookie!.value,
+            secret
+          )) as jose.JWTDecryptResult
+        ).payload
+      ).toEqual(
+        expect.objectContaining({
+          maxAge: 900
+        })
+      );
+    });
+
+    it("should store per-request maxAge=0 (step-up) in transaction state when not set in SDK config", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+      loginUrl.searchParams.set("max_age", "0");
+      const request = new NextRequest(loginUrl, { method: "GET" });
+
+      const response = await authClient.handleLogin(request);
+      const authorizationUrl = new URL(response.headers.get("Location")!);
+
+      expect(authorizationUrl.searchParams.get("max_age")).toEqual("0");
+
+      const transactionCookie = response.cookies.get(
+        `__txn_${authorizationUrl.searchParams.get("state")}`
+      );
+      expect(transactionCookie).toBeDefined();
+      expect(
+        (
+          (await decrypt(
+            transactionCookie!.value,
+            secret
+          )) as jose.JWTDecryptResult
+        ).payload
+      ).toEqual(
+        expect.objectContaining({
+          maxAge: 0
+        })
+      );
+    });
+
+    it("should use per-request maxAge over SDK-level max_age in transaction state", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        authorizationParameters: { max_age: 3600 },
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+      loginUrl.searchParams.set("max_age", "0");
+      const request = new NextRequest(loginUrl, { method: "GET" });
+
+      const response = await authClient.handleLogin(request);
+      const authorizationUrl = new URL(response.headers.get("Location")!);
+
+      expect(authorizationUrl.searchParams.get("max_age")).toEqual("0");
+
+      const transactionCookie = response.cookies.get(
+        `__txn_${authorizationUrl.searchParams.get("state")}`
+      );
+      expect(transactionCookie).toBeDefined();
+      expect(
+        (
+          (await decrypt(
+            transactionCookie!.value,
+            secret
+          )) as jose.JWTDecryptResult
+        ).payload
+      ).toEqual(
+        expect.objectContaining({
+          maxAge: 0
+        })
+      );
+    });
+
     it("should store the returnTo path in the transaction state", async () => {
       const secret = await generateSecret(32);
       const transactionStore = new TransactionStore({

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -2356,48 +2356,6 @@ ca/T0LLtgmbMmxSv/MmzIg==
       );
     });
 
-    it("should store per-request maxAge in transaction state when not set in SDK config", async () => {
-      const secret = await generateSecret(32);
-      const transactionStore = new TransactionStore({ secret });
-      const sessionStore = new StatelessSessionStore({ secret });
-      const authClient = new AuthClient({
-        transactionStore,
-        sessionStore,
-        domain: DEFAULT.domain,
-        clientId: DEFAULT.clientId,
-        clientSecret: DEFAULT.clientSecret,
-        secret,
-        appBaseUrl: DEFAULT.appBaseUrl,
-        routes: getDefaultRoutes(),
-        fetch: getMockAuthorizationServer()
-      });
-      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
-      loginUrl.searchParams.set("max_age", "900");
-      const request = new NextRequest(loginUrl, { method: "GET" });
-
-      const response = await authClient.handleLogin(request);
-      const authorizationUrl = new URL(response.headers.get("Location")!);
-
-      expect(authorizationUrl.searchParams.get("max_age")).toEqual("900");
-
-      const transactionCookie = response.cookies.get(
-        `__txn_${authorizationUrl.searchParams.get("state")}`
-      );
-      expect(transactionCookie).toBeDefined();
-      expect(
-        (
-          (await decrypt(
-            transactionCookie!.value,
-            secret
-          )) as jose.JWTDecryptResult
-        ).payload
-      ).toEqual(
-        expect.objectContaining({
-          maxAge: 900
-        })
-      );
-    });
-
     it("should store per-request maxAge=0 (step-up) in transaction state when not set in SDK config", async () => {
       const secret = await generateSecret(32);
       const transactionStore = new TransactionStore({ secret });
@@ -2591,6 +2549,52 @@ ca/T0LLtgmbMmxSv/MmzIg==
           returnTo: "/"
         })
       );
+    });
+
+    it("should return a 400 for a non-numeric max_age query param", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+      loginUrl.searchParams.set("max_age", "abc");
+      const response = await authClient.handleLogin(
+        new NextRequest(loginUrl, { method: "GET" })
+      );
+      expect(response.status).toEqual(400);
+    });
+
+    it("should return a 400 for a negative max_age query param", async () => {
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer()
+      });
+      const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+      loginUrl.searchParams.set("max_age", "-1");
+      const response = await authClient.handleLogin(
+        new NextRequest(loginUrl, { method: "GET" })
+      );
+      expect(response.status).toEqual(400);
     });
 
     describe("with pushed authorization requests", async () => {
@@ -8600,6 +8604,24 @@ ca/T0LLtgmbMmxSv/MmzIg==
 
       await expect(
         authClient.startInteractiveLogin({}, request)
+      ).rejects.toThrow(InvalidConfigurationError);
+    });
+
+    it("should throw InvalidConfigurationError for a non-numeric max_age authorization parameter", async () => {
+      const authClient = await createAuthClient();
+      await expect(
+        authClient.startInteractiveLogin({
+          authorizationParameters: { max_age: "abc" as unknown as number }
+        })
+      ).rejects.toThrow(InvalidConfigurationError);
+    });
+
+    it("should throw InvalidConfigurationError for a negative max_age authorization parameter", async () => {
+      const authClient = await createAuthClient();
+      await expect(
+        authClient.startInteractiveLogin({
+          authorizationParameters: { max_age: -1 }
+        })
       ).rejects.toThrow(InvalidConfigurationError);
     });
 

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -4541,6 +4541,80 @@ ca/T0LLtgmbMmxSv/MmzIg==
       );
     });
 
+    it("should reject callback when max_age=0 was requested but auth_time in the token is stale", async () => {
+      const state = "transaction-state";
+      const code = "auth-code";
+
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+
+      // Build an ID token whose auth_time is 2 hours in the past.
+      // With max_age=0, oauth4webapi requires auth_time ≥ now − tolerance.
+      const staleAuthTime = Math.floor(Date.now() / 1000) - 7200;
+      const idToken = await new jose.SignJWT({
+        sid: DEFAULT.sid,
+        auth_time: staleAuthTime,
+        nonce: "nonce-value"
+      })
+        .setProtectedHeader({ alg: DEFAULT.alg })
+        .setSubject(DEFAULT.sub)
+        .setIssuedAt()
+        .setIssuer(_authorizationServerMetadata.issuer)
+        .setAudience(DEFAULT.clientId)
+        .setExpirationTime("2h")
+        .sign(DEFAULT.keyPair.privateKey);
+
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch: getMockAuthorizationServer({
+          tokenEndpointResponse: {
+            token_type: "Bearer",
+            access_token: DEFAULT.accessToken,
+            refresh_token: DEFAULT.refreshToken,
+            id_token: idToken,
+            expires_in: 86400
+          } as oauth.TokenEndpointResponse
+        })
+      });
+
+      const url = new URL("/auth/callback", DEFAULT.appBaseUrl);
+      url.searchParams.set("code", code);
+      url.searchParams.set("state", state);
+
+      const headers = new Headers();
+      // TransactionState with maxAge=0 — the fix ensures this is now stored correctly
+      const transactionState: TransactionState = {
+        nonce: "nonce-value",
+        maxAge: 0,
+        codeVerifier: "code-verifier",
+        responseType: RESPONSE_TYPES.CODE,
+        state,
+        returnTo: "/dashboard"
+      };
+      const expiration = Math.floor(Date.now() / 1000 + 3600);
+      headers.set(
+        "cookie",
+        `__txn_${state}=${await encrypt(transactionState, secret, expiration)}`
+      );
+      const request = new NextRequest(url, { method: "GET", headers });
+
+      const response = await authClient.handleCallback(request);
+      // oauth4webapi enforces auth_time + max_age ≥ now − tolerance and throws;
+      // the SDK surfaces this as a 500 AuthorizationCodeGrantError
+      expect(response.status).toEqual(500);
+      expect(await response.text()).toEqual(
+        "An error occurred while trying to exchange the authorization code."
+      );
+    });
+
     it("should return an error if the discovery endpoint could not be fetched", async () => {
       const state = "transaction-state";
       const code = "auth-code";

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -855,9 +855,16 @@ export class AuthClient {
     }
 
     // Prepare transaction state
+    // Read max_age from the already-merged authorizationParams (not the static SDK config)
+    // so that per-request values (e.g. max_age=0 for step-up auth) are preserved for
+    // auth_time validation at callback. Falls back to SDK-level config when absent.
+    const requestedMaxAgeStr = authorizationParams.get("max_age");
     const transactionState: TransactionState = {
       nonce,
-      maxAge: this.authorizationParameters.max_age,
+      maxAge:
+        requestedMaxAgeStr !== null
+          ? Number(requestedMaxAgeStr)
+          : this.authorizationParameters.max_age,
       codeVerifier,
       responseType: RESPONSE_TYPES.CODE,
       state,

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -102,7 +102,10 @@ import {
 import type { SessionCheckResult } from "../types/mcd.js";
 import type { MfaTokenEndpointResponse } from "../types/mfa.js";
 import { resolveAppBaseUrl } from "../utils/app-base-url.js";
-import { mergeAuthorizationParamsIntoSearchParams } from "../utils/authorization-params-helpers.js";
+import {
+  mergeAuthorizationParamsIntoSearchParams,
+  parseNonNegativeIntegerParam
+} from "../utils/authorization-params-helpers.js";
 import {
   DEFAULT_MFA_CONTEXT_TTL_SECONDS,
   DEFAULT_SCOPES
@@ -859,12 +862,23 @@ export class AuthClient {
     // so that per-request values (e.g. max_age=0 for step-up auth) are preserved for
     // auth_time validation at callback. Falls back to SDK-level config when absent.
     const requestedMaxAgeStr = authorizationParams.get("max_age");
+    let resolvedMaxAge: number | undefined =
+      this.authorizationParameters.max_age;
+    if (requestedMaxAgeStr !== null) {
+      const parsed = parseNonNegativeIntegerParam(
+        "max_age",
+        requestedMaxAgeStr
+      );
+      if (parsed === null) {
+        throw new InvalidConfigurationError(
+          `Invalid max_age parameter: "${requestedMaxAgeStr}". Must be a non-negative integer.`
+        );
+      }
+      resolvedMaxAge = parsed;
+    }
     const transactionState: TransactionState = {
       nonce,
-      maxAge:
-        requestedMaxAgeStr !== null
-          ? Number(requestedMaxAgeStr)
-          : this.authorizationParameters.max_age,
+      maxAge: resolvedMaxAge,
       codeVerifier,
       responseType: RESPONSE_TYPES.CODE,
       state,
@@ -915,6 +929,17 @@ export class AuthClient {
     ) {
       return new NextResponse(
         `Invalid challengeMode query param: ${queryChallengeMode}. Expected 'redirect', 'popup', or omit.`,
+        { status: 400 }
+      );
+    }
+
+    // Validate max_age query param value
+    if (
+      searchParams.max_age !== undefined &&
+      parseNonNegativeIntegerParam("max_age", searchParams.max_age) === null
+    ) {
+      return new NextResponse(
+        `Invalid max_age query param: "${searchParams.max_age}". Must be a non-negative integer.`,
         { status: 400 }
       );
     }

--- a/src/utils/authorization-params-helpers.test.ts
+++ b/src/utils/authorization-params-helpers.test.ts
@@ -107,5 +107,13 @@ describe("authorization-params-helpers", () => {
     it("should return null for a float", () => {
       expect(parseNonNegativeIntegerParam("max_age", "1.5")).toBeNull();
     });
+
+    it("should return null for scientific notation", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "1e3")).toBeNull();
+    });
+
+    it("should return null for a value with leading whitespace", () => {
+      expect(parseNonNegativeIntegerParam("max_age", " 3600")).toBeNull();
+    });
   });
 });

--- a/src/utils/authorization-params-helpers.test.ts
+++ b/src/utils/authorization-params-helpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { mergeAuthorizationParamsIntoSearchParams } from "./authorization-params-helpers.js";
+import {
+  mergeAuthorizationParamsIntoSearchParams,
+  parseNonNegativeIntegerParam
+} from "./authorization-params-helpers.js";
 
 describe("authorization-params-helpers", () => {
   describe("mergeAuthorizationParamsIntoSearchParams", () => {
@@ -77,6 +80,32 @@ describe("authorization-params-helpers", () => {
       expect(searchParams.get("a")).toEqual("0");
       expect(searchParams.get("b")).toEqual("");
       expect(searchParams.get("c")).toEqual("false");
+    });
+  });
+
+  describe("parseNonNegativeIntegerParam", () => {
+    it("should return 0 for '0'", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "0")).toBe(0);
+    });
+
+    it("should return the integer for a valid positive integer string", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "3600")).toBe(3600);
+    });
+
+    it("should return null for a non-numeric string", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "abc")).toBeNull();
+    });
+
+    it("should return null for an empty string", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "")).toBeNull();
+    });
+
+    it("should return null for a negative integer", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "-1")).toBeNull();
+    });
+
+    it("should return null for a float", () => {
+      expect(parseNonNegativeIntegerParam("max_age", "1.5")).toBeNull();
     });
   });
 });

--- a/src/utils/authorization-params-helpers.ts
+++ b/src/utils/authorization-params-helpers.ts
@@ -3,20 +3,18 @@ import { getScopeForAudience } from "./scope-helpers.js";
 
 /**
  * Parses a string value as a non-negative integer authorization parameter.
- * Returns the parsed number, or null if the value is not a valid non-negative integer.
+ * Accepts only strings matching /^\d+$/ (decimal digits only — rejects floats,
+ * scientific notation, negative values, empty strings, and whitespace).
+ * Returns the parsed number, or null if the value is invalid.
  */
 export function parseNonNegativeIntegerParam(
   name: string,
   value: string
 ): number | null {
-  if (value.trim() === "") {
+  if (!/^\d+$/.test(value)) {
     return null;
   }
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    return null;
-  }
-  return parsed;
+  return Number(value);
 }
 
 /**

--- a/src/utils/authorization-params-helpers.ts
+++ b/src/utils/authorization-params-helpers.ts
@@ -2,6 +2,24 @@ import type { AuthorizationParameters } from "../types/index.js";
 import { getScopeForAudience } from "./scope-helpers.js";
 
 /**
+ * Parses a string value as a non-negative integer authorization parameter.
+ * Returns the parsed number, or null if the value is not a valid non-negative integer.
+ */
+export function parseNonNegativeIntegerParam(
+  name: string,
+  value: string
+): number | null {
+  if (value.trim() === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
  * Merges two instances of authorization parameters into a URLSearchParams object,
  * excluding any parameters specified in the excludedParams array.
  * If the scope is provided as a map of audience to scopes, it selects the appropriate scope


### PR DESCRIPTION
PR description:

  - [x] All new/changed/fixed functionality is covered by tests (or N/A)
  - [ ] I have added documentation for all new/changed functionality (or N/A)

  ### 📋 Changes

  **Bug:** When `max_age` is passed as a per-request authorization parameter (via `startInteractiveLogin({authorizationParameters: {max_age: 0 } })` or the `?max_age=0` login URL query param), the SDK correctly forwards it to the Auth0 `/authorize` endpoint but neverstores it in `TransactionState`. 
  At callback, `processAuthorizationCodeResponse()` receives `maxAge: undefined`, which`oauth4webapi` aliases `skipAuthTimeCheck`, silently bypassing the OIDC Core §3.1.3.7 `auth_time` validation entirely.

  **Root cause:** `src/server/auth-client.ts` line 816 read `this.authorizationParameters.max_age` (the static SDK-level config) instead of the already-merged `authorizationParams` URLSearchParams object that was built two lines earlier and forwarded to Auth0. These are two different objects; per-request values only exist in the latter.

  **Fix:** Read `max_age` from `authorizationParams` (the merged URLSearchParams) when constructing `TransactionState`, falling back to the SDK-level config when absent. This guarantees that whatever `max_age` Auth0 received is also what gets verified at callback.

  ```ts
  // Before
  maxAge: this.authorizationParameters.max_age,

  // After
  const requestedMaxAgeStr = authorizationParams.get("max_age");
  maxAge: requestedMaxAgeStr !== null
    ? Number(requestedMaxAgeStr)
    : this.authorizationParameters.max_age,
```

  🎯 Testing

  Three new unit tests added to src/server/auth-client.test.ts alongside the existing SDK-level max_age test:

  1. Per-request max_age (non-zero) — verifies maxAge: 900 is stored in TransactionState when absent from SDK config but present in the login URL query param
  2. Per-request max_age=0 (step-up) — the exact reported bug vector; verifies maxAge: 0 is stored and survives the JWT round-trip (falsy but valid)
  3. Per-request overrides SDK-level — verifies max_age=0 in the request overrides max_age: 3600 in SDK config, matching the value Auth0 actually received

  All 1560 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow `max_age` to be provided per request, overriding SDK defaults, including support for step-up flows with `max_age=0`.
* **Bug Fixes**
  * Ensure the effective `max_age` used during login is derived from the merged per-request/SKD settings.
  * Validate `max_age` inputs: non-numeric/negative values now return `400`, and invalid SDK `max_age` throws a configuration error.
* **Tests**
  * Added coverage for `max_age` parsing, per-request overrides, and error behavior during the callback flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->