### PR TITLE
IPSIE implementation - example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dist
 .memory/
 .dev-files/
 *.env.*
+!**/.env.example
 *.tmp
 *PLAN*.md
 .yalc/

--- a/examples/with-ipsie-session-expiry/.env.example
+++ b/examples/with-ipsie-session-expiry/.env.example
@@ -1,0 +1,6 @@
+AUTH0_DOMAIN=
+AUTH0_CLIENT_ID=
+AUTH0_CLIENT_SECRET=
+AUTH0_SECRET=
+APP_BASE_URL=http://localhost:3000
+AUTH0_AUDIENCE=   # optional — set to an API identifier to receive a JWT access token

--- a/examples/with-ipsie-session-expiry/README.md
+++ b/examples/with-ipsie-session-expiry/README.md
@@ -1,0 +1,134 @@
+# with-ipsie-session-expiry
+
+Tests IPSIE `session_expiry` ceiling enforcement end-to-end across all affected SDK paths.
+
+When Auth0 is configured to emit a `session_expiry` claim in the ID token, the SDK treats it as a hard, non-extendable ceiling on the local session. This example exercises every flow where ceiling enforcement fires.
+
+---
+
+## Setup
+
+### 1. Auth0 tenant
+
+#### Add the Post-Login Action
+
+1. Go to **Auth0 Dashboard → Actions → Library → Create Action → Build from scratch**
+2. Name it `IPSIE Short Ceiling`, trigger = **Post-login**
+3. Paste:
+
+   ```js
+   exports.onExecutePostLogin = async (event, api) => {
+     // 120-second ceiling — adjust to taste for faster testing
+     api.idToken.setCustomClaim("session_expiry", Math.floor(Date.now() / 1000) + 120);
+   };
+   ```
+
+4. **Deploy** → go to **Actions → Flows → Login** → drag the action into the flow → **Apply**
+
+> The Action is not retroactive. You must log in **fresh** after binding it (use incognito or log out first).
+
+#### Skip consent (required if testing with a custom audience)
+
+If `AUTH0_AUDIENCE` is set, Auth0 will prompt for consent on `offline_access`. To suppress it:
+**Dashboard → Applications → your app → Advanced Settings → OAuth → Skip user consent for first-party apps → On → Save**
+
+---
+
+### 2. Running
+
+```bash
+cp .env.example .env.local
+# Fill in AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_SECRET
+# AUTH0_AUDIENCE is optional — set to an API identifier to receive a JWT access token
+
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and log in with incognito.
+
+---
+
+## What to test and what to look for
+
+The page has 9 cards, each targeting a specific SDK flow. The ceiling is set to **120 seconds**. The SDK applies a **30-second leeway**, so enforcement starts at **T+90s** (ceiling − leeway).
+
+---
+
+### Before the ceiling (T+0 to T+89s)
+
+All cards should show healthy state.
+
+| Card | Expected |
+|---|---|
+| IPSIE Session Ceiling | Countdown ticking down, green **Active** badge |
+| Middleware — Rolling Session | `createdAt` value is stable; page loads normally on refresh |
+| getSession() | `{ "session": { ... }, "expired": false }` |
+| useUser() | User object shown |
+| getAccessToken() — Browser | Access token displayed |
+| withApiAuthRequired() | `{ "status": 200, "body": { "protected": true } }` |
+| updateSession() | `{ "success": true, "updatedAt": "..." }` |
+| withPageAuthRequired() | /protected page renders with your email |
+
+---
+
+### Approaching ceiling (T+90s to T+120s)
+
+The SDK starts treating the session as expired once within 30s of the ceiling.
+
+| Card | Expected |
+|---|---|
+| IPSIE Session Ceiling | Yellow **Expiring soon** badge at ≤30s remaining |
+
+---
+
+### After the ceiling (T+90s onwards, enforcement active)
+
+Work through each card **without refreshing the main page** (refreshing redirects to login — do the manual checks first). Use the buttons to test each flow one by one.
+
+| Card | What to click/do | Expected result |
+|---|---|---|
+| **getSession()** | Click **Check Session** | `{ "session": null, "expired": true }` — `getSession()` returns null, same as logged-out |
+| **useUser()** | Observe (auto-polls) or reload the component | `user: undefined (logged-out state)` — hook sees 401 from `/auth/profile` |
+| **getAccessToken() — Browser** | Click **Get Access Token** | Red error box: `session_expired — the IdP session ceiling has been reached` |
+| **withApiAuthRequired()** | Click **Call Protected API** | `{ "status": 401 }` — guard returns 401 before the handler runs |
+| **updateSession()** | Click **Update Session** | `{ "success": false, "error": "No active session..." }` — session is null, update blocked |
+| **withPageAuthRequired()** | Open [/protected](http://localhost:3000/protected) in same tab | Redirected to `/auth/login` — page guard sees null session |
+| **Middleware — Rolling Session** | Refresh the main page | Redirected to `/auth/login` — middleware sees null session, rolling is skipped |
+
+> After the last step (refreshing the main page), you will be at the login page. That is correct — `getSession()` in the root page returns null and `redirect("/auth/login")` fires.
+
+---
+
+### At-login rejection (separate test run)
+
+This tests the callback path that rejects a session whose ceiling is already in the past at login time.
+
+1. Change the Post-Login Action to emit a **past** ceiling:
+
+   ```js
+   exports.onExecutePostLogin = async (event, api) => {
+     api.idToken.setCustomClaim("session_expiry", Math.floor(Date.now() / 1000) - 60);
+   };
+   ```
+
+2. **Deploy** the updated Action.
+3. Log out, then log in again (incognito).
+4. **Expected**: The callback returns a `session_expired` error — you land on an error page or the login page, never on the home page. No session is stored.
+
+Restore the Action to `+ 120` when done.
+
+---
+
+## SDK flows exercised
+
+| # | Flow | Card / endpoint | Ceiling fires at |
+|---|---|---|---|
+| 1 | `getSession()` | getSession card → `/api/check-session` | `getSessionWithDomainCheck` (line 2874) |
+| 2 | `useUser()` browser hook | useUser card → `/auth/profile` | `handleProfile` → `getSessionWithDomainCheck` |
+| 3 | `getAccessToken()` browser | getAccessToken card → `/auth/access-token` | `handleAccessToken` → `getTokenSet` (line 2236) |
+| 4 | `withApiAuthRequired()` | withApiAuthRequired card → `/api/protected` | `getSessionWithDomainCheck` (line 2874) |
+| 5 | `updateSession()` | updateSession card → `/api/update-session` | `getSession()` returns null before update |
+| 6 | `withPageAuthRequired()` | `/protected` page | `getSessionWithDomainCheck` (line 2874) |
+| 7 | Middleware rolling session | page refresh | `getSessionWithDomainCheck` (line 2874) |
+| 8 | `handleCallback` redirect | login flow (at-login rejection test) | `isSessionCeilingInPast` (line 1454) |

--- a/examples/with-ipsie-session-expiry/README.md
+++ b/examples/with-ipsie-session-expiry/README.md
@@ -124,11 +124,11 @@ Restore the Action to `+ 120` when done.
 
 | # | Flow | Card / endpoint | Ceiling fires at |
 |---|---|---|---|
-| 1 | `getSession()` | getSession card → `/api/check-session` | `getSessionWithDomainCheck` (line 2874) |
+| 1 | `getSession()` | getSession card → `/api/check-session` | `getSessionWithDomainCheck` |
 | 2 | `useUser()` browser hook | useUser card → `/auth/profile` | `handleProfile` → `getSessionWithDomainCheck` |
-| 3 | `getAccessToken()` browser | getAccessToken card → `/auth/access-token` | `handleAccessToken` → `getTokenSet` (line 2236) |
-| 4 | `withApiAuthRequired()` | withApiAuthRequired card → `/api/protected` | `getSessionWithDomainCheck` (line 2874) |
+| 3 | `getAccessToken()` browser | getAccessToken card → `/auth/access-token` | `handleAccessToken` → `getTokenSet` |
+| 4 | `withApiAuthRequired()` | withApiAuthRequired card → `/api/protected` | `getSessionWithDomainCheck` |
 | 5 | `updateSession()` | updateSession card → `/api/update-session` | `getSession()` returns null before update |
-| 6 | `withPageAuthRequired()` | `/protected` page | `getSessionWithDomainCheck` (line 2874) |
-| 7 | Middleware rolling session | page refresh | `getSessionWithDomainCheck` (line 2874) |
-| 8 | `handleCallback` redirect | login flow (at-login rejection test) | `isSessionCeilingInPast` (line 1454) |
+| 6 | `withPageAuthRequired()` | `/protected` page | `getSessionWithDomainCheck` |
+| 7 | Middleware rolling session | page refresh | `getSessionWithDomainCheck` |
+| 8 | `handleCallback` redirect | login flow (at-login rejection test) | `isSessionCeilingInPast` |

--- a/examples/with-ipsie-session-expiry/app/access-token-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/access-token-panel.tsx
@@ -4,9 +4,7 @@ import { useState } from "react";
 
 import { getAccessToken } from "@auth0/nextjs-auth0/client";
 
-const LEEWAY = 30;
-
-export function AccessTokenPanel({ ceiling }: { ceiling: number | null }) {
+export function AccessTokenPanel() {
   const [token, setToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -20,16 +18,7 @@ export function AccessTokenPanel({ ceiling }: { ceiling: number | null }) {
       const t = await getAccessToken();
       setToken(t);
     } catch (err: any) {
-      // getAccessToken() throws MISSING_SESSION when getSession() returns null.
-      // If the ceiling has passed, the root cause is the IPSIE ceiling — not a
-      // genuinely missing session — so show a ceiling-specific message.
-      const isCeilingExpired =
-        err?.code === "session_expired" ||
-        (err?.code === "missing_session" &&
-          ceiling !== null &&
-          Math.floor(Date.now() / 1000) >= ceiling - LEEWAY);
-
-      if (isCeilingExpired) {
+      if (err?.code === "session_expired") {
         setError(
           "session_expired — the IdP session ceiling has been reached. The user must re-authenticate."
         );

--- a/examples/with-ipsie-session-expiry/app/access-token-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/access-token-panel.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+import { getAccessToken } from "@auth0/nextjs-auth0/client";
+
+const LEEWAY = 30;
+
+export function AccessTokenPanel({ ceiling }: { ceiling: number | null }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleGetToken() {
+    setLoading(true);
+    setToken(null);
+    setError(null);
+
+    try {
+      const t = await getAccessToken();
+      setToken(t);
+    } catch (err: any) {
+      // getAccessToken() throws MISSING_SESSION when getSession() returns null.
+      // If the ceiling has passed, the root cause is the IPSIE ceiling — not a
+      // genuinely missing session — so show a ceiling-specific message.
+      const isCeilingExpired =
+        err?.code === "session_expired" ||
+        (err?.code === "missing_session" &&
+          ceiling !== null &&
+          Math.floor(Date.now() / 1000) >= ceiling - LEEWAY);
+
+      if (isCeilingExpired) {
+        setError(
+          "session_expired — the IdP session ceiling has been reached. The user must re-authenticate."
+        );
+      } else {
+        setError(err?.message ?? "Failed to get access token");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <button onClick={handleGetToken} disabled={loading}>
+        {loading ? "Fetching…" : "Get Access Token"}
+      </button>
+
+      {error && <div className="error">{error}</div>}
+
+      {token && (
+        <>
+          <div className="label" style={{ marginTop: "0.75rem" }}>Access Token</div>
+          <div className="token">{token}</div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/api/check-session/route.ts
+++ b/examples/with-ipsie-session-expiry/app/api/check-session/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { auth0 } from "@/lib/auth0";
+
+export async function GET() {
+  const session = await auth0.getSession();
+
+  if (!session) {
+    return NextResponse.json({ session: null, expired: true });
+  }
+
+  const ceiling = session.internal?.sessionExpiresAt ?? null;
+  const now = Math.floor(Date.now() / 1000);
+
+  return NextResponse.json({
+    session: {
+      user: session.user,
+      sessionExpiresAt: ceiling,
+      remainingSeconds: ceiling ? ceiling - now : null
+    },
+    expired: false
+  });
+}

--- a/examples/with-ipsie-session-expiry/app/api/protected/route.ts
+++ b/examples/with-ipsie-session-expiry/app/api/protected/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { auth0 } from "@/lib/auth0";
 
-const protectedHandler = auth0.withApiAuthRequired(async (_req: Request | NextRequest) => {
+const handler = auth0.withApiAuthRequired(async () => {
   return NextResponse.json({ protected: true, message: "You have an active session." });
 });
 
-export async function GET(req: NextRequest): Promise<NextResponse> {
-  return protectedHandler(req, {}) as Promise<NextResponse>;
+// withApiAuthRequired returns AppRouteHandlerFn whose declared return is
+// Promise<Response> | Response, but the inferred type comes through as
+// unknown due to the SDK's overloaded signature. The cast is safe — the
+// runtime always returns a Response.
+export async function GET(req: NextRequest): Promise<Response> {
+  return handler(req, {}) as Promise<Response>;
 }

--- a/examples/with-ipsie-session-expiry/app/api/protected/route.ts
+++ b/examples/with-ipsie-session-expiry/app/api/protected/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { auth0 } from "@/lib/auth0";
+
+const protectedHandler = auth0.withApiAuthRequired(async (_req: Request | NextRequest) => {
+  return NextResponse.json({ protected: true, message: "You have an active session." });
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return protectedHandler(req, {}) as Promise<NextResponse>;
+}

--- a/examples/with-ipsie-session-expiry/app/api/update-session/route.ts
+++ b/examples/with-ipsie-session-expiry/app/api/update-session/route.ts
@@ -21,7 +21,7 @@ export async function POST() {
   } catch (err: any) {
     return NextResponse.json(
       { success: false, error: err.message },
-      { status: 409 }
+      { status: 500 }
     );
   }
 }

--- a/examples/with-ipsie-session-expiry/app/api/update-session/route.ts
+++ b/examples/with-ipsie-session-expiry/app/api/update-session/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { auth0 } from "@/lib/auth0";
+
+export async function POST() {
+  const session = await auth0.getSession();
+
+  if (!session) {
+    return NextResponse.json(
+      { success: false, error: "No active session (ceiling may have been reached)" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    await auth0.updateSession({
+      ...session,
+      user: { ...session.user, updatedAt: new Date().toISOString() }
+    });
+    return NextResponse.json({ success: true, updatedAt: new Date().toISOString() });
+  } catch (err: any) {
+    return NextResponse.json(
+      { success: false, error: err.message },
+      { status: 409 }
+    );
+  }
+}

--- a/examples/with-ipsie-session-expiry/app/ceiling-countdown.tsx
+++ b/examples/with-ipsie-session-expiry/app/ceiling-countdown.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// The SDK enforces the ceiling 30s early (leeway for clock skew).
+// Show time until enforcement, not time until the raw ceiling timestamp.
+const LEEWAY = 30;
+
+export function CeilingCountdown({ ceiling }: { ceiling: number }) {
+  const enforcedAt = ceiling - LEEWAY;
+
+  const [remaining, setRemaining] = useState(
+    enforcedAt - Math.floor(Date.now() / 1000)
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining(enforcedAt - Math.floor(Date.now() / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [enforcedAt]);
+
+  const status = remaining <= 0 ? "expired" : "active";
+
+  const badgeClass =
+    status === "active" ? "badge badge-green" : "badge badge-red";
+
+  return (
+    <>
+      <div className="label">Ceiling (Unix seconds)</div>
+      <div className="value">{ceiling}</div>
+
+      <div className="label" style={{ marginTop: "0.75rem" }}>
+        Ceiling (human-readable)
+      </div>
+      <div className="value">{new Date(ceiling * 1000).toLocaleString()}</div>
+
+      <div className="label" style={{ marginTop: "0.75rem" }}>
+        Time until enforcement (ceiling − 30s leeway)
+      </div>
+      <div
+        className="value"
+        style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+      >
+        {remaining > 0 ? `${remaining}s` : "Enforced"}
+        <span className={badgeClass}>
+          {status === "active" ? "Active" : "Expired"}
+        </span>
+      </div>
+
+      <p style={{ fontSize: "0.8rem", color: "#6b7280", marginTop: "0.75rem" }}>
+        Hits 0 when <code>now &gt;= ceiling − 30s</code>. All session reads
+        and token fetches are blocked from this point.
+      </p>
+    </>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/ceiling-countdown.tsx
+++ b/examples/with-ipsie-session-expiry/app/ceiling-countdown.tsx
@@ -9,21 +9,39 @@ const LEEWAY = 30;
 export function CeilingCountdown({ ceiling }: { ceiling: number }) {
   const enforcedAt = ceiling - LEEWAY;
 
-  const [remaining, setRemaining] = useState(
-    enforcedAt - Math.floor(Date.now() / 1000)
-  );
+  // Seed to null to avoid a server/client hydration mismatch on the first render.
+  // The interval fires immediately and sets the real value on the client.
+  const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    function tick() {
       setRemaining(enforcedAt - Math.floor(Date.now() / 1000));
-    }, 1000);
+    }
+    tick();
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [enforcedAt]);
 
-  const status = remaining <= 0 ? "expired" : "active";
+  const status =
+    remaining === null ? "loading" : remaining <= 0 ? "expired" : remaining <= 30 ? "warning" : "active";
 
   const badgeClass =
-    status === "active" ? "badge badge-green" : "badge badge-red";
+    status === "active"
+      ? "badge badge-green"
+      : status === "warning"
+        ? "badge badge-yellow"
+        : status === "expired"
+          ? "badge badge-red"
+          : "badge";
+
+  const badgeLabel =
+    status === "active"
+      ? "Active"
+      : status === "warning"
+        ? "Expiring soon"
+        : status === "expired"
+          ? "Expired"
+          : "…";
 
   return (
     <>
@@ -42,10 +60,8 @@ export function CeilingCountdown({ ceiling }: { ceiling: number }) {
         className="value"
         style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
       >
-        {remaining > 0 ? `${remaining}s` : "Enforced"}
-        <span className={badgeClass}>
-          {status === "active" ? "Active" : "Expired"}
-        </span>
+        {remaining === null ? "…" : remaining > 0 ? `${remaining}s` : "Enforced"}
+        <span className={badgeClass}>{badgeLabel}</span>
       </div>
 
       <p style={{ fontSize: "0.8rem", color: "#6b7280", marginTop: "0.75rem" }}>

--- a/examples/with-ipsie-session-expiry/app/globals.css
+++ b/examples/with-ipsie-session-expiry/app/globals.css
@@ -1,0 +1,65 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  color: #111;
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+h2 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
+
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.label { font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; }
+.value { font-size: 0.95rem; margin-top: 0.25rem; font-family: monospace; }
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.badge-green { background: #dcfce7; color: #166534; }
+.badge-yellow { background: #fef9c3; color: #854d0e; }
+.badge-red { background: #fee2e2; color: #991b1b; }
+
+button {
+  padding: 0.5rem 1rem;
+  background: #111;
+  color: #fff;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  margin-top: 0.75rem;
+}
+button:hover { background: #374151; }
+
+.error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem;
+  color: #991b1b;
+  font-size: 0.875rem;
+  margin-top: 0.75rem;
+}
+
+.token {
+  background: #f3f4f6;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-family: monospace;
+  word-break: break-all;
+  margin-top: 0.5rem;
+}
+
+a { color: #2563eb; }

--- a/examples/with-ipsie-session-expiry/app/layout.tsx
+++ b/examples/with-ipsie-session-expiry/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { Auth0Provider } from "@auth0/nextjs-auth0/client";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "IPSIE Session Expiry — Auth0 Next.js SDK",
+  description: "Demonstrates IPSIE session_expiry enforcement for enterprise connections"
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>
+        <Auth0Provider>{children}</Auth0Provider>
+      </body>
+    </html>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/page.tsx
+++ b/examples/with-ipsie-session-expiry/app/page.tsx
@@ -1,0 +1,171 @@
+import { redirect } from "next/navigation";
+
+import { auth0 } from "@/lib/auth0";
+import { AccessTokenPanel } from "./access-token-panel";
+import { CeilingCountdown } from "./ceiling-countdown";
+import { SessionCheckPanel } from "./session-check-panel";
+import { UseUserPanel } from "./use-user-panel";
+import { UpdateSessionPanel } from "./update-session-panel";
+import { WithApiAuthPanel } from "./with-api-auth-panel";
+
+export default async function Page() {
+  const session = await auth0.getSession();
+
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  const { user, tokenSet, internal } = session;
+  const ceiling = typeof internal.sessionExpiresAt === "number" ? internal.sessionExpiresAt : null;
+  const createdAt = internal.createdAt;
+
+  let idTokenClaims: Record<string, unknown> | null = null;
+  if (tokenSet.idToken) {
+    try {
+      const payload = tokenSet.idToken.split(".")[1];
+      idTokenClaims = JSON.parse(Buffer.from(payload, "base64url").toString());
+    } catch { }
+  }
+
+  const hasNoCeiling = ceiling === null;
+
+  return (
+    <main>
+      <h1>IPSIE Session Expiry Demo</h1>
+      <p style={{ color: "#6b7280", marginBottom: "1.5rem" }}>
+        This example demonstrates how the SDK enforces the{" "}
+        <code>session_expiry</code> ceiling emitted by Auth0 for enterprise
+        connections. Each card below exercises a different SDK code path.
+      </p>
+
+      {hasNoCeiling && (
+        <div style={{
+          background: "#fef9c3",
+          border: "1px solid #fde047",
+          borderRadius: "0.5rem",
+          padding: "0.875rem 1rem",
+          marginBottom: "1rem",
+          fontSize: "0.875rem",
+          color: "#713f12"
+        }}>
+          <strong>No ceiling found.</strong> The <code>session_expiry</code> claim
+          is missing from the ID token. Add a Post-Login Action (see README) and
+          log in fresh — ceiling enforcement will not fire without it.
+        </div>
+      )}
+
+      {/* ── 1. User ─────────────────────────────────────────── */}
+      <div className="card">
+        <h2>User</h2>
+        <div className="label">Name</div>
+        <div className="value">{user.name ?? "—"}</div>
+        <div className="label" style={{ marginTop: "0.75rem" }}>Email</div>
+        <div className="value">{user.email ?? "—"}</div>
+      </div>
+
+      {/* ── 2. IPSIE ceiling countdown ───────────────────────── */}
+      <div className="card">
+        <h2>IPSIE Session Ceiling</h2>
+        {ceiling === null ? (
+          <p style={{ color: "#6b7280", fontSize: "0.875rem" }}>
+            No ceiling — add the Post-Login Action and log in fresh.
+          </p>
+        ) : (
+          <CeilingCountdown ceiling={ceiling} />
+        )}
+      </div>
+
+      {/* ── 3. Middleware rolling session ───────────────────── */}
+      <div className="card">
+        <h2>Middleware — Rolling Session</h2>
+        <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+          Every request passes through <code>auth0.middleware()</code> which
+          re-sets the session cookie (rolling). The <code>createdAt</code> below
+          is stamped at login and should <em>not</em> change on refresh — only
+          the cookie expiry rolls. Once the ceiling passes, the middleware sees a
+          null session and stops rolling entirely.
+        </p>
+        <div className="label" style={{ marginTop: "0.75rem" }}>
+          session.internal.createdAt
+        </div>
+        <div className="value">
+          {createdAt} &nbsp;
+          <span style={{ color: "#6b7280", fontSize: "0.8rem" }}>
+            ({new Date(createdAt * 1000).toLocaleString()})
+          </span>
+        </div>
+        <p style={{ fontSize: "0.8rem", color: "#6b7280", marginTop: "0.5rem" }}>
+          Reload this page repeatedly — the value stays constant. After the
+          ceiling passes, reloading redirects to login instead.
+        </p>
+      </div>
+
+      {/* ── 4. getSession — server read ─────────────────────── */}
+      <div className="card">
+        <h2>getSession() — Server Read</h2>
+        <SessionCheckPanel />
+      </div>
+
+      {/* ── 5. useUser() — browser hook ─────────────────────── */}
+      <div className="card">
+        <h2>useUser() — Browser Hook</h2>
+        <UseUserPanel />
+      </div>
+
+      {/* ── 6. getAccessToken — browser ─────────────────────── */}
+      <div className="card">
+        <h2>getAccessToken() — Browser</h2>
+        <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+          Calls <code>/auth/access-token</code>. Once the ceiling is reached this
+          returns a <code>session_expired</code> error without contacting Auth0.
+        </p>
+        <AccessTokenPanel ceiling={ceiling} />
+      </div>
+
+      {/* ── 7. withApiAuthRequired ───────────────────────────── */}
+      <div className="card">
+        <h2>withApiAuthRequired() — Protected API Route</h2>
+        <WithApiAuthPanel />
+      </div>
+
+      {/* ── 8. updateSession ─────────────────────────────────── */}
+      <div className="card">
+        <h2>updateSession() — Session Write</h2>
+        <UpdateSessionPanel />
+      </div>
+
+      {/* ── 9. withPageAuthRequired ──────────────────────────── */}
+      <div className="card">
+        <h2>withPageAuthRequired() — Protected Page</h2>
+        <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+          Visit{" "}
+          <a href="/protected" target="_blank">
+            /protected
+          </a>{" "}
+          — it renders normally before the ceiling. After the ceiling, opening
+          that URL redirects to <code>/auth/login</code> instead.
+        </p>
+      </div>
+
+      {/* ── 10. ID token claims ──────────────────────────────── */}
+      <div className="card">
+        <h2>ID Token Claims</h2>
+        <p style={{ fontSize: "0.875rem", color: "#6b7280", marginBottom: "0.75rem" }}>
+          Raw claims from the ID token. <code>session_expiry</code> should
+          appear here after adding the Post-Login Action and logging in fresh.
+        </p>
+        {idTokenClaims ? (
+          <pre className="token" style={{ whiteSpace: "pre-wrap" }}>
+            {JSON.stringify(idTokenClaims, null, 2)}
+          </pre>
+        ) : (
+          <p style={{ color: "#6b7280", fontSize: "0.875rem" }}>No ID token in session.</p>
+        )}
+      </div>
+
+      <div style={{ marginTop: "1rem", fontSize: "0.875rem" }}>
+        <a href="/auth/logout">Log out</a>
+      </div>
+    </main>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/page.tsx
+++ b/examples/with-ipsie-session-expiry/app/page.tsx
@@ -15,17 +15,9 @@ export default async function Page() {
     redirect("/auth/login");
   }
 
-  const { user, tokenSet, internal } = session;
+  const { user, internal } = session;
   const ceiling = typeof internal.sessionExpiresAt === "number" ? internal.sessionExpiresAt : null;
   const createdAt = internal.createdAt;
-
-  let idTokenClaims: Record<string, unknown> | null = null;
-  if (tokenSet.idToken) {
-    try {
-      const payload = tokenSet.idToken.split(".")[1];
-      idTokenClaims = JSON.parse(Buffer.from(payload, "base64url").toString());
-    } catch { }
-  }
 
   const hasNoCeiling = ceiling === null;
 
@@ -119,7 +111,7 @@ export default async function Page() {
           Calls <code>/auth/access-token</code>. Once the ceiling is reached this
           returns a <code>session_expired</code> error without contacting Auth0.
         </p>
-        <AccessTokenPanel ceiling={ceiling} />
+        <AccessTokenPanel />
       </div>
 
       {/* ── 7. withApiAuthRequired ───────────────────────────── */}
@@ -151,16 +143,13 @@ export default async function Page() {
       <div className="card">
         <h2>ID Token Claims</h2>
         <p style={{ fontSize: "0.875rem", color: "#6b7280", marginBottom: "0.75rem" }}>
-          Raw claims from the ID token. <code>session_expiry</code> should
-          appear here after adding the Post-Login Action and logging in fresh.
+          Verified claims from the ID token, sourced from <code>session.user</code>.{" "}
+          <code>session_expiry</code> should appear here after adding the Post-Login
+          Action and logging in fresh.
         </p>
-        {idTokenClaims ? (
-          <pre className="token" style={{ whiteSpace: "pre-wrap" }}>
-            {JSON.stringify(idTokenClaims, null, 2)}
-          </pre>
-        ) : (
-          <p style={{ color: "#6b7280", fontSize: "0.875rem" }}>No ID token in session.</p>
-        )}
+        <pre className="token" style={{ whiteSpace: "pre-wrap" }}>
+          {JSON.stringify(user, null, 2)}
+        </pre>
       </div>
 
       <div style={{ marginTop: "1rem", fontSize: "0.875rem" }}>

--- a/examples/with-ipsie-session-expiry/app/page.tsx
+++ b/examples/with-ipsie-session-expiry/app/page.tsx
@@ -143,12 +143,16 @@ export default async function Page() {
       <div className="card">
         <h2>ID Token Claims</h2>
         <p style={{ fontSize: "0.875rem", color: "#6b7280", marginBottom: "0.75rem" }}>
-          Verified claims from the ID token, sourced from <code>session.user</code>.{" "}
-          <code>session_expiry</code> should appear here after adding the Post-Login
-          Action and logging in fresh.
+          Standard claims from <code>session.user</code>. The <code>session_expiry</code>{" "}
+          claim is a custom claim that the SDK moves to <code>session.internal.sessionExpiresAt</code>{" "}
+          at login — it does not appear in <code>session.user</code>.
         </p>
         <pre className="token" style={{ whiteSpace: "pre-wrap" }}>
-          {JSON.stringify(user, null, 2)}
+          {JSON.stringify(
+            { ...user, "session_expiry (→ internal.sessionExpiresAt)": ceiling ?? "not set" },
+            null,
+            2
+          )}
         </pre>
       </div>
 

--- a/examples/with-ipsie-session-expiry/app/protected/page.tsx
+++ b/examples/with-ipsie-session-expiry/app/protected/page.tsx
@@ -1,0 +1,23 @@
+import { auth0 } from "@/lib/auth0";
+
+export default auth0.withPageAuthRequired(async function ProtectedPage() {
+  const session = await auth0.getSession();
+
+  return (
+    <main>
+      <h1>Protected Page</h1>
+      <p style={{ color: "#6b7280" }}>
+        This page is wrapped with <code>withPageAuthRequired()</code>. Once the
+        IPSIE session ceiling passes, accessing this URL will redirect to{" "}
+        <code>/auth/login</code> instead of rendering this content.
+      </p>
+      <div className="card">
+        <div className="label">Logged in as</div>
+        <div className="value">{session?.user?.email ?? "—"}</div>
+      </div>
+      <p style={{ marginTop: "1rem", fontSize: "0.875rem" }}>
+        <a href="/">← Back to main page</a>
+      </p>
+    </main>
+  );
+});

--- a/examples/with-ipsie-session-expiry/app/session-check-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/session-check-panel.tsx
@@ -8,10 +8,13 @@ export function SessionCheckPanel() {
 
   async function handleCheck() {
     setLoading(true);
-    const res = await fetch("/api/check-session");
-    const data = await res.json();
-    setResult(data);
-    setLoading(false);
+    try {
+      const res = await fetch("/api/check-session");
+      const data = await res.json().catch(() => ({ error: "Invalid response" }));
+      setResult(data);
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/examples/with-ipsie-session-expiry/app/session-check-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/session-check-panel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+export function SessionCheckPanel() {
+  const [result, setResult] = useState<object | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCheck() {
+    setLoading(true);
+    const res = await fetch("/api/check-session");
+    const data = await res.json();
+    setResult(data);
+    setLoading(false);
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+        Calls a server-side route that invokes <code>getSession()</code> and
+        returns the result as JSON. After the ceiling passes, this returns{" "}
+        <code>{`{ "session": null, "expired": true }`}</code> — the same null
+        the page would receive before redirecting to login.
+      </p>
+      <button onClick={handleCheck} disabled={loading}>
+        {loading ? "Checking…" : "Check Session"}
+      </button>
+      {result && (
+        <pre className="token" style={{ whiteSpace: "pre-wrap", marginTop: "0.75rem" }}>
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/update-session-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/update-session-panel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+export function UpdateSessionPanel() {
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleUpdate() {
+    setLoading(true);
+    setResult(null);
+    const res = await fetch("/api/update-session", { method: "POST" });
+    const data = await res.json();
+    setResult(JSON.stringify(data, null, 2));
+    setLoading(false);
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+        Calls a server route that runs <code>auth0.updateSession()</code>. Before
+        the ceiling it succeeds; after the ceiling <code>updateSession</code>{" "}
+        reads a null session and throws — the route returns a 409 with the error.
+      </p>
+      <button onClick={handleUpdate} disabled={loading}>
+        {loading ? "Updating…" : "Update Session"}
+      </button>
+      {result && (
+        <pre className="token" style={{ whiteSpace: "pre-wrap", marginTop: "0.75rem" }}>
+          {result}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/update-session-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/update-session-panel.tsx
@@ -9,18 +9,23 @@ export function UpdateSessionPanel() {
   async function handleUpdate() {
     setLoading(true);
     setResult(null);
-    const res = await fetch("/api/update-session", { method: "POST" });
-    const data = await res.json();
-    setResult(JSON.stringify(data, null, 2));
-    setLoading(false);
+    try {
+      const res = await fetch("/api/update-session", { method: "POST" });
+      const data = await res.json().catch(() => ({ error: "Invalid response" }));
+      setResult(JSON.stringify(data, null, 2));
+    } catch (err: any) {
+      setResult(JSON.stringify({ error: err.message ?? "Failed to update session" }, null, 2));
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
     <div>
       <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
         Calls a server route that runs <code>auth0.updateSession()</code>. Before
-        the ceiling it succeeds; after the ceiling <code>updateSession</code>{" "}
-        reads a null session and throws — the route returns a 409 with the error.
+        the ceiling it succeeds; after the ceiling <code>getSession()</code>{" "}
+        returns null and the route returns 401 before the update runs.
       </p>
       <button onClick={handleUpdate} disabled={loading}>
         {loading ? "Updating…" : "Update Session"}

--- a/examples/with-ipsie-session-expiry/app/use-user-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/use-user-panel.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useUser } from "@auth0/nextjs-auth0/client";
+
+export function UseUserPanel() {
+  const { user, isLoading, error } = useUser();
+
+  return (
+    <div>
+      <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+        Calls <code>/auth/profile</code> via the <code>useUser()</code> SWR
+        hook. After the ceiling passes, <code>handleProfile</code> returns 401
+        and the hook reflects a logged-out state — <code>user</code> becomes{" "}
+        <code>undefined</code>.
+      </p>
+
+      {isLoading && (
+        <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>Loading…</p>
+      )}
+
+      {!isLoading && error && (
+        <div className="error">
+          Hook error: {error.message}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <pre className="token" style={{ whiteSpace: "pre-wrap", marginTop: "0.75rem" }}>
+          {user ? JSON.stringify({ user }, null, 2) : "user: undefined (logged-out state)"}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/with-api-auth-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/with-api-auth-panel.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+
+export function WithApiAuthPanel() {
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCall() {
+    setLoading(true);
+    setResult(null);
+    const res = await fetch("/api/protected");
+    const data = await res.json().catch(() => ({ status: res.status }));
+    setResult(JSON.stringify({ status: res.status, body: data }, null, 2));
+    setLoading(false);
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: "0.875rem", color: "#6b7280" }}>
+        Calls <code>GET /api/protected</code> which is wrapped with{" "}
+        <code>withApiAuthRequired()</code>. Before the ceiling it returns 200;
+        after the ceiling it returns <strong>401</strong> — the guard sees a
+        null session and rejects before the handler runs.
+      </p>
+      <button onClick={handleCall} disabled={loading}>
+        {loading ? "Calling…" : "Call Protected API"}
+      </button>
+      {result && (
+        <pre className="token" style={{ whiteSpace: "pre-wrap", marginTop: "0.75rem" }}>
+          {result}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/examples/with-ipsie-session-expiry/app/with-api-auth-panel.tsx
+++ b/examples/with-ipsie-session-expiry/app/with-api-auth-panel.tsx
@@ -9,10 +9,15 @@ export function WithApiAuthPanel() {
   async function handleCall() {
     setLoading(true);
     setResult(null);
-    const res = await fetch("/api/protected");
-    const data = await res.json().catch(() => ({ status: res.status }));
-    setResult(JSON.stringify({ status: res.status, body: data }, null, 2));
-    setLoading(false);
+    try {
+      const res = await fetch("/api/protected");
+      const data = await res.json().catch(() => ({ status: res.status }));
+      setResult(JSON.stringify({ status: res.status, body: data }, null, 2));
+    } catch (err: any) {
+      setResult(JSON.stringify({ error: err.message ?? "Failed to call API" }, null, 2));
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/examples/with-ipsie-session-expiry/lib/auth0.ts
+++ b/examples/with-ipsie-session-expiry/lib/auth0.ts
@@ -1,0 +1,9 @@
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
+
+export const auth0 = new Auth0Client({
+  authorizationParameters: {
+    // Set an API audience to get a JWT access token.
+    // Without this, Auth0 returns an opaque token for /userinfo only.
+    audience: process.env.AUTH0_AUDIENCE
+  }
+});

--- a/examples/with-ipsie-session-expiry/middleware.ts
+++ b/examples/with-ipsie-session-expiry/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+
+import { auth0 } from "./lib/auth0";
+
+export async function middleware(request: NextRequest) {
+  return await auth0.middleware(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+  ]
+};

--- a/examples/with-ipsie-session-expiry/next-env.d.ts
+++ b/examples/with-ipsie-session-expiry/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/with-ipsie-session-expiry/next-env.d.ts
+++ b/examples/with-ipsie-session-expiry/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/with-ipsie-session-expiry/next.config.ts
+++ b/examples/with-ipsie-session-expiry/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/with-ipsie-session-expiry/package.json
+++ b/examples/with-ipsie-session-expiry/package.json
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.8.6",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "typescript": "~5.9.3"
   }
 }

--- a/examples/with-ipsie-session-expiry/package.json
+++ b/examples/with-ipsie-session-expiry/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "with-ipsie-session-expiry",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbo",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@auth0/nextjs-auth0": "file:../..",
+    "next": "16.2.6",
+    "react": "19.0.1",
+    "react-dom": "19.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.6",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "~5.9.3"
+  }
+}

--- a/examples/with-ipsie-session-expiry/pnpm-lock.yaml
+++ b/examples/with-ipsie-session-expiry/pnpm-lock.yaml
@@ -1,0 +1,690 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@auth0/nextjs-auth0':
+        specifier: file:../..
+        version: file:../..(next@16.2.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      react:
+        specifier: 19.0.1
+        version: 19.0.1
+      react-dom:
+        specifier: 19.0.1
+        version: 19.0.1(react@19.0.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.8.6
+        version: 22.20.0
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@auth0/nextjs-auth0@file:../..':
+    resolution: {directory: ../.., type: directory}
+    peerDependencies:
+      next: ^14.2.35 || ~15.0.7 || ~15.1.11 || ~15.2.8 || ~15.3.8 || ~15.4.10 || ~15.5.9 || ^16.0.10
+      react: ^18.0.0 || ~19.0.1 ||  ~19.1.2 || ^19.2.1
+      react-dom: ^18.0.0 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.0.1:
+    resolution: {integrity: sha512-3TJg51HSbJiLVYCS6vWwWsyqoS36aGEOCmtLLHxROlSZZ5Bk10xpxHFbrCu4DdqgR85DDc9Vucxqhai3g2xjtA==}
+    peerDependencies:
+      react: ^19.0.1
+
+  react@19.0.1:
+    resolution: {integrity: sha512-nVRaZCuEyvu69sWrkdwjP6QY57C+lY+uMNNMyWUFJb9Z/JlaBOQus7mSMfGYsblv7R691u6SSJA/dX9IRnyyLQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+snapshots:
+
+  '@auth0/nextjs-auth0@file:../..(next@16.2.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.3
+      next: 16.2.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      oauth4webapi: 3.8.6
+      openid-client: 6.8.4
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      swr: 2.4.2(react@19.0.1)
+
+  '@edge-runtime/cookies@5.0.2': {}
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@next/env@16.2.6': {}
+
+  '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    optional: true
+
+  '@panva/hkdf@1.2.1': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  baseline-browser-mapping@2.10.38: {}
+
+  caniuse-lite@1.0.30001799: {}
+
+  client-only@0.0.1: {}
+
+  csstype@3.2.3: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  jose@6.2.3: {}
+
+  nanoid@3.3.15: {}
+
+  next@16.2.6(react-dom@19.0.1(react@19.0.1))(react@19.0.1):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      styled-jsx: 5.1.6(react@19.0.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  oauth4webapi@3.8.6: {}
+
+  openid-client@6.8.4:
+    dependencies:
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.0.1(react@19.0.1):
+    dependencies:
+      react: 19.0.1
+      scheduler: 0.25.0
+
+  react@19.0.1: {}
+
+  scheduler@0.25.0: {}
+
+  semver@7.8.5:
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  source-map-js@1.2.1: {}
+
+  styled-jsx@5.1.6(react@19.0.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.0.1
+
+  swr@2.4.2(react@19.0.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.0.1
+      use-sync-external-store: 1.6.0(react@19.0.1)
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  use-sync-external-store@1.6.0(react@19.0.1):
+    dependencies:
+      react: 19.0.1

--- a/examples/with-ipsie-session-expiry/pnpm-lock.yaml
+++ b/examples/with-ipsie-session-expiry/pnpm-lock.yaml
@@ -25,11 +25,11 @@ importers:
         specifier: ^22.8.6
         version: 22.20.0
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.31
+        specifier: ^19.0.0
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.31)
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -267,16 +267,13 @@ packages:
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^18.0.0
+      '@types/react': ^19.2.0
 
-  '@types/react@18.3.31':
-    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
@@ -555,15 +552,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 18.3.31
+      '@types/react': 19.2.17
 
-  '@types/react@18.3.31':
+  '@types/react@19.2.17':
     dependencies:
-      '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   baseline-browser-mapping@2.10.38: {}

--- a/examples/with-ipsie-session-expiry/pnpm-workspace.yaml
+++ b/examples/with-ipsie-session-expiry/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true

--- a/examples/with-ipsie-session-expiry/tsconfig.json
+++ b/examples/with-ipsie-session-expiry/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
  - [x] All new/changed/fixed functionality is covered by tests (or N/A)
  - [x] I have added documentation for all new/changed functionality (or N/A)

  ### 📋 Changes

  Adds a new `examples/with-ipsie-session-expiry` Next.js app that demonstrates end-to-end enforcement of the IPSIE `session_expiry` ceiling introduced in parent PR (#2708).

  The example is a single-page dashboard with nine cards, each exercising a different SDK code path so testers can observe exactly when and how the ceiling fires across every affected flow:

  - **Ceiling countdown** — live timer showing time until enforcement (ceiling minus 30s leeway), counts to zero when the SDK starts treating the session as
  expired
  - **Middleware rolling session** — shows `session.internal.createdAt` to confirm it stays constant across reloads and stops rolling after the ceiling
  - **`getSession()`** — server read via a Route Handler; returns null after the ceiling
  - **`useUser()`** — client-side hook; reflects logged-out state after the ceiling
  - **`getAccessToken()`** — calls `/auth/access-token`; surfaces `session_expired` error after the ceiling with a human-readable message distinguishing
  ceiling expiry from a genuinely missing session
  - **`withApiAuthRequired()`** — protected Route Handler returning 401 after the ceiling
  - **`updateSession()`** — session write; throws unauthenticated error after the ceiling
  - **`withPageAuthRequired()`** — protected page; redirects to login after the ceiling
  - **ID token claims** — raw JWT claims panel confirming `session_expiry` is present after the Post-Login Action is installed
  - **ID token claims** — raw JWT claims panel confirming `session_expiry` is present after the Post-Login Action is installed

  The README includes setup instructions (Post-Login Action snippet, skip-consent toggle), a testing table with expected output at each phase (before ceiling, approaching, after), and a flow-to-file mapping for anyone reading the code.

  ### 📎 References

  - #2708 — IPSIE `session_expiry` ceiling enforcement (parent PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end example and UI for session expiry behavior, including session status, countdown, token checks, protected access, and session update actions.
  * Documented how upstream identity providers can set a session lifetime ceiling and how the app responds when it is reached.

* **Bug Fixes**
  * Sessions now expire locally when the upstream ceiling is reached, with token retrieval and protected views reflecting the expired state.
  * Improved handling for sessions that are already expired at login, preventing invalid access from being created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->