### PR TITLE
fix: forward state param to OIDC end-session URL in handleLogout

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -954,6 +954,7 @@ export class AuthClient {
 
     const appBaseUrl = resolveAppBaseUrl(this.appBaseUrl, req);
     const returnTo = req.nextUrl.searchParams.get("returnTo") || appBaseUrl;
+    const logoutState = req.nextUrl.searchParams.get("state");
     const federated = req.nextUrl.searchParams.has("federated");
 
     const createV2LogoutResponse = (): NextResponse => {
@@ -972,6 +973,10 @@ export class AuthClient {
       const url = new URL(authorizationServerMetadata.end_session_endpoint!);
       url.searchParams.set("client_id", this.clientMetadata.client_id);
       url.searchParams.set("post_logout_redirect_uri", returnTo);
+
+      if (logoutState) {
+        url.searchParams.set("state", logoutState);
+      }
 
       if (session?.internal.sid) {
         url.searchParams.set("logout_hint", session.internal.sid);

--- a/src/server/logout-strategy.flow.test.ts
+++ b/src/server/logout-strategy.flow.test.ts
@@ -929,4 +929,111 @@ describe("Logout Strategy Flow Tests", () => {
       expect(logoutUrl.searchParams.get("federated")).toBe("");
     });
   });
+
+  describe("state parameter support", () => {
+    it("should forward state to OIDC logout URL", async () => {
+      const authClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret,
+        transactionStore,
+        sessionStore,
+        logoutStrategy: "oidc",
+        routes: getDefaultRoutes()
+      });
+
+      const url = new URL("/auth/logout", DEFAULT.appBaseUrl);
+      url.searchParams.set("returnTo", DEFAULT.appBaseUrl);
+      url.searchParams.set("state", "my-opaque-state");
+
+      const request = new NextRequest(url, { method: "GET" });
+      const response = await authClient.handleLogout(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("Location");
+      const logoutUrl = new URL(location!);
+      expect(logoutUrl.searchParams.get("state")).toBe("my-opaque-state");
+      expect(logoutUrl.searchParams.get("post_logout_redirect_uri")).toBe(
+        DEFAULT.appBaseUrl
+      );
+    });
+
+    it("should not set state on OIDC logout URL when not provided", async () => {
+      const authClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret,
+        transactionStore,
+        sessionStore,
+        logoutStrategy: "oidc",
+        routes: getDefaultRoutes()
+      });
+
+      const request = new NextRequest(
+        new URL("/auth/logout", DEFAULT.appBaseUrl),
+        { method: "GET" }
+      );
+      const response = await authClient.handleLogout(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("Location");
+      const logoutUrl = new URL(location!);
+      expect(logoutUrl.searchParams.has("state")).toBe(false);
+    });
+
+    it("should not forward state to v2 logout URL", async () => {
+      const authClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret,
+        transactionStore,
+        sessionStore,
+        logoutStrategy: "v2",
+        routes: getDefaultRoutes()
+      });
+
+      const url = new URL("/auth/logout", DEFAULT.appBaseUrl);
+      url.searchParams.set("state", "my-opaque-state");
+
+      const request = new NextRequest(url, { method: "GET" });
+      const response = await authClient.handleLogout(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("Location");
+      const logoutUrl = new URL(location!);
+      expect(logoutUrl.searchParams.has("state")).toBe(false);
+    });
+
+    it("should forward state to OIDC logout URL with auto strategy", async () => {
+      const authClient = new AuthClient({
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        secret,
+        transactionStore,
+        sessionStore,
+        logoutStrategy: "auto",
+        routes: getDefaultRoutes()
+      });
+
+      const url = new URL("/auth/logout", DEFAULT.appBaseUrl);
+      url.searchParams.set("state", "my-opaque-state");
+
+      const request = new NextRequest(url, { method: "GET" });
+      const response = await authClient.handleLogout(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("Location");
+      const logoutUrl = new URL(location!);
+      expect(logoutUrl.pathname).toBe("/oidc/logout");
+      expect(logoutUrl.searchParams.get("state")).toBe("my-opaque-state");
+    });
+  });
 });


### PR DESCRIPTION
  - [x] All new/changed/fixed functionality is covered by tests (or N/A)
  - [x] I have added documentation for all new/changed functionality (or N/A)

  ### 📋 Changes

  The OIDC RP-Initiated Logout endpoint (`/oidc/logout`) supports an optional `state` parameter — an opaque value the authorization server echoes back as a query param when redirecting to `post_logout_redirect_uri`. The SDK was not forwarding this parameter, leaving users with no supported way to round-trip context (e.g. where to redirect after logout) through the logout flow.

 This is a real gap because `post_logout_redirect_uri` must exactly match a registered allowed logout URL on the Auth0 tenant — so embedding context as a query param there gets rejected. `state` is the correct OIDC mechanism for this use case.

  `handleLogout` now reads a `state` query param from the incoming logout request and forwards it to the OIDC end-session URL. Users can call
  `/auth/logout?returnTo=https://example.com/done&state=someOpaqueValue` and Auth0 will redirect to
  `https://example.com/done?state=someOpaqueValue` after logout.

  This only applies to the OIDC logout path (`logoutStrategy: "oidc"` and `logoutStrategy: "auto"` when the OIDC endpoint is available). The `/v2/logout` endpoint does not support `state` and is unchanged.

  This is a non-breaking, purely additive change — callers that do not pass `state` see no difference in behavior.

  ### 📎 References

  - Fixes #2717
  - Related: #2655

  ### 🎯 Testing

  Four unit tests added to `logout-strategy.flow.test.ts` covering:

  - `state` is forwarded to the OIDC logout URL when provided
  - `state` is absent from the OIDC logout URL when not provided (no regression)
  - `state` is not forwarded on the `v2` logout path
  - `state` is forwarded when using the `auto` strategy and the OIDC endpoint is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Logout redirects now preserve an optional `state` value when using OIDC logout flows.
  - `state` is only included when provided, and it is not passed to non-OIDC logout endpoints.
  - Auto-selected logout behavior now correctly forwards `state` for OIDC-based redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->