### PR TITLE
feat: add session transfer token support to CTE

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5077,10 +5077,10 @@ if (actor) {
 
 - **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side (confidential-client RWAs; SPAs/native are out of scope).
 - **One-shot, ~60 s**: The STT is opaque and must never be decoded, cached, or reused. Redeem it immediately.
-- **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is missing or expired the SDK fails with `ACTOR_UNAVAILABLE` — there is no automatic refresh, so refresh the agent session or pass a fresh explicit `actor`.
+- **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is expired and a refresh token is present the SDK automatically refreshes it; otherwise it fails with `ACTOR_UNAVAILABLE`. Pass an explicit `actor` to use a non-session token.
 - **Non-localhost callback**: STT redemption rejects `localhost` redirect URIs — use a real domain (or a tunnel) for the target callback.
 - **Same tenant**: Both agent and target app must be on the same Auth0 tenant.
-- **No refresh, short-lived session**: The impersonation session cannot mint a refresh token and self-expires; re-run the flow to continue.
+- **No refresh token / no `offline_access`**: Auth0 silently drops `offline_access` from the STT scope — the impersonation session has no refresh token and self-expires according to the tenant's session lifetime settings. Pass `scope: "openid profile"` on the target login URL (or via `options.scope`) to make the intent explicit and avoid unexpected scope-negotiation warnings.
 - **No session modification**: The agent's own session is not modified; the STT is never written to `session.tokenSet`.
 
 ## Customizing Auth Handlers

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -182,6 +182,12 @@
   - [Token Type Requirements](#token-type-requirements)
   - [Limitations](#limitations)
   - [DPoP Support](#dpop-support)
+- [Session Transfer Token](#session-transfer-token)
+  - [Basic Usage](#basic-usage-1)
+  - [Actor Override](#actor-override)
+  - [With Organization](#with-organization-1)
+  - [Error Handling](#error-handling-6)
+  - [Limitations](#limitations-1)
 - [Customizing Auth Handlers](#customizing-auth-handlers)
   - [Run custom code before Auth Handlers](#run-custom-code-before-auth-handlers)
   - [Run code after callback](#run-code-after-callback)
@@ -4928,6 +4934,105 @@ const result = await auth0.customTokenExchange({
 
 // result.tokenType will be "DPoP"
 ```
+
+## Session Transfer Token
+
+Session Transfer Token (STT) is CTE Phase 2. An authenticated agent establishes a web session **as a customer** in a target app — without the customer's password. The agent app requests a one-shot STT for the customer, then redirects the agent's browser to the target app's login URL carrying the token. Auth0 validates the STT and creates an ephemeral session for the agent.
+
+> [!IMPORTANT]
+> Session Transfer requires the `session_transfer` feature flag to be enabled on your tenant. Both the agent app and target app must be on the same Auth0 tenant. Contact Auth0 support or raise an ESD to enable the flag.
+
+### Basic Usage
+
+```ts
+import { TOKEN_TYPES } from "@auth0/nextjs-auth0/server";
+
+// app/api/stt/route.ts — runs in the agent app
+export async function POST(req: NextRequest) {
+  const { subjectToken, subjectTokenType, targetLoginUrl } = await req.json();
+
+  // Request a one-shot STT for the customer
+  const result = await auth0.requestSessionTransferToken({
+    subjectToken,                  // customer's ID or access token
+    subjectTokenType,              // TOKEN_TYPES.ID_TOKEN or TOKEN_TYPES.ACCESS_TOKEN
+    reason: "Support investigation #1234"
+  });
+
+  // Redirect the agent's browser to the target app's login URL
+  return auth0.buildSessionTransferRedirect(targetLoginUrl, result);
+  // → 307 to https://target-app.example.com/auth/login?session_transfer_token=<stt>
+}
+```
+
+The target app needs no changes — `handleLogin()` already forwards all query params to `/authorize`, so `session_transfer_token` passes through automatically.
+
+### Actor Override
+
+The actor (the party making the request on the customer's behalf) defaults to the agent session's ID token. Pass `actor` explicitly to override:
+
+```ts
+import { TOKEN_TYPES } from "@auth0/nextjs-auth0/server";
+
+const result = await auth0.requestSessionTransferToken({
+  subjectToken: customerIdToken,
+  subjectTokenType: TOKEN_TYPES.ID_TOKEN,
+  actor: { token: agentIdToken, type: TOKEN_TYPES.ID_TOKEN }
+});
+```
+
+### With Organization
+
+```ts
+const result = await auth0.requestSessionTransferToken({
+  subjectToken: customerIdToken,
+  subjectTokenType: TOKEN_TYPES.ID_TOKEN,
+  organization: "org_abc123"
+});
+
+return auth0.buildSessionTransferRedirect(
+  "https://target-app.example.com/auth/login",
+  result,
+  { organization: "org_abc123" }
+);
+```
+
+### Error Handling
+
+```ts
+import {
+  CustomTokenExchangeError,
+  CustomTokenExchangeErrorCode
+} from "@auth0/nextjs-auth0/server";
+
+try {
+  const result = await auth0.requestSessionTransferToken({ ... });
+} catch (error) {
+  if (error instanceof CustomTokenExchangeError) {
+    switch (error.code) {
+      case CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE:
+        // No usable actor token — agent session has no ID token or it is expired
+        break;
+      case CustomTokenExchangeErrorCode.SETACTOR_REQUIRED:
+        // Tenant requires api.authentication.setActor() to be called in an Action
+        break;
+      case CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED:
+        // session_transfer feature flag not enabled on this tenant
+        break;
+      case CustomTokenExchangeErrorCode.EXCHANGE_FAILED:
+        // Generic server error — check error.cause for details
+        console.error("STT exchange failed:", error.cause);
+        break;
+    }
+  }
+}
+```
+
+### Limitations
+
+- **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side.
+- **One-shot, ~60 s**: The STT expires quickly and must never be cached or reused.
+- **Same tenant**: Both agent and target app must be on the same Auth0 tenant.
+- **No session modification**: The agent's own session is not modified; no tokens are written to `session.tokenSet`.
 
 ## Customizing Auth Handlers
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4943,15 +4943,11 @@ Session Transfer Token (STT) is CTE Release 2. An authenticated agent (for examp
 Almost all of the new SDK surface is on the **initiator** side (the app that requests the STT and builds the redirect): one method — `requestSessionTransferToken()` — plus a redirect helper — `buildSessionTransferRedirect()`. The **target** app barely changes: it does a standard OIDC Authorization Code login with `session_transfer_token` riding along in the `/authorize` query string.
 
 > [!IMPORTANT]
-<<<<<<< Updated upstream
-> Session Transfer is a **two-client flow** and requires the `cte_session_transfer_token` feature flag on your tenant (raise an ESD, or enable via layer0 for internal testing). Both clients must be on the same Auth0 tenant. Configure:
+> Session Transfer is a **two-client flow** and requires the `cte_session_transfer_token` feature flag on your tenant (contact Auth0 support to enable it). Both clients must be on the same Auth0 tenant. Configure:
 > - **Issuing (initiator) client** — `token_exchange.allow_any_profile_of_type: ["custom_authentication"]` and `session_transfer.can_create_session_transfer_token: true`.
 > - **Redeeming (target) client** — `session_transfer.delegation.allow_delegated_access: true`, `allowed_authentication_methods` must include `"query"` (the STT is redeemed as a query parameter), and `session_transfer.delegation.enforce_device_binding` (`"ip"` default or `"asn"`). Register a **non-localhost** callback — STT redemption rejects `localhost` redirect URIs.
 >
 > A CTE Action must validate the `subject_token`, call `setUserById(customer)`, and call `setActor(agent)` — an STT is only issued when an actor is set. These client settings are configured out of band via the Management API; they are not SDK code.
-=======
-> Session Transfer requires the `cte_session_transfer_token` feature flag to be enabled on your tenant. Both the agent app and target app must be on the same Auth0 tenant. Contact Auth0 support or raise an ESD to enable the flag.
->>>>>>> Stashed changes
 
 ### Basic Usage
 
@@ -5029,18 +5025,15 @@ try {
   if (error instanceof CustomTokenExchangeError) {
     switch (error.code) {
       case CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE:
-<<<<<<< Updated upstream
         // Raised client-side, before any network call: no explicit `actor` was
-        // passed and the agent session has no usable (unexpired) ID token.
-=======
-        // No usable actor token — agent session has no ID token or it is expired
+        // passed and the agent session has no usable (unexpired) ID token and no
+        // refresh token to recover with.
         break;
       case CustomTokenExchangeErrorCode.SETACTOR_REQUIRED:
         // Tenant requires api.authentication.setActor() to be called in an Action
         break;
       case CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED:
         // cte_session_transfer_token feature flag not enabled on this tenant
->>>>>>> Stashed changes
         break;
       case CustomTokenExchangeErrorCode.EXCHANGE_FAILED:
         // Server-side failure. Today the server returns a generic `invalid_request`
@@ -5077,6 +5070,7 @@ if (actor) {
 
 - **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side (confidential-client RWAs; SPAs/native are out of scope).
 - **One-shot, ~60 s**: The STT is opaque and must never be decoded, cached, or reused. Redeem it immediately.
+- **Branch on `issued_token_type`, not `token_type`**: The response carries `token_type: "N_A"` (informational). The SDK already validates that `issued_token_type === "urn:auth0:params:oauth:token-type:session_transfer_token"` before returning; if it doesn't match the exchange throws `EXCHANGE_FAILED`. Use `TOKEN_TYPES.SESSION_TRANSFER_TOKEN` in any downstream checks — never branch on `token_type`.
 - **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is expired and a refresh token is present the SDK automatically refreshes it; otherwise it fails with `ACTOR_UNAVAILABLE`. Pass an explicit `actor` to use a non-session token.
 - **Non-localhost callback**: STT redemption rejects `localhost` redirect URIs — use a real domain (or a tunnel) for the target callback.
 - **Same tenant**: Both agent and target app must be on the same Auth0 tenant.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -186,7 +186,7 @@
   - [Basic Usage](#basic-usage-1)
   - [Actor Override](#actor-override)
   - [With Organization](#with-organization-1)
-  - [Error Handling](#error-handling-6)
+  - [Error Handling](#error-handling-5)
   - [Reading the `act` claim on the established session](#reading-the-act-claim-on-the-established-session)
   - [Limitations](#limitations-1)
 - [Customizing Auth Handlers](#customizing-auth-handlers)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4943,11 +4943,15 @@ Session Transfer Token (STT) is CTE Release 2. An authenticated agent (for examp
 Almost all of the new SDK surface is on the **initiator** side (the app that requests the STT and builds the redirect): one method — `requestSessionTransferToken()` — plus a redirect helper — `buildSessionTransferRedirect()`. The **target** app barely changes: it does a standard OIDC Authorization Code login with `session_transfer_token` riding along in the `/authorize` query string.
 
 > [!IMPORTANT]
+<<<<<<< Updated upstream
 > Session Transfer is a **two-client flow** and requires the `cte_session_transfer_token` feature flag on your tenant (raise an ESD, or enable via layer0 for internal testing). Both clients must be on the same Auth0 tenant. Configure:
 > - **Issuing (initiator) client** — `token_exchange.allow_any_profile_of_type: ["custom_authentication"]` and `session_transfer.can_create_session_transfer_token: true`.
 > - **Redeeming (target) client** — `session_transfer.delegation.allow_delegated_access: true`, `allowed_authentication_methods` must include `"query"` (the STT is redeemed as a query parameter), and `session_transfer.delegation.enforce_device_binding` (`"ip"` default or `"asn"`). Register a **non-localhost** callback — STT redemption rejects `localhost` redirect URIs.
 >
 > A CTE Action must validate the `subject_token`, call `setUserById(customer)`, and call `setActor(agent)` — an STT is only issued when an actor is set. These client settings are configured out of band via the Management API; they are not SDK code.
+=======
+> Session Transfer requires the `cte_session_transfer_token` feature flag to be enabled on your tenant. Both the agent app and target app must be on the same Auth0 tenant. Contact Auth0 support or raise an ESD to enable the flag.
+>>>>>>> Stashed changes
 
 ### Basic Usage
 
@@ -5025,8 +5029,18 @@ try {
   if (error instanceof CustomTokenExchangeError) {
     switch (error.code) {
       case CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE:
+<<<<<<< Updated upstream
         // Raised client-side, before any network call: no explicit `actor` was
         // passed and the agent session has no usable (unexpired) ID token.
+=======
+        // No usable actor token — agent session has no ID token or it is expired
+        break;
+      case CustomTokenExchangeErrorCode.SETACTOR_REQUIRED:
+        // Tenant requires api.authentication.setActor() to be called in an Action
+        break;
+      case CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED:
+        // cte_session_transfer_token feature flag not enabled on this tenant
+>>>>>>> Stashed changes
         break;
       case CustomTokenExchangeErrorCode.EXCHANGE_FAILED:
         // Server-side failure. Today the server returns a generic `invalid_request`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4981,6 +4981,26 @@ The target app needs no SDK changes — `nextjs-auth0`'s login handler already f
 > [!NOTE]
 > The redeemed impersonation session cannot mint a refresh token and is short-lived (the platform hard-caps it). To continue after it expires, the agent re-runs the whole flow.
 
+Pages Router — pass `req`/`res` so a silently-refreshed actor token set is persisted back to the session cookie:
+
+```ts
+// pages/api/stt.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { subjectToken, subjectTokenType, targetLoginUrl } = req.body;
+
+  const result = await auth0.requestSessionTransferToken(req, res, {
+    subjectToken,
+    subjectTokenType,
+    reason: "Support investigation #1234"
+  });
+
+  const redirect = auth0.buildSessionTransferRedirect(targetLoginUrl, result);
+  res.redirect(307, redirect.headers.get("location")!);
+}
+```
+
 ### Actor Override
 
 The actor (the party making the request on the customer's behalf) defaults to the agent session's ID token. Pass `actor` explicitly to override:
@@ -5068,14 +5088,14 @@ if (actor) {
 
 ### Limitations
 
-- **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side (confidential-client RWAs; SPAs/native are out of scope).
+- **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side (confidential-client RWAs; SPAs/native are out of scope). Supported in both the App Router (Server Components, Server Actions, Route Handlers) and the Pages Router (`requestSessionTransferToken(req, res, options)`).
 - **One-shot, ~60 s**: The STT is opaque and must never be decoded, cached, or reused. Redeem it immediately.
 - **Branch on `issued_token_type`, not `token_type`**: The response carries `token_type: "N_A"` (informational). The SDK already validates that `issued_token_type === "urn:auth0:params:oauth:token-type:session_transfer_token"` before returning; if it doesn't match the exchange throws `EXCHANGE_FAILED`. Use `TOKEN_TYPES.SESSION_TRANSFER_TOKEN` in any downstream checks — never branch on `token_type`.
-- **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is expired and a refresh token is present the SDK automatically refreshes it; otherwise it fails with `ACTOR_UNAVAILABLE`. Pass an explicit `actor` to use a non-session token.
+- **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is expired and a refresh token is present the SDK automatically refreshes it — the refreshed token set is persisted back to the agent's session, since refresh token rotation invalidates the old refresh token; otherwise it fails with `ACTOR_UNAVAILABLE`. If the refresh itself requires MFA step-up, an `MfaRequiredError` is thrown instead. Pass an explicit `actor` to use a non-session token and skip the refresh path entirely.
 - **Non-localhost callback**: STT redemption rejects `localhost` redirect URIs — use a real domain (or a tunnel) for the target callback.
 - **Same tenant**: Both agent and target app must be on the same Auth0 tenant.
 - **No refresh token / no `offline_access`**: Auth0 silently drops `offline_access` from the STT scope — the impersonation session has no refresh token and self-expires according to the tenant's session lifetime settings. Pass `scope: "openid profile"` on the target login URL (or via `options.scope`) to make the intent explicit and avoid unexpected scope-negotiation warnings.
-- **No session modification**: The agent's own session is not modified; the STT is never written to `session.tokenSet`.
+- **STT itself is never written to the agent's session**: `session.tokenSet` never carries the STT. The agent's own session tokens are only touched when the actor's ID token had to be refreshed (see above) — otherwise nothing about the agent's session changes.
 
 ## Customizing Auth Handlers
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -187,6 +187,7 @@
   - [Actor Override](#actor-override)
   - [With Organization](#with-organization-1)
   - [Error Handling](#error-handling-6)
+  - [Reading the `act` claim on the established session](#reading-the-act-claim-on-the-established-session)
   - [Limitations](#limitations-1)
 - [Customizing Auth Handlers](#customizing-auth-handlers)
   - [Run custom code before Auth Handlers](#run-custom-code-before-auth-handlers)
@@ -4937,34 +4938,48 @@ const result = await auth0.customTokenExchange({
 
 ## Session Transfer Token
 
-Session Transfer Token (STT) is CTE Phase 2. An authenticated agent establishes a web session **as a customer** in a target app — without the customer's password. The agent app requests a one-shot STT for the customer, then redirects the agent's browser to the target app's login URL carrying the token. Auth0 validates the STT and creates an ephemeral session for the agent.
+Session Transfer Token (STT) is CTE Release 2. An authenticated agent (for example a support engineer) establishes a web session **as the customer** in a target app — without the customer's password — so they can see and reproduce the customer's exact experience. The agent app requests a one-shot STT, then redirects the agent's browser to the target app's login URL carrying the token. Auth0 redeems the STT and establishes an ephemeral, device-bound session **as the customer, with the agent recorded in the `act` claim**. The access and ID tokens for that session carry `act`, exactly as in the Release 1 delegation flow.
+
+Almost all of the new SDK surface is on the **initiator** side (the app that requests the STT and builds the redirect): one method — `requestSessionTransferToken()` — plus a redirect helper — `buildSessionTransferRedirect()`. The **target** app barely changes: it does a standard OIDC Authorization Code login with `session_transfer_token` riding along in the `/authorize` query string.
 
 > [!IMPORTANT]
-> Session Transfer requires the `session_transfer` feature flag to be enabled on your tenant. Both the agent app and target app must be on the same Auth0 tenant. Contact Auth0 support or raise an ESD to enable the flag.
+> Session Transfer is a **two-client flow** and requires the `cte_session_transfer_token` feature flag on your tenant (raise an ESD, or enable via layer0 for internal testing). Both clients must be on the same Auth0 tenant. Configure:
+> - **Issuing (initiator) client** — `token_exchange.allow_any_profile_of_type: ["custom_authentication"]` and `session_transfer.can_create_session_transfer_token: true`.
+> - **Redeeming (target) client** — `session_transfer.delegation.allow_delegated_access: true`, `allowed_authentication_methods` must include `"query"` (the STT is redeemed as a query parameter), and `session_transfer.delegation.enforce_device_binding` (`"ip"` default or `"asn"`). Register a **non-localhost** callback — STT redemption rejects `localhost` redirect URIs.
+>
+> A CTE Action must validate the `subject_token`, call `setUserById(customer)`, and call `setActor(agent)` — an STT is only issued when an actor is set. These client settings are configured out of band via the Management API; they are not SDK code.
 
 ### Basic Usage
 
 ```ts
-import { TOKEN_TYPES } from "@auth0/nextjs-auth0/server";
-
-// app/api/stt/route.ts — runs in the agent app
+// app/api/stt/route.ts — runs in the agent (initiator) app
 export async function POST(req: NextRequest) {
   const { subjectToken, subjectTokenType, targetLoginUrl } = await req.json();
 
-  // Request a one-shot STT for the customer
+  // Your app runs its own authorization check here: is this agent allowed to
+  // impersonate this customer, right now? That decision is the app's, not the SDK's.
+
+  // Request a one-shot STT. `subjectToken` is always developer-supplied — it is
+  // your own proof of which customer to impersonate, opaque to Auth0 and validated
+  // only by your CTE Action. The SDK fills in audience, grant_type, and the actor
+  // (from the agent's session ID token) automatically.
   const result = await auth0.requestSessionTransferToken({
-    subjectToken,                  // customer's ID or access token
-    subjectTokenType,              // TOKEN_TYPES.ID_TOKEN or TOKEN_TYPES.ACCESS_TOKEN
+    subjectToken,
+    subjectTokenType,              // must match a registered CTE profile
     reason: "Support investigation #1234"
   });
 
-  // Redirect the agent's browser to the target app's login URL
+  // Redirect the agent's browser to the target app's login URL. The STT is
+  // one-shot (~60s) — hand it straight to the redirect, never store it.
   return auth0.buildSessionTransferRedirect(targetLoginUrl, result);
   // → 307 to https://target-app.example.com/auth/login?session_transfer_token=<stt>
 }
 ```
 
-The target app needs no changes — `handleLogin()` already forwards all query params to `/authorize`, so `session_transfer_token` passes through automatically.
+The target app needs no SDK changes — `nextjs-auth0`'s login handler already forwards arbitrary authorization parameters to `/authorize`, so `session_transfer_token` (and `organization`, when present) pass through automatically on the existing login route.
+
+> [!NOTE]
+> The redeemed impersonation session cannot mint a refresh token and is short-lived (the platform hard-caps it). To continue after it expires, the agent re-runs the whole flow.
 
 ### Actor Override
 
@@ -5010,16 +5025,13 @@ try {
   if (error instanceof CustomTokenExchangeError) {
     switch (error.code) {
       case CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE:
-        // No usable actor token — agent session has no ID token or it is expired
-        break;
-      case CustomTokenExchangeErrorCode.SETACTOR_REQUIRED:
-        // Tenant requires api.authentication.setActor() to be called in an Action
-        break;
-      case CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED:
-        // session_transfer feature flag not enabled on this tenant
+        // Raised client-side, before any network call: no explicit `actor` was
+        // passed and the agent session has no usable (unexpired) ID token.
         break;
       case CustomTokenExchangeErrorCode.EXCHANGE_FAILED:
-        // Generic server error — check error.cause for details
+        // Server-side failure. Today the server returns a generic `invalid_request`
+        // for "setActor is required" and "feature disabled", so those surface here —
+        // read error.cause for the server's exact `error` / `error_description`.
         console.error("STT exchange failed:", error.cause);
         break;
     }
@@ -5027,12 +5039,35 @@ try {
 }
 ```
 
+> [!NOTE]
+> `SETACTOR_REQUIRED` (the Action didn't call `setActor()`) and `SESSION_TRANSFER_DISABLED` (the `cte_session_transfer_token` flag is off) are defined as named constants, but the SDK does not remap based on the server's message text. Auth0 currently returns these as a generic `invalid_request`, so they surface as `EXCHANGE_FAILED` with the raw server message on `error.cause`; the typed codes begin firing once the platform emits a machine-readable error code.
+
+### Reading the `act` claim on the established session
+
+Once the STT is redeemed and the code exchanged, the target app has a normal session whose tokens carry the `act` (actor) claim identifying the impersonating agent. Read it off the session user through the SDK's existing claims surface — no new method — to drive UI such as an impersonation banner:
+
+```ts
+// In the target app, after the session is established:
+const session = await auth0.getSession();
+const actor = session?.user.act; // { sub: "agent|support-007", ... } | undefined
+
+if (actor) {
+  // e.g. show an "Impersonating — acting as <customer>" banner,
+  // and/or restrict destructive actions while impersonating.
+}
+```
+
+`act` carries the acting party's `sub` and optionally a few small custom fields the Action added (for example the agent's email or a reason). The `act` claim is **not** present on the STT exchange response — it only appears on the redeemed session's tokens.
+
 ### Limitations
 
-- **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side.
-- **One-shot, ~60 s**: The STT expires quickly and must never be cached or reused.
+- **Server-side only**: `requestSessionTransferToken` requires `client_secret` and can only be called server-side (confidential-client RWAs; SPAs/native are out of scope).
+- **One-shot, ~60 s**: The STT is opaque and must never be decoded, cached, or reused. Redeem it immediately.
+- **Actor is mandatory and must be fresh**: The actor token (the agent's session ID token by default) must be an unexpired, asymmetrically-signed (RS256/PS256) JWT. If it is missing or expired the SDK fails with `ACTOR_UNAVAILABLE` — there is no automatic refresh, so refresh the agent session or pass a fresh explicit `actor`.
+- **Non-localhost callback**: STT redemption rejects `localhost` redirect URIs — use a real domain (or a tunnel) for the target callback.
 - **Same tenant**: Both agent and target app must be on the same Auth0 tenant.
-- **No session modification**: The agent's own session is not modified; no tokens are written to `session.tokenSet`.
+- **No refresh, short-lived session**: The impersonation session cannot mint a refresh token and self-expires; re-run the flow to continue.
+- **No session modification**: The agent's own session is not modified; the STT is never written to `session.tokenSet`.
 
 ## Customizing Auth Handlers
 

--- a/src/errors/oauth-errors.ts
+++ b/src/errors/oauth-errors.ts
@@ -272,7 +272,26 @@ export enum CustomTokenExchangeErrorCode {
   /**
    * The token exchange request failed.
    */
-  EXCHANGE_FAILED = "exchange_failed"
+  EXCHANGE_FAILED = "exchange_failed",
+
+  /**
+   * No actor could be resolved for the STT exchange: no explicit `actor` was passed
+   * and no usable session ID token is available (missing or expired with no refresh token).
+   * Thrown client-side before any network call.
+   */
+  ACTOR_UNAVAILABLE = "actor_unavailable",
+
+  /**
+   * The CTE Action did not call `setActor`, which is required when requesting an STT.
+   * Surfaces the server 400 response.
+   */
+  SETACTOR_REQUIRED = "setactor_required",
+
+  /**
+   * The `cte_session_transfer_token` feature flag is disabled on the tenant.
+   * Surfaces the server 400 response.
+   */
+  SESSION_TRANSFER_DISABLED = "session_transfer_disabled"
 }
 
 /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -119,7 +119,8 @@ import {
 } from "../utils/authorization-params-helpers.js";
 import {
   DEFAULT_MFA_CONTEXT_TTL_SECONDS,
-  DEFAULT_SCOPES
+  DEFAULT_SCOPES,
+  DEFAULT_STT_SCOPES
 } from "../utils/constants.js";
 import { withDPoPNonceRetry } from "../utils/dpopRetry.js";
 import { createSizeLimitedFetch } from "../utils/fetchUtils.js";
@@ -3734,19 +3735,28 @@ export class AuthClient {
    * unexpired, asymmetrically-signed (RS256/PS256) JWT — the server rejects HS256
    * or expired actor tokens. If the session ID token is expired and a refresh token
    * is present the SDK silently refreshes it first; if no refresh token is available
-   * the exchange fails client-side with `ACTOR_UNAVAILABLE`.
+   * the exchange fails client-side with `ACTOR_UNAVAILABLE`. If that refresh itself
+   * requires MFA step-up, the error is `[MfaRequiredError, null, null]` — same as any
+   * other refresh-triggered step-up — rather than being collapsed into `ACTOR_UNAVAILABLE`.
+   * On Multiple Custom Domains (MCD) tenants, a session created for a different domain than
+   * the current request is never used as the actor source (`ACTOR_UNAVAILABLE`) — this holds
+   * even if the caller bypasses `Auth0Client`'s own domain check on session read.
    * Precedence: explicit `options.actor` → session ID token (refreshed if stale) → throws `ACTOR_UNAVAILABLE`.
    *
    * **The STT is never cached.** Use it immediately with `buildSessionTransferRedirect`.
    *
    * @param options - STT exchange options
    * @param session - The agent's current session, used to source the actor token
-   * @returns A tuple of `[error, null]` or `[null, SessionTransferTokenResult]`
+   * @returns A tuple of `[error, null, null]` or `[null, SessionTransferTokenResult, updatedSession]`.
+   * `updatedSession` is non-null only when the agent's ID token was refreshed to resolve the
+   * actor — the caller (`Auth0Client.requestSessionTransferToken`) MUST persist it back to the
+   * session store, or the agent's session cookie will hold a stale refresh token once refresh
+   * token rotation consumes it.
    *
    * @example
    * ```typescript
    * const session = await this.getSession();
-   * const [error, result] = await authClient.requestSessionTransferToken(
+   * const [error, result, updatedSession] = await authClient.requestSessionTransferToken(
    *   { subjectToken, subjectTokenType: "urn:acme:subject" },
    *   session
    * );
@@ -3756,7 +3766,8 @@ export class AuthClient {
     options: SessionTransferTokenOptions,
     session: SessionData | null
   ): Promise<
-    [CustomTokenExchangeError, null] | [null, SessionTransferTokenResult]
+    | [CustomTokenExchangeError | MfaRequiredError, null, null]
+    | [null, SessionTransferTokenResult, SessionData | null]
   > {
     await this.ensureDpopValidated();
 
@@ -3767,6 +3778,7 @@ export class AuthClient {
           CustomTokenExchangeErrorCode.MISSING_SUBJECT_TOKEN,
           "The subject_token is required and cannot be empty."
         ),
+        null,
         null
       ];
     }
@@ -3776,21 +3788,62 @@ export class AuthClient {
       options.subjectTokenType
     );
     if (tokenTypeError) {
-      return [tokenTypeError, null];
+      return [tokenTypeError, null, null];
+    }
+
+    // MCD defense-in-depth: refuse to source the actor from a session created for a
+    // different domain than the current request. `Auth0Client.requestSessionTransferToken`
+    // already enforces this via `getSession()` → `getSessionWithDomainCheck`, but this method
+    // can also be called directly with a session read some other way, so the guard is
+    // duplicated here rather than relied on solely at the caller. Only applies when the actor
+    // is sourced from the session — an explicit `actor` bypasses the session entirely.
+    if (
+      !options.actor &&
+      session?.internal?.mcd &&
+      session.internal.mcd.domain !== this.domain
+    ) {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+          `No usable actor token: the agent session was created for domain '${session.internal.mcd.domain}' ` +
+            `but the current request is for domain '${this.domain}'.`
+        ),
+        null,
+        null
+      ];
     }
 
     // Resolve actor — must come before any network call (client-side guard).
     // If the session ID token is expired but a refresh token is available, attempt a
     // silent refresh to get a fresh ID token before giving up with ACTOR_UNAVAILABLE.
+    // `refreshedSession`, once set, is returned to the caller so it can persist the new
+    // refresh token — #refreshTokenSet only returns the new token set, it does not save it,
+    // and refresh token rotation invalidates the old one still sitting in the session cookie.
+    //
+    // Only attempt this when no explicit `actor` was passed: `resolveActorFromSession` returns
+    // the same ACTOR_UNAVAILABLE code whether the cause is a blank explicit actor or a stale
+    // session ID token, so we can't distinguish them from the error alone. Gating on
+    // `!options.actor` ensures a bad explicit actor never triggers a wasted refresh (or a
+    // confusing MfaRequiredError) for a problem refreshing the session can't fix.
     let [actorError, actor] = resolveActorFromSession(session, options.actor);
-    if (actorError && session?.tokenSet?.refreshToken) {
+    let refreshedSession: SessionData | null = null;
+    if (!options.actor && actorError && session?.tokenSet?.refreshToken) {
       const [refreshError, refreshed] = await this.#refreshTokenSet(
         session.tokenSet,
         { requestedScope: DEFAULT_SCOPES }
       );
+      // A step-up challenge on the refresh is a distinct, recoverable case from "no usable
+      // actor" — surface it to the caller instead of silently falling through to
+      // ACTOR_UNAVAILABLE, which would give the agent no path to complete MFA and retry.
+      if (refreshError instanceof MfaRequiredError) {
+        return [refreshError, null, null];
+      }
       if (!refreshError && refreshed?.updatedTokenSet?.idToken) {
-        const refreshedSession: SessionData = {
+        refreshedSession = {
           ...session,
+          user: refreshed.idTokenClaims
+            ? (refreshed.idTokenClaims as User)
+            : session.user,
           tokenSet: refreshed.updatedTokenSet
         };
         [actorError, actor] = resolveActorFromSession(
@@ -3800,7 +3853,7 @@ export class AuthClient {
       }
     }
     if (actorError) {
-      return [actorError, null];
+      return [actorError, null, null];
     }
 
     // Discover authorization server metadata
@@ -3816,6 +3869,7 @@ export class AuthClient {
             message: discoveryError.message
           })
         ),
+        null,
         null
       ];
     }
@@ -3825,8 +3879,10 @@ export class AuthClient {
     // get the correct per-domain audience.
     const audience = buildSessionTransferAudience(this.domain);
 
-    // Merge scopes (offline_access is silently suppressed by Auth0 for STT)
-    const finalScope = mergeScopes(DEFAULT_SCOPES, options.scope);
+    // Merge scopes. offline_access is excluded from the STT default scopes — Auth0
+    // silently suppresses it for impersonation sessions, so requesting it here would
+    // just be a scope the server ignores.
+    const finalScope = mergeScopes(DEFAULT_STT_SCOPES, options.scope);
 
     const params = new URLSearchParams();
     params.append("subject_token", options.subjectToken);
@@ -3844,7 +3900,9 @@ export class AuthClient {
     }
     if (options.additionalParameters) {
       // Guard against callers overriding parameters the SDK manages — silently
-      // shadowing e.g. audience or actor_token would break the STT contract.
+      // shadowing e.g. audience or actor_token would break the STT contract, and
+      // organization/reason are already appended above so re-appending them here
+      // would produce a duplicate (and ambiguous) query param.
       const reservedParams = new Set([
         "subject_token",
         "subject_token_type",
@@ -3852,7 +3910,9 @@ export class AuthClient {
         "scope",
         "actor_token",
         "actor_token_type",
-        "grant_type"
+        "grant_type",
+        "organization",
+        "reason"
       ]);
       for (const [key, value] of Object.entries(options.additionalParameters)) {
         if (reservedParams.has(key)) {
@@ -3916,6 +3976,7 @@ export class AuthClient {
             message: oauthErr.error_description ?? err.message
           })
         ),
+        null,
         null
       ];
     }
@@ -3939,6 +4000,7 @@ export class AuthClient {
           CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
           `Failed to parse the Session Transfer Token response body (HTTP ${httpResponse.status}).${rawText ? " " + rawText : ""}`
         ),
+        null,
         null
       ];
     }
@@ -3957,6 +4019,7 @@ export class AuthClient {
             message: rawBody?.error_description ?? errorCode
           })
         ),
+        null,
         null
       ];
     }
@@ -3970,6 +4033,7 @@ export class AuthClient {
           CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
           `Unexpected issued_token_type: "${rawBody.issued_token_type ?? "(missing)"}". Expected "${TOKEN_TYPES.SESSION_TRANSFER_TOKEN}".`
         ),
+        null,
         null
       ];
     }
@@ -3982,7 +4046,8 @@ export class AuthClient {
         issued_token_type: rawBody.issued_token_type,
         expires_in: rawBody.expires_in,
         token_type: rawBody.token_type
-      })
+      }),
+      refreshedSession
     ];
   }
 

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -164,6 +164,7 @@ import {
 } from "../utils/session-helpers.js";
 import {
   buildSessionTransferAudience,
+  buildSessionTransferRedirectUrl,
   mapSttServerError,
   parseSessionTransferTokenResponse,
   resolveActorFromSession
@@ -3728,18 +3729,22 @@ export class AuthClient {
    * Pass the result to `buildSessionTransferRedirect` to start the redirect.
    *
    * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type`.
-   * The actor is sourced from the agent session's ID token (refreshed if expired).
+   * The actor is sourced from the agent session's ID token. The token must be an
+   * unexpired, asymmetrically-signed (RS256/PS256) JWT — the server rejects HS256
+   * or expired actor tokens. If the session ID token is missing or already expired,
+   * the exchange fails client-side with `ACTOR_UNAVAILABLE` (no automatic refresh is
+   * performed); refresh the agent session or pass a fresh explicit `actor` first.
    * Precedence: explicit `options.actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
    *
    * **The STT is never cached.** Use it immediately with `buildSessionTransferRedirect`.
    *
    * @param options - STT exchange options
-   * @param session - The agent's current session (from `getSessionWithDomainCheck`)
+   * @param session - The agent's current session, used to source the actor token
    * @returns A tuple of `[error, null]` or `[null, SessionTransferTokenResult]`
    *
    * @example
    * ```typescript
-   * const { session } = await authClient.getSessionWithDomainCheck(req.cookies);
+   * const session = await this.getSession();
    * const [error, result] = await authClient.requestSessionTransferToken(
    *   { subjectToken, subjectTokenType: "urn:acme:subject" },
    *   session
@@ -3819,7 +3824,21 @@ export class AuthClient {
       params.append("reason", options.reason);
     }
     if (options.additionalParameters) {
+      // Guard against callers overriding parameters the SDK manages — silently
+      // shadowing e.g. audience or actor_token would break the STT contract.
+      const reservedParams = new Set([
+        "subject_token",
+        "subject_token_type",
+        "audience",
+        "scope",
+        "actor_token",
+        "actor_token_type",
+        "grant_type"
+      ]);
       for (const [key, value] of Object.entries(options.additionalParameters)) {
+        if (reservedParams.has(key)) {
+          continue;
+        }
         if (value !== undefined && value !== null) {
           params.append(key, String(value));
         }
@@ -3853,31 +3872,17 @@ export class AuthClient {
       );
     };
 
-    // Minimal DPoP nonce retry wrapper for the raw HTTP response path.
-    // We re-send if the response is a 400 with error=use_dpop_nonce, extracting
-    // the new nonce from the DPoP-Nonce header and reusing the same dpopHandle.
+    // DPoP nonce handling via the shared retry helper (Path 1: it inspects the
+    // returned Response for a `use_dpop_nonce` 400 and retries once). The DPoP
+    // handle learns the nonce from the `DPoP-Nonce` header automatically, so the
+    // resent request carries a valid proof. When DPoP is disabled this is a
+    // single pass-through call.
     let httpResponse: Response;
     try {
-      httpResponse = await sendExchange();
-
-      if (this.useDPoP && dpopHandle && httpResponse.status === 400) {
-        const cloned = httpResponse.clone();
-        let body: any;
-        try {
-          body = await cloned.json();
-        } catch {
-          body = {};
-        }
-        if (body?.error === "use_dpop_nonce") {
-          const newNonce = httpResponse.headers.get("DPoP-Nonce");
-          if (newNonce) {
-            // Let the dpopHandle learn the nonce by making a throwaway attempt
-            // through the standard path so oauth4webapi's internals update.
-            // Then resend.
-            httpResponse = await sendExchange();
-          }
-        }
-      }
+      httpResponse = await withDPoPNonceRetry(sendExchange, {
+        isDPoPEnabled: !!(this.useDPoP && dpopHandle),
+        ...this.dpopOptions?.retry
+      });
     } catch (err: any) {
       const oauthErr = await extractOAuthErrorDetails(err);
       const errorCode = oauthErr.error ?? "unknown_error";
@@ -3973,12 +3978,12 @@ export class AuthClient {
     result: SessionTransferTokenResult,
     opts?: { organization?: string }
   ): NextResponse {
-    const url = new URL(targetLoginUrl);
-    url.searchParams.set("session_transfer_token", result.sessionTransferToken);
-    if (opts?.organization) {
-      url.searchParams.set("organization", opts.organization);
-    }
-    return NextResponse.redirect(url.toString());
+    const url = buildSessionTransferRedirectUrl(
+      targetLoginUrl,
+      result.sessionTransferToken,
+      opts
+    );
+    return NextResponse.redirect(url);
   }
 
   /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -101,6 +101,8 @@ import {
   ProxyOptions,
   RESPONSE_TYPES,
   SessionData,
+  SessionTransferTokenOptions,
+  SessionTransferTokenResult,
   StartInteractiveLoginOptions,
   SUBJECT_TOKEN_TYPES,
   TokenSet,
@@ -160,6 +162,12 @@ import {
   isSessionCeilingReached,
   mergePopupTokenIntoSession
 } from "../utils/session-helpers.js";
+import {
+  buildSessionTransferAudience,
+  mapSttServerError,
+  parseSessionTransferTokenResponse,
+  resolveActorFromSession
+} from "../utils/session-transfer-helpers.js";
 import {
   compareScopes,
   findAccessTokenSet,
@@ -3710,6 +3718,267 @@ export class AuthClient {
         act
       }
     ];
+  }
+
+  /**
+   * Requests a Session Transfer Token (STT) via Custom Token Exchange.
+   *
+   * The STT is a one-shot, ~60s token that lets an authenticated agent establish
+   * a web session **as the customer** in a target app — without the customer's password.
+   * Pass the result to `buildSessionTransferRedirect` to start the redirect.
+   *
+   * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type`.
+   * The actor is sourced from the agent session's ID token (refreshed if expired).
+   * Precedence: explicit `options.actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
+   *
+   * **The STT is never cached.** Use it immediately with `buildSessionTransferRedirect`.
+   *
+   * @param options - STT exchange options
+   * @param session - The agent's current session (from `getSessionWithDomainCheck`)
+   * @returns A tuple of `[error, null]` or `[null, SessionTransferTokenResult]`
+   *
+   * @example
+   * ```typescript
+   * const { session } = await authClient.getSessionWithDomainCheck(req.cookies);
+   * const [error, result] = await authClient.requestSessionTransferToken(
+   *   { subjectToken, subjectTokenType: "urn:acme:subject" },
+   *   session
+   * );
+   * ```
+   */
+  async requestSessionTransferToken(
+    options: SessionTransferTokenOptions,
+    session: SessionData | null
+  ): Promise<
+    [CustomTokenExchangeError, null] | [null, SessionTransferTokenResult]
+  > {
+    await this.ensureDpopValidated();
+
+    // Validate subjectToken
+    if (!options.subjectToken || options.subjectToken.trim() === "") {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.MISSING_SUBJECT_TOKEN,
+          "The subject_token is required and cannot be empty."
+        ),
+        null
+      ];
+    }
+
+    // Validate subjectTokenType
+    const tokenTypeError = this.validateSubjectTokenType(
+      options.subjectTokenType
+    );
+    if (tokenTypeError) {
+      return [tokenTypeError, null];
+    }
+
+    // Resolve actor — must come before any network call (client-side guard)
+    const [actorError, actor] = resolveActorFromSession(session, options.actor);
+    if (actorError) {
+      return [actorError, null];
+    }
+
+    // Discover authorization server metadata
+    const [discoveryError, authorizationServerMetadata] =
+      await this.discoverAuthorizationServerMetadata();
+    if (discoveryError) {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+          "Failed to discover authorization server metadata.",
+          new OAuth2Error({
+            code: "discovery_error",
+            message: discoveryError.message
+          })
+        ),
+        null
+      ];
+    }
+
+    // Build the STT-specific audience: urn:{domain}:session_transfer
+    // Use this.domain (the effective domain for this request) so MCD tenants
+    // get the correct per-domain audience.
+    const audience = buildSessionTransferAudience(this.domain);
+
+    // Merge scopes (offline_access is silently suppressed by Auth0 for STT)
+    const finalScope = mergeScopes(DEFAULT_SCOPES, options.scope);
+
+    const params = new URLSearchParams();
+    params.append("subject_token", options.subjectToken);
+    params.append("subject_token_type", options.subjectTokenType);
+    params.append("audience", audience);
+    params.append("scope", finalScope);
+    params.append("actor_token", actor.token);
+    params.append("actor_token_type", actor.type);
+
+    if (options.organization) {
+      params.append("organization", options.organization);
+    }
+    if (options.reason) {
+      params.append("reason", options.reason);
+    }
+    if (options.additionalParameters) {
+      for (const [key, value] of Object.entries(options.additionalParameters)) {
+        if (value !== undefined && value !== null) {
+          params.append(key, String(value));
+        }
+      }
+    }
+
+    const dpopHandle =
+      this.useDPoP && this.dpopKeyPair
+        ? oauth.DPoP(this.clientMetadata, this.dpopKeyPair)
+        : undefined;
+
+    const tokenExchangeMetadata = this.withMtlsEndpoint(
+      authorizationServerMetadata
+    );
+
+    // STT responses carry `token_type: "N_A"` which oauth4webapi's
+    // processGenericTokenEndpointResponse rejects. We send the request via
+    // genericTokenEndpointRequest and parse the body ourselves.
+    const sendExchange = async (): Promise<Response> => {
+      return oauth.genericTokenEndpointRequest(
+        tokenExchangeMetadata,
+        this.clientMetadata,
+        await this.getClientAuth(),
+        GRANT_TYPE_CUSTOM_TOKEN_EXCHANGE,
+        params,
+        {
+          [oauth.customFetch]: this.fetch,
+          [oauth.allowInsecureRequests]: this.allowInsecureRequests,
+          ...(dpopHandle && { DPoP: dpopHandle })
+        }
+      );
+    };
+
+    // Minimal DPoP nonce retry wrapper for the raw HTTP response path.
+    // We re-send if the response is a 400 with error=use_dpop_nonce, extracting
+    // the new nonce from the DPoP-Nonce header and reusing the same dpopHandle.
+    let httpResponse: Response;
+    try {
+      httpResponse = await sendExchange();
+
+      if (this.useDPoP && dpopHandle && httpResponse.status === 400) {
+        const cloned = httpResponse.clone();
+        let body: any;
+        try {
+          body = await cloned.json();
+        } catch {
+          body = {};
+        }
+        if (body?.error === "use_dpop_nonce") {
+          const newNonce = httpResponse.headers.get("DPoP-Nonce");
+          if (newNonce) {
+            // Let the dpopHandle learn the nonce by making a throwaway attempt
+            // through the standard path so oauth4webapi's internals update.
+            // Then resend.
+            httpResponse = await sendExchange();
+          }
+        }
+      }
+    } catch (err: any) {
+      const oauthErr = await extractOAuthErrorDetails(err);
+      const errorCode = oauthErr.error ?? "unknown_error";
+      const sttCode = mapSttServerError(errorCode);
+      return [
+        new CustomTokenExchangeError(
+          sttCode ?? CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+          oauthErr.error_description ??
+            "There was an error trying to exchange the token for a Session Transfer Token.",
+          new OAuth2Error({
+            code: errorCode,
+            message: oauthErr.error_description ?? err.message
+          })
+        ),
+        null
+      ];
+    }
+
+    // Parse the raw JSON response ourselves — bypasses oauth4webapi's
+    // token_type allowlist which blocks "N_A".
+    let rawBody: any;
+    try {
+      rawBody = await httpResponse.json();
+    } catch {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+          "Failed to parse the Session Transfer Token response body."
+        ),
+        null
+      ];
+    }
+
+    // Surface server-side errors (4xx/5xx with error field)
+    if (!httpResponse.ok || rawBody?.error) {
+      const errorCode = rawBody?.error ?? "unknown_error";
+      const sttCode = mapSttServerError(errorCode);
+      return [
+        new CustomTokenExchangeError(
+          sttCode ?? CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+          rawBody?.error_description ??
+            "There was an error trying to exchange the token for a Session Transfer Token.",
+          new OAuth2Error({
+            code: errorCode,
+            message: rawBody?.error_description ?? errorCode
+          })
+        ),
+        null
+      ];
+    }
+
+    // STT never decoded, never cached — treat as opaque handle
+    return [
+      null,
+      parseSessionTransferTokenResponse({
+        access_token: rawBody.access_token,
+        issued_token_type:
+          rawBody.issued_token_type ??
+          "urn:auth0:params:oauth:token-type:session_transfer_token",
+        expires_in: rawBody.expires_in,
+        token_type: rawBody.token_type
+      })
+    ];
+  }
+
+  /**
+   * Builds the redirect URL that carries the STT to the target app's login route.
+   *
+   * Returns a `NextResponse` redirect to
+   * `targetLoginUrl?session_transfer_token=<encoded>(&organization=…)`.
+   *
+   * This is a pure URL builder — no network call, nothing written to session.
+   * The STT is one-shot; use this immediately after `requestSessionTransferToken`.
+   *
+   * @param targetLoginUrl - The target app's login URL (e.g. `https://app.example.com/auth/login`).
+   *   Must be a trusted, app-controlled value. Never derive this from untrusted input.
+   * @param result - The `SessionTransferTokenResult` from `requestSessionTransferToken`
+   * @param opts - Optional overrides
+   * @param opts.organization - Org ID/name to append; use the same value passed to `requestSessionTransferToken`
+   *
+   * @example
+   * ```typescript
+   * const redirect = authClient.buildSessionTransferRedirect(
+   *   "https://app.example.com/auth/login",
+   *   result,
+   *   { organization: "org_abc123" }
+   * );
+   * return redirect;
+   * ```
+   */
+  buildSessionTransferRedirect(
+    targetLoginUrl: string,
+    result: SessionTransferTokenResult,
+    opts?: { organization?: string }
+  ): NextResponse {
+    const url = new URL(targetLoginUrl);
+    url.searchParams.set("session_transfer_token", result.sessionTransferToken);
+    if (opts?.organization) {
+      url.searchParams.set("organization", opts.organization);
+    }
+    return NextResponse.redirect(url.toString());
   }
 
   /**

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -105,6 +105,7 @@ import {
   SessionTransferTokenResult,
   StartInteractiveLoginOptions,
   SUBJECT_TOKEN_TYPES,
+  TOKEN_TYPES,
   TokenSet,
   User,
   VerifyMfaOptions
@@ -3731,10 +3732,10 @@ export class AuthClient {
    * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type`.
    * The actor is sourced from the agent session's ID token. The token must be an
    * unexpired, asymmetrically-signed (RS256/PS256) JWT — the server rejects HS256
-   * or expired actor tokens. If the session ID token is missing or already expired,
-   * the exchange fails client-side with `ACTOR_UNAVAILABLE` (no automatic refresh is
-   * performed); refresh the agent session or pass a fresh explicit `actor` first.
-   * Precedence: explicit `options.actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
+   * or expired actor tokens. If the session ID token is expired and a refresh token
+   * is present the SDK silently refreshes it first; if no refresh token is available
+   * the exchange fails client-side with `ACTOR_UNAVAILABLE`.
+   * Precedence: explicit `options.actor` → session ID token (refreshed if stale) → throws `ACTOR_UNAVAILABLE`.
    *
    * **The STT is never cached.** Use it immediately with `buildSessionTransferRedirect`.
    *
@@ -3778,8 +3779,26 @@ export class AuthClient {
       return [tokenTypeError, null];
     }
 
-    // Resolve actor — must come before any network call (client-side guard)
-    const [actorError, actor] = resolveActorFromSession(session, options.actor);
+    // Resolve actor — must come before any network call (client-side guard).
+    // If the session ID token is expired but a refresh token is available, attempt a
+    // silent refresh to get a fresh ID token before giving up with ACTOR_UNAVAILABLE.
+    let [actorError, actor] = resolveActorFromSession(session, options.actor);
+    if (actorError && session?.tokenSet?.refreshToken) {
+      const [refreshError, refreshed] = await this.#refreshTokenSet(
+        session.tokenSet,
+        { requestedScope: DEFAULT_SCOPES }
+      );
+      if (!refreshError && refreshed?.updatedTokenSet?.idToken) {
+        const refreshedSession: SessionData = {
+          ...session,
+          tokenSet: refreshed.updatedTokenSet
+        };
+        [actorError, actor] = resolveActorFromSession(
+          refreshedSession,
+          options.actor
+        );
+      }
+    }
     if (actorError) {
       return [actorError, null];
     }
@@ -3814,8 +3833,8 @@ export class AuthClient {
     params.append("subject_token_type", options.subjectTokenType);
     params.append("audience", audience);
     params.append("scope", finalScope);
-    params.append("actor_token", actor.token);
-    params.append("actor_token_type", actor.type);
+    params.append("actor_token", actor!.token);
+    params.append("actor_token_type", actor!.type);
 
     if (options.organization) {
       params.append("organization", options.organization);
@@ -3903,14 +3922,22 @@ export class AuthClient {
 
     // Parse the raw JSON response ourselves — bypasses oauth4webapi's
     // token_type allowlist which blocks "N_A".
+    // Fall back to text() when the body is not JSON (e.g. plain-text gateway errors)
+    // so the status code and raw message are preserved in the error.
     let rawBody: any;
     try {
       rawBody = await httpResponse.json();
     } catch {
+      let rawText = "";
+      try {
+        rawText = await httpResponse.text();
+      } catch {
+        // ignore — body already consumed or unreadable
+      }
       return [
         new CustomTokenExchangeError(
           CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
-          "Failed to parse the Session Transfer Token response body."
+          `Failed to parse the Session Transfer Token response body (HTTP ${httpResponse.status}).${rawText ? " " + rawText : ""}`
         ),
         null
       ];
@@ -3934,14 +3961,25 @@ export class AuthClient {
       ];
     }
 
+    // The spec requires branching on issued_token_type to identify an STT.
+    // Reject any response where it is missing or not the STT URN — a plain Bearer
+    // access-token response must never be mistaken for a session transfer token.
+    if (rawBody.issued_token_type !== TOKEN_TYPES.SESSION_TRANSFER_TOKEN) {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+          `Unexpected issued_token_type: "${rawBody.issued_token_type ?? "(missing)"}". Expected "${TOKEN_TYPES.SESSION_TRANSFER_TOKEN}".`
+        ),
+        null
+      ];
+    }
+
     // STT never decoded, never cached — treat as opaque handle
     return [
       null,
       parseSessionTransferTokenResponse({
         access_token: rawBody.access_token,
-        issued_token_type:
-          rawBody.issued_token_type ??
-          "urn:auth0:params:oauth:token-type:session_transfer_token",
+        issued_token_type: rawBody.issued_token_type,
         expires_in: rawBody.expires_in,
         token_type: rawBody.token_type
       })

--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -10,6 +10,11 @@ import {
 import { SessionData } from "../types/index.js";
 import { Auth0Client } from "./client.js";
 
+vi.mock("next/headers.js", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+  cookies: vi.fn().mockResolvedValue({ getAll: () => [] })
+}));
+
 // Define ENV_VARS at the top level for broader scope
 const ENV_VARS = {
   DOMAIN: "AUTH0_DOMAIN",
@@ -665,6 +670,127 @@ describe("Auth0Client", () => {
       await expect(client.revokeRefreshToken({ req })).rejects.toMatchObject({
         code: TokenRevocationErrorCode.FAILED_TO_REVOKE
       });
+    });
+  });
+
+  describe("requestSessionTransferToken / buildSessionTransferRedirect", () => {
+    let client: Auth0Client;
+
+    const mockSession: SessionData = {
+      user: { sub: "agent|007" },
+      tokenSet: {
+        accessToken: "at_agent",
+        idToken: "id_token_agent",
+        expiresAt: Math.floor(Date.now() / 1000) + 3600
+      },
+      internal: { sid: "sid_agent", createdAt: Math.floor(Date.now() / 1000) }
+    };
+
+    const mockSttResult = {
+      sessionTransferToken: "stt_opaque_123",
+      issuedTokenType:
+        "urn:auth0:params:oauth:token-type:session_transfer_token",
+      expiresIn: 60,
+      tokenType: "N_A"
+    };
+
+    beforeEach(() => {
+      process.env[ENV_VARS.DOMAIN] = "test.auth0.com";
+      process.env[ENV_VARS.CLIENT_ID] = "test_client_id";
+      process.env[ENV_VARS.CLIENT_SECRET] = "test_client_secret";
+      process.env[ENV_VARS.APP_BASE_URL] = "https://myapp.test";
+      process.env[ENV_VARS.SECRET] = "test_secret";
+      client = new Auth0Client();
+    });
+
+    it("should call authClient.requestSessionTransferToken with the current session and return the result", async () => {
+      const requestSessionTransferToken = vi
+        .fn()
+        .mockResolvedValue([null, mockSttResult]);
+      vi.spyOn(client, "getSession").mockResolvedValue(mockSession);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        requestSessionTransferToken
+      });
+
+      const result = await client.requestSessionTransferToken({
+        subjectToken: "sub-tok",
+        subjectTokenType: "urn:acme:subject"
+      });
+
+      expect(result).toBe(mockSttResult);
+      expect(requestSessionTransferToken).toHaveBeenCalledWith(
+        { subjectToken: "sub-tok", subjectTokenType: "urn:acme:subject" },
+        mockSession
+      );
+    });
+
+    it("should throw when authClient.requestSessionTransferToken returns an error", async () => {
+      const { CustomTokenExchangeError, CustomTokenExchangeErrorCode } =
+        await import("../errors/index.js");
+      const sttError = new CustomTokenExchangeError(
+        CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+        "No actor available."
+      );
+      vi.spyOn(client, "getSession").mockResolvedValue(null);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        requestSessionTransferToken: vi.fn().mockResolvedValue([sttError, null])
+      });
+
+      await expect(
+        client.requestSessionTransferToken({
+          subjectToken: "sub-tok",
+          subjectTokenType: "urn:acme:subject"
+        })
+      ).rejects.toMatchObject({
+        code: CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+      });
+    });
+
+    it("should pass null session when there is no active session", async () => {
+      const requestSessionTransferToken = vi
+        .fn()
+        .mockResolvedValue([null, mockSttResult]);
+      vi.spyOn(client, "getSession").mockResolvedValue(null);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        requestSessionTransferToken
+      });
+
+      await client.requestSessionTransferToken({
+        subjectToken: "sub-tok",
+        subjectTokenType: "urn:acme:subject"
+      });
+
+      expect(requestSessionTransferToken).toHaveBeenCalledWith(
+        expect.anything(),
+        null
+      );
+    });
+
+    it("buildSessionTransferRedirect should return a redirect with session_transfer_token param", () => {
+      const response = client.buildSessionTransferRedirect(
+        "https://app.example.com/auth/login",
+        mockSttResult
+      );
+
+      expect(response.status).toBeGreaterThanOrEqual(300);
+      expect(response.status).toBeLessThan(400);
+      const location = response.headers.get("location") ?? "";
+      const url = new URL(location);
+      expect(url.searchParams.get("session_transfer_token")).toBe(
+        "stt_opaque_123"
+      );
+    });
+
+    it("buildSessionTransferRedirect should append organization when provided", () => {
+      const response = client.buildSessionTransferRedirect(
+        "https://app.example.com/auth/login",
+        mockSttResult,
+        { organization: "org_abc" }
+      );
+
+      const location = response.headers.get("location") ?? "";
+      const url = new URL(location);
+      expect(url.searchParams.get("organization")).toBe("org_abc");
     });
   });
 

--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -707,8 +707,10 @@ describe("Auth0Client", () => {
       const requestSessionTransferToken = vi
         .fn()
         .mockResolvedValue([null, mockSttResult]);
-      vi.spyOn(client, "getSession").mockResolvedValue(mockSession);
       vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: mockSession, error: null }),
         requestSessionTransferToken
       });
 
@@ -731,8 +733,10 @@ describe("Auth0Client", () => {
         CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
         "No actor available."
       );
-      vi.spyOn(client, "getSession").mockResolvedValue(null);
       vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: null, error: null }),
         requestSessionTransferToken: vi.fn().mockResolvedValue([sttError, null])
       });
 
@@ -750,8 +754,10 @@ describe("Auth0Client", () => {
       const requestSessionTransferToken = vi
         .fn()
         .mockResolvedValue([null, mockSttResult]);
-      vi.spyOn(client, "getSession").mockResolvedValue(null);
       vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: null, error: null }),
         requestSessionTransferToken
       });
 
@@ -763,6 +769,122 @@ describe("Auth0Client", () => {
       expect(requestSessionTransferToken).toHaveBeenCalledWith(
         expect.anything(),
         null
+      );
+    });
+
+    it("should persist the refreshed session (through finalizeSession) when the actor's ID token was refreshed", async () => {
+      const refreshedSession: SessionData = {
+        ...mockSession,
+        tokenSet: {
+          ...mockSession.tokenSet,
+          idToken: "id_token_agent_refreshed",
+          refreshToken: "rt_agent_rotated"
+        }
+      };
+      const finalizedSession: SessionData = {
+        ...refreshedSession,
+        user: { sub: "agent|007", extra: "filtered" }
+      };
+      const finalizeSession = vi.fn().mockResolvedValue(finalizedSession);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: mockSession, error: null }),
+        requestSessionTransferToken: vi
+          .fn()
+          .mockResolvedValue([null, mockSttResult, refreshedSession]),
+        finalizeSession
+      });
+      const saveToSession = vi
+        .spyOn(client as any, "saveToSession")
+        .mockResolvedValue(undefined);
+
+      await client.requestSessionTransferToken({
+        subjectToken: "sub-tok",
+        subjectTokenType: "urn:acme:subject"
+      });
+
+      expect(finalizeSession).toHaveBeenCalledWith(
+        refreshedSession,
+        refreshedSession.tokenSet.idToken
+      );
+      expect(saveToSession).toHaveBeenCalledWith(
+        finalizedSession,
+        undefined,
+        undefined
+      );
+    });
+
+    it("should not persist a session when the actor's ID token was not refreshed", async () => {
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: mockSession, error: null }),
+        requestSessionTransferToken: vi
+          .fn()
+          .mockResolvedValue([null, mockSttResult, null])
+      });
+      const saveToSession = vi
+        .spyOn(client as any, "saveToSession")
+        .mockResolvedValue(undefined);
+
+      await client.requestSessionTransferToken({
+        subjectToken: "sub-tok",
+        subjectTokenType: "urn:acme:subject"
+      });
+
+      expect(saveToSession).not.toHaveBeenCalled();
+    });
+
+    it("should support the Pages Router overload (req, res, options) and persist via saveToSession(session, req, res)", async () => {
+      const refreshedSession: SessionData = {
+        ...mockSession,
+        tokenSet: {
+          ...mockSession.tokenSet,
+          idToken: "id_token_agent_refreshed",
+          refreshToken: "rt_agent_rotated"
+        }
+      };
+      const finalizeSession = vi.fn().mockResolvedValue(refreshedSession);
+      const requestSessionTransferToken = vi
+        .fn()
+        .mockResolvedValue([null, mockSttResult, refreshedSession]);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: mockSession, error: null }),
+        requestSessionTransferToken,
+        finalizeSession
+      });
+      const saveToSession = vi
+        .spyOn(client as any, "saveToSession")
+        .mockResolvedValue(undefined);
+
+      const mockReq = {
+        headers: {},
+        cookies: {}
+      } as any;
+      const mockRes = {
+        headers: {},
+        setHeader: vi.fn(),
+        appendHeader: vi.fn()
+      } as any;
+
+      const result = await client.requestSessionTransferToken(
+        mockReq,
+        mockRes,
+        { subjectToken: "sub-tok", subjectTokenType: "urn:acme:subject" }
+      );
+
+      expect(result).toBe(mockSttResult);
+      expect(requestSessionTransferToken).toHaveBeenCalledWith(
+        { subjectToken: "sub-tok", subjectTokenType: "urn:acme:subject" },
+        mockSession
+      );
+      expect(saveToSession).toHaveBeenCalledWith(
+        refreshedSession,
+        mockReq,
+        mockRes
       );
     });
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1298,10 +1298,20 @@ export class Auth0Client {
    * Requests a Session Transfer Token (STT) that lets an authenticated agent
    * establish a web session **as a customer** in a target app — without the customer's password.
    *
+   * This method can be used in Server Components, Server Actions, and Route Handlers in the
+   * **App Router**.
+   *
+   * NOTE: Server Components cannot set cookies. If the actor's ID token needs a silent refresh
+   * (see below), calling this from a Server Component will refresh the token but the updated
+   * token set will not be persisted. Prefer calling this from a Route Handler or Server Action.
+   *
    * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type` automatically.
    * The actor defaults to the agent session's ID token. If the ID token is expired and a
-   * refresh token is available the SDK silently refreshes the session first. If no refresh
-   * token is available this throws `ACTOR_UNAVAILABLE`.
+   * refresh token is available the SDK silently refreshes the session first — the refreshed
+   * token set is persisted back to the session cookie (through the `beforeSessionSaved` hook,
+   * if configured), since refresh token rotation invalidates the old refresh token still held
+   * in the session. If no refresh token is available this throws `ACTOR_UNAVAILABLE`. If the
+   * refresh itself requires MFA step-up, this throws `MfaRequiredError`.
    *
    * Use the result with `buildSessionTransferRedirect` to redirect the agent's browser
    * to the target app's login URL.
@@ -1310,6 +1320,7 @@ export class Auth0Client {
    *
    * @example
    * ```typescript
+   * // app/api/stt/route.ts — App Router Route Handler
    * const result = await auth0.requestSessionTransferToken({
    *   subjectToken: mySubjectToken,
    *   subjectTokenType: "urn:acme:subject",
@@ -1320,19 +1331,79 @@ export class Auth0Client {
    */
   async requestSessionTransferToken(
     options: SessionTransferTokenOptions
+  ): Promise<SessionTransferTokenResult>;
+
+  /**
+   * Requests a Session Transfer Token (STT) that lets an authenticated agent
+   * establish a web session **as a customer** in a target app — without the customer's password.
+   *
+   * This method can be used in middleware and `getServerSideProps`, API routes in the
+   * **Pages Router**.
+   *
+   * @param req The request object.
+   * @param res The response object.
+   * @param options STT exchange options.
+   *
+   * @example
+   * ```typescript
+   * // pages/api/stt.ts — Pages Router API route
+   * const result = await auth0.requestSessionTransferToken(req, res, {
+   *   subjectToken: mySubjectToken,
+   *   subjectTokenType: "urn:acme:subject"
+   * });
+   * ```
+   */
+  async requestSessionTransferToken(
+    req: PagesRouterRequest | NextRequest,
+    res: PagesRouterResponse | NextResponse,
+    options: SessionTransferTokenOptions
+  ): Promise<SessionTransferTokenResult>;
+
+  async requestSessionTransferToken(
+    arg1: SessionTransferTokenOptions | PagesRouterRequest | NextRequest,
+    arg2?: PagesRouterResponse | NextResponse,
+    arg3?: SessionTransferTokenOptions
   ): Promise<SessionTransferTokenResult> {
-    const reqHeaders = await getHeaders();
-    const authClient = await this.provider.forRequest(reqHeaders, undefined);
+    let req: PagesRouterRequest | NextRequest | undefined;
+    let res: PagesRouterResponse | NextResponse | undefined;
+    let options: SessionTransferTokenOptions;
 
-    const session = await this.getSession();
+    // Determine which overload was called based on arguments — same pattern as getAccessToken.
+    if (
+      arg1 &&
+      (arg1 instanceof Request || typeof (arg1 as any).headers === "object")
+    ) {
+      // Case: requestSessionTransferToken(req, res, options)
+      req = arg1 as PagesRouterRequest | NextRequest;
+      res = arg2;
+      options = arg3 as SessionTransferTokenOptions;
+    } else {
+      // Case: requestSessionTransferToken(options)
+      options = arg1 as SessionTransferTokenOptions;
+    }
 
-    const [error, result] = await authClient.requestSessionTransferToken(
-      options,
-      session
+    const { authClient, normalizedReq } = await this.resolveRequestContext(req);
+    const session = await this.getSessionFromAuthClient(
+      authClient,
+      normalizedReq
     );
+
+    const [error, result, refreshedSession] =
+      await authClient.requestSessionTransferToken(options, session);
 
     if (error !== null) {
       throw error;
+    }
+
+    if (refreshedSession) {
+      // Route through finalizeSession so a configured beforeSessionSaved hook runs (or
+      // default ID token claim filtering is applied) — same as every other refresh-and-save
+      // path (e.g. executeGetAccessToken).
+      const finalSession = await authClient.finalizeSession(
+        refreshedSession,
+        refreshedSession.tokenSet.idToken
+      );
+      await this.saveToSession(finalSession, req, res);
     }
 
     return result;

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1299,10 +1299,9 @@ export class Auth0Client {
    * establish a web session **as a customer** in a target app — without the customer's password.
    *
    * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type` automatically.
-   * The actor defaults to the agent session's ID token, which must be unexpired and
-   * asymmetrically signed (RS256/PS256). If it is missing or expired, this throws
-   * `ACTOR_UNAVAILABLE` — no automatic refresh is performed, so refresh the session
-   * or pass a fresh explicit `actor` first.
+   * The actor defaults to the agent session's ID token. If the ID token is expired and a
+   * refresh token is available the SDK silently refreshes the session first. If no refresh
+   * token is available this throws `ACTOR_UNAVAILABLE`.
    *
    * Use the result with `buildSessionTransferRedirect` to redirect the agent's browser
    * to the target app's login URL.

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -28,6 +28,8 @@ import {
   LogoutStrategy,
   SessionData,
   SessionDataStore,
+  SessionTransferTokenOptions,
+  SessionTransferTokenResult,
   StartInteractiveLoginOptions,
   User
 } from "../types/index.js";
@@ -1289,6 +1291,88 @@ export class Auth0Client {
     if (error !== null) {
       throw error;
     }
+  }
+
+  /**
+   * Requests a Session Transfer Token (STT) that lets an authenticated agent
+   * establish a web session **as a customer** in a target app — without the customer's password.
+   *
+   * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type` automatically.
+   * The actor defaults to the agent session's ID token (refreshed if expired).
+   *
+   * Use the result with `buildSessionTransferRedirect` to redirect the agent's browser
+   * to the target app's login URL.
+   *
+   * **The returned STT is one-shot (~60s) and must never be cached.**
+   *
+   * @example
+   * ```typescript
+   * const result = await auth0.requestSessionTransferToken({
+   *   subjectToken: mySubjectToken,
+   *   subjectTokenType: "urn:acme:subject",
+   *   reason: "Investigating ticket #1234"
+   * });
+   * return auth0.buildSessionTransferRedirect("https://app.example.com/auth/login", result);
+   * ```
+   */
+  async requestSessionTransferToken(
+    options: SessionTransferTokenOptions
+  ): Promise<SessionTransferTokenResult> {
+    const reqHeaders = await getHeaders();
+    const authClient = await this.provider.forRequest(reqHeaders, undefined);
+
+    const session = await this.getSession();
+
+    const [error, result] = await authClient.requestSessionTransferToken(
+      options,
+      session
+    );
+
+    if (error !== null) {
+      throw error;
+    }
+
+    return result;
+  }
+
+  /**
+   * Builds a `NextResponse` redirect that carries the STT to the target app's login route.
+   *
+   * Returns a redirect to `targetLoginUrl?session_transfer_token=<encoded>(&organization=…)`.
+   * Pure URL builder — no network call, nothing written to session.
+   *
+   * @param targetLoginUrl - The target app's login URL. Must be a trusted, app-controlled value.
+   * @param result - The `SessionTransferTokenResult` from `requestSessionTransferToken`
+   * @param opts - Optional: `organization` to append (same value passed to `requestSessionTransferToken`)
+   *
+   * @example
+   * ```typescript
+   * const result = await auth0.requestSessionTransferToken({ subjectToken, subjectTokenType });
+   * return auth0.buildSessionTransferRedirect("https://app.example.com/auth/login", result);
+   * ```
+   */
+  buildSessionTransferRedirect(
+    targetLoginUrl: string,
+    result: SessionTransferTokenResult,
+    opts?: { organization?: string }
+  ): NextResponse {
+    // buildSessionTransferRedirect is a pure URL builder — delegate directly
+    // to any AuthClient instance since it uses no per-request state.
+    const staticClient = this.provider.getAuthClientForStaticMode();
+    if (staticClient) {
+      return staticClient.buildSessionTransferRedirect(
+        targetLoginUrl,
+        result,
+        opts
+      );
+    }
+    // Fallback: build the URL inline (resolver mode with no static client)
+    const url = new URL(targetLoginUrl);
+    url.searchParams.set("session_transfer_token", result.sessionTransferToken);
+    if (opts?.organization) {
+      url.searchParams.set("organization", opts.organization);
+    }
+    return NextResponse.redirect(url.toString());
   }
 
   /**

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils/constants.js";
 import { isRequest } from "../utils/request.js";
 import { getSessionChangesAfterGetAccessToken } from "../utils/session-changes-helpers.js";
+import { buildSessionTransferRedirectUrl } from "../utils/session-transfer-helpers.js";
 import { AuthClientProvider } from "./auth-client-provider.js";
 import {
   AuthClient,
@@ -1298,7 +1299,10 @@ export class Auth0Client {
    * establish a web session **as a customer** in a target app — without the customer's password.
    *
    * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type` automatically.
-   * The actor defaults to the agent session's ID token (refreshed if expired).
+   * The actor defaults to the agent session's ID token, which must be unexpired and
+   * asymmetrically signed (RS256/PS256). If it is missing or expired, this throws
+   * `ACTOR_UNAVAILABLE` — no automatic refresh is performed, so refresh the session
+   * or pass a fresh explicit `actor` first.
    *
    * Use the result with `buildSessionTransferRedirect` to redirect the agent's browser
    * to the target app's login URL.
@@ -1366,13 +1370,15 @@ export class Auth0Client {
         opts
       );
     }
-    // Fallback: build the URL inline (resolver mode with no static client)
-    const url = new URL(targetLoginUrl);
-    url.searchParams.set("session_transfer_token", result.sessionTransferToken);
-    if (opts?.organization) {
-      url.searchParams.set("organization", opts.organization);
-    }
-    return NextResponse.redirect(url.toString());
+    // Fallback for resolver mode with no static client. Uses the same shared
+    // URL builder (with the same absolute-URL guard) as the core AuthClient,
+    // so behaviour is identical on both paths.
+    const url = buildSessionTransferRedirectUrl(
+      targetLoginUrl,
+      result.sessionTransferToken,
+      opts
+    );
+    return NextResponse.redirect(url);
   }
 
   /**

--- a/src/server/custom-token-exchange.test.ts
+++ b/src/server/custom-token-exchange.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server.js";
 import * as jose from "jose";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -1735,6 +1736,35 @@ describe("Custom Token Exchange", () => {
 
         expect(response).not.toHaveProperty("sessionTransferToken");
         expect(response).not.toHaveProperty("issuedTokenType");
+      });
+    });
+
+    // Pin the claim that handleLogin forwards all query params to /authorize
+    // untouched, so session_transfer_token reaches the authorization endpoint
+    // automatically on the target app side — no middleware change needed.
+    describe("5.9: handleLogin forwards session_transfer_token to /authorize", () => {
+      it("should forward session_transfer_token query param to the authorization URL", async () => {
+        let capturedAuthorizeUrl = "";
+        server.use(
+          http.get(`https://${DEFAULT.domain}/authorize`, ({ request }) => {
+            capturedAuthorizeUrl = request.url;
+            return HttpResponse.text("", { status: 302 });
+          })
+        );
+
+        const loginUrl = new URL("/auth/login", DEFAULT.appBaseUrl);
+        loginUrl.searchParams.set("session_transfer_token", "stt_opaque_abc");
+        const request = new NextRequest(loginUrl);
+
+        const response = await authClient.handleLogin(request);
+
+        // handleLogin redirects to /authorize; the location header holds the URL
+        const authorizeUrl = new URL(
+          response.headers.get("location") ?? capturedAuthorizeUrl
+        );
+        expect(authorizeUrl.searchParams.get("session_transfer_token")).toBe(
+          "stt_opaque_abc"
+        );
       });
     });
   });

--- a/src/server/custom-token-exchange.test.ts
+++ b/src/server/custom-token-exchange.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../errors/index.js";
 import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
+import { SessionData } from "../types/index.js";
+import { TOKEN_TYPES } from "../types/token-vault.js";
 import { generateDpopKeyPair } from "../utils/dpopRetry.js";
 import { AuthClient } from "./auth-client.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
@@ -950,6 +952,689 @@ describe("Custom Token Exchange", () => {
 
       expect(error).toBeInstanceOf(CustomTokenExchangeError);
       expect(error?.name).toBe("CustomTokenExchangeError");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5: Session Transfer Token (STT) — requestSessionTransferToken
+  // -------------------------------------------------------------------------
+
+  describe("5: Session Transfer Token", () => {
+    const STT_SUBJECT_TOKEN_TYPE = "urn:acme:subject-token";
+    const STT_URN = TOKEN_TYPES.SESSION_TRANSFER_TOKEN;
+
+    async function makeAgentIdToken(
+      opts: { expiresIn?: string } = {}
+    ): Promise<string> {
+      return new jose.SignJWT({})
+        .setProtectedHeader({ alg: DEFAULT.alg })
+        .setSubject("agent|support-007")
+        .setIssuedAt()
+        .setIssuer(`https://${DEFAULT.domain}`)
+        .setAudience(DEFAULT.clientId)
+        .setExpirationTime(opts.expiresIn ?? "2h")
+        .sign(keyPair.privateKey);
+    }
+
+    function makeAgentSession(idToken?: string): SessionData {
+      return {
+        user: { sub: "agent|support-007" },
+        tokenSet: {
+          accessToken: "at_agent",
+          idToken,
+          expiresAt: Math.floor(Date.now() / 1000) + 3600
+        },
+        internal: {
+          sid: "sid_agent",
+          createdAt: Math.floor(Date.now() / 1000)
+        }
+      };
+    }
+
+    // STT token endpoint handler: returns an STT response shape
+    function sttTokenHandler(
+      opts: {
+        error?: string;
+        errorDescription?: string;
+        status?: number;
+      } = {}
+    ) {
+      return http.post(
+        `https://${DEFAULT.domain}/oauth/token`,
+        async ({ request }) => {
+          if (opts.error) {
+            return HttpResponse.json(
+              {
+                error: opts.error,
+                error_description: opts.errorDescription ?? opts.error
+              },
+              { status: opts.status ?? 400 }
+            );
+          }
+
+          const body = await request.text();
+          const params = new URLSearchParams(body);
+
+          // Capture params for inspection in tests via closure
+          (sttTokenHandler as any)._lastParams = params;
+
+          return HttpResponse.json({
+            issued_token_type: STT_URN,
+            access_token: "stt_opaque_" + params.get("subject_token"),
+            token_type: "N_A",
+            expires_in: 60,
+            scope: params.get("scope") ?? "openid profile email"
+          });
+        }
+      );
+    }
+
+    describe("5.1: result shape", () => {
+      it("should return a SessionTransferTokenResult with issuedTokenType = SESSION_TRANSFER_TOKEN", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(sttTokenHandler());
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "my-subject",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(result).not.toBeNull();
+        expect(result?.issuedTokenType).toBe(STT_URN);
+        expect(result?.sessionTransferToken).toContain("stt_opaque_");
+        expect(result?.expiresIn).toBe(60);
+        expect(result?.tokenType).toBe("N_A");
+      });
+
+      it("should expose sessionTransferToken, never access_token field", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(sttTokenHandler());
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "my-subject",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(result).toHaveProperty("sessionTransferToken");
+        expect(result).not.toHaveProperty("access_token");
+        expect(result).not.toHaveProperty("accessToken");
+      });
+
+      it("should not include id_token or act on the result", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(sttTokenHandler());
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "my-subject",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(result).not.toHaveProperty("act");
+        expect(result).not.toHaveProperty("idToken");
+      });
+    });
+
+    describe("5.2: actor resolution", () => {
+      it("should use the session ID token as actor_token by default", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedActorToken = "";
+        let capturedActorTokenType = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedActorToken = params.get("actor_token") ?? "";
+              capturedActorTokenType = params.get("actor_token_type") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        const [error] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(capturedActorToken).toBe(idToken);
+        expect(capturedActorTokenType).toBe(TOKEN_TYPES.ID_TOKEN);
+      });
+
+      it("should use an explicit actor token when provided", async () => {
+        const session = makeAgentSession(undefined); // no session ID token
+        const explicitToken = await makeAgentIdToken();
+
+        let capturedActorToken = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedActorToken = params.get("actor_token") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_explicit",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        const [error] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            actor: { token: explicitToken, type: TOKEN_TYPES.ID_TOKEN }
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(capturedActorToken).toBe(explicitToken);
+      });
+
+      it("should return ACTOR_UNAVAILABLE when session has no ID token and no explicit actor", async () => {
+        const session = makeAgentSession(undefined);
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error).toBeInstanceOf(CustomTokenExchangeError);
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should return ACTOR_UNAVAILABLE when session is null", async () => {
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          null
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should return ACTOR_UNAVAILABLE when session ID token is expired", async () => {
+        const expiredToken = await new jose.SignJWT({})
+          .setProtectedHeader({ alg: DEFAULT.alg })
+          .setSubject("agent|expired")
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+          .setIssuer(`https://${DEFAULT.domain}`)
+          .setAudience(DEFAULT.clientId)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+          .sign(keyPair.privateKey);
+
+        const session = makeAgentSession(expiredToken);
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("5.3: wire parameters", () => {
+      it("should set audience to urn:{domain}:session_transfer", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedAudience = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedAudience = params.get("audience") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(capturedAudience).toBe(`urn:${DEFAULT.domain}:session_transfer`);
+      });
+
+      it("should set grant_type to token-exchange", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedGrantType = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedGrantType = params.get("grant_type") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(capturedGrantType).toBe(
+          "urn:ietf:params:oauth:grant-type:token-exchange"
+        );
+      });
+
+      it("should forward reason to the token endpoint", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedReason = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedReason = params.get("reason") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        const [error] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            reason: "Investigating TCK-4821"
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(capturedReason).toBe("Investigating TCK-4821");
+      });
+
+      it("should forward organization to the token endpoint", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedOrg = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedOrg = params.get("organization") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            organization: "org_globex"
+          },
+          session
+        );
+
+        expect(capturedOrg).toBe("org_globex");
+      });
+
+      it("should forward additionalParameters to the token endpoint", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedCustomParam = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedCustomParam = params.get("ticket_id") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            additionalParameters: { ticket_id: "TCK-4821" }
+          },
+          session
+        );
+
+        expect(capturedCustomParam).toBe("TCK-4821");
+      });
+    });
+
+    describe("5.4: STT never persisted / no act on response", () => {
+      it("should not include the STT in any session-like field on the result", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(sttTokenHandler());
+
+        const [, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        // Result must only have the documented fields
+        const allowedKeys = new Set([
+          "sessionTransferToken",
+          "issuedTokenType",
+          "expiresIn",
+          "tokenType"
+        ]);
+        for (const key of Object.keys(result ?? {})) {
+          expect(allowedKeys.has(key)).toBe(true);
+        }
+      });
+    });
+
+    describe("5.5: server error mapping", () => {
+      it("should return SETACTOR_REQUIRED when server returns setactor_required", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(
+          sttTokenHandler({
+            error: "setactor_required",
+            errorDescription:
+              "setActor is required when requesting a session transfer token via token exchange.",
+            status: 400
+          })
+        );
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.SETACTOR_REQUIRED
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should return SESSION_TRANSFER_DISABLED when feature flag is off", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(
+          sttTokenHandler({
+            error: "session_transfer_disabled",
+            errorDescription:
+              "Session Transfer Tokens cannot be requested on this tenant.",
+            status: 400
+          })
+        );
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should return EXCHANGE_FAILED for generic server errors", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        server.use(
+          sttTokenHandler({
+            error: "server_error",
+            errorDescription: "Internal server error",
+            status: 500
+          })
+        );
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(CustomTokenExchangeErrorCode.EXCHANGE_FAILED);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("5.6: input validation", () => {
+      it("should return MISSING_SUBJECT_TOKEN when subjectToken is empty", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          { subjectToken: "", subjectTokenType: STT_SUBJECT_TOKEN_TYPE },
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.MISSING_SUBJECT_TOKEN
+        );
+        expect(result).toBeNull();
+      });
+
+      it("should return INVALID_SUBJECT_TOKEN_TYPE for a short subjectTokenType", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          { subjectToken: "valid", subjectTokenType: "urn:a:b" }, // < 10 chars
+          session
+        );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.INVALID_SUBJECT_TOKEN_TYPE
+        );
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("5.7: buildSessionTransferRedirect", () => {
+      it("should build a redirect URL with session_transfer_token param", () => {
+        const result = {
+          sessionTransferToken: "stt_abc123",
+          issuedTokenType: STT_URN,
+          expiresIn: 60
+        };
+
+        const redirect = authClient.buildSessionTransferRedirect(
+          "https://app.example.com/auth/login",
+          result
+        );
+
+        expect(redirect.status).toBeGreaterThanOrEqual(300);
+        expect(redirect.status).toBeLessThan(400);
+        const location = redirect.headers.get("location") ?? "";
+        const url = new URL(location);
+        expect(url.searchParams.get("session_transfer_token")).toBe(
+          "stt_abc123"
+        );
+        expect(url.origin).toBe("https://app.example.com");
+        expect(url.pathname).toBe("/auth/login");
+      });
+
+      it("should URL-encode the STT value", () => {
+        const result = {
+          sessionTransferToken: "stt_with+special=chars&more",
+          issuedTokenType: STT_URN,
+          expiresIn: 60
+        };
+
+        const redirect = authClient.buildSessionTransferRedirect(
+          "https://app.example.com/auth/login",
+          result
+        );
+
+        const location = redirect.headers.get("location") ?? "";
+        const url = new URL(location);
+        // searchParams.get() decodes it — should round-trip cleanly
+        expect(url.searchParams.get("session_transfer_token")).toBe(
+          "stt_with+special=chars&more"
+        );
+      });
+
+      it("should append organization when provided via opts", () => {
+        const result = {
+          sessionTransferToken: "stt_org_flow",
+          issuedTokenType: STT_URN,
+          expiresIn: 60
+        };
+
+        const redirect = authClient.buildSessionTransferRedirect(
+          "https://app.example.com/auth/login",
+          result,
+          { organization: "org_globex" }
+        );
+
+        const location = redirect.headers.get("location") ?? "";
+        const url = new URL(location);
+        expect(url.searchParams.get("organization")).toBe("org_globex");
+        expect(url.searchParams.get("session_transfer_token")).toBe(
+          "stt_org_flow"
+        );
+      });
+
+      it("should not append organization when not provided", () => {
+        const result = {
+          sessionTransferToken: "stt_no_org",
+          issuedTokenType: STT_URN,
+          expiresIn: 60
+        };
+
+        const redirect = authClient.buildSessionTransferRedirect(
+          "https://app.example.com/auth/login",
+          result
+        );
+
+        const location = redirect.headers.get("location") ?? "";
+        const url = new URL(location);
+        expect(url.searchParams.has("organization")).toBe(false);
+      });
+    });
+
+    describe("5.8: backward compatibility — existing CTE tests unaffected", () => {
+      it("customTokenExchange should still work after adding STT methods", async () => {
+        const [error, response] = await authClient.customTokenExchange({
+          subjectToken: "legacy-token",
+          subjectTokenType: "urn:acme:legacy-token"
+        });
+
+        expect(error).toBeNull();
+        expect(response?.accessToken).toMatch(/^at_cte_test_/);
+        expect(response?.tokenType.toLowerCase()).toBe("bearer");
+      });
+
+      it("customTokenExchange response should not have sessionTransferToken field", async () => {
+        const [, response] = await authClient.customTokenExchange({
+          subjectToken: "legacy-token",
+          subjectTokenType: "urn:acme:legacy-token"
+        });
+
+        expect(response).not.toHaveProperty("sessionTransferToken");
+        expect(response).not.toHaveProperty("issuedTokenType");
+      });
     });
   });
 });

--- a/src/server/custom-token-exchange.test.ts
+++ b/src/server/custom-token-exchange.test.ts
@@ -1388,6 +1388,107 @@ describe("Custom Token Exchange", () => {
 
         expect(capturedCustomParam).toBe("TCK-4821");
       });
+
+      it("should NOT let additionalParameters override SDK-managed params", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedAudience = "";
+        let capturedActorToken = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedAudience = params.get("audience") ?? "";
+              capturedActorToken = params.get("actor_token") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            additionalParameters: {
+              audience: "urn:evil:override",
+              actor_token: "spoofed-actor"
+            }
+          },
+          session
+        );
+
+        // Managed params win — the injected overrides are ignored.
+        expect(capturedAudience).toBe(`urn:${DEFAULT.domain}:session_transfer`);
+        expect(capturedActorToken).toBe(idToken);
+      });
+
+      // MCD: the audience must be built from the domain the request is served on,
+      // not a fixed configured domain, so the STT is issued for the right domain.
+      it("should build the audience from the effective request domain (MCD)", async () => {
+        const otherDomain = "brand-b.custom.example.com";
+        const transactionStore = new TransactionStore({ secret });
+        const sessionStore = new StatelessSessionStore({ secret });
+        const mcdClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+          domain: otherDomain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          secret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          routes: getDefaultRoutes()
+        });
+
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedAudience = "";
+        server.use(
+          http.get(
+            `https://${otherDomain}/.well-known/openid-configuration`,
+            () =>
+              HttpResponse.json({
+                issuer: `https://${otherDomain}`,
+                authorization_endpoint: `https://${otherDomain}/authorize`,
+                token_endpoint: `https://${otherDomain}/oauth/token`,
+                jwks_uri: `https://${otherDomain}/.well-known/jwks.json`,
+                response_types_supported: ["code"],
+                subject_types_supported: ["public"],
+                id_token_signing_alg_values_supported: ["RS256"]
+              })
+          ),
+          http.post(
+            `https://${otherDomain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              capturedAudience = params.get("audience") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await mcdClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+          },
+          session
+        );
+
+        expect(capturedAudience).toBe(`urn:${otherDomain}:session_transfer`);
+      });
     });
 
     describe("5.4: STT never persisted / no act on response", () => {

--- a/src/server/custom-token-exchange.test.ts
+++ b/src/server/custom-token-exchange.test.ts
@@ -14,7 +14,8 @@ import {
 
 import {
   CustomTokenExchangeError,
-  CustomTokenExchangeErrorCode
+  CustomTokenExchangeErrorCode,
+  MfaRequiredError
 } from "../errors/index.js";
 import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
@@ -977,12 +978,16 @@ describe("Custom Token Exchange", () => {
         .sign(keyPair.privateKey);
     }
 
-    function makeAgentSession(idToken?: string): SessionData {
+    function makeAgentSession(
+      idToken?: string,
+      refreshToken?: string
+    ): SessionData {
       return {
         user: { sub: "agent|support-007" },
         tokenSet: {
           accessToken: "at_agent",
           idToken,
+          refreshToken,
           expiresAt: Math.floor(Date.now() / 1000) + 3600
         },
         internal: {
@@ -1161,6 +1166,53 @@ describe("Custom Token Exchange", () => {
         expect(capturedActorToken).toBe(explicitToken);
       });
 
+      it("should NOT attempt a session refresh when an explicit actor is blank, even if the session has a refresh token", async () => {
+        const idToken = await makeAgentIdToken();
+        // Session has a perfectly usable ID token and refresh token — irrelevant here,
+        // since a blank explicit actor should fail on its own terms without touching them.
+        const session = makeAgentSession(
+          idToken,
+          "rt_agent_should_not_be_used"
+        );
+
+        let refreshAttempted = false;
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              if (params.get("grant_type") === "refresh_token") {
+                refreshAttempted = true;
+              }
+              return HttpResponse.json(
+                { error: "unsupported_grant_type" },
+                { status: 400 }
+              );
+            }
+          )
+        );
+
+        const [error, result, refreshedSession] =
+          await authClient.requestSessionTransferToken(
+            {
+              subjectToken: "sub-token",
+              subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+              actor: { token: "  ", type: TOKEN_TYPES.ID_TOKEN }
+            },
+            session
+          );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+        expect(refreshedSession).toBeNull();
+        // A bad explicit actor is a caller input error the session can't fix —
+        // refreshing the agent's own tokens must never be attempted for it.
+        expect(refreshAttempted).toBe(false);
+      });
+
       it("should return ACTOR_UNAVAILABLE when session has no ID token and no explicit actor", async () => {
         const session = makeAgentSession(undefined);
 
@@ -1196,6 +1248,68 @@ describe("Custom Token Exchange", () => {
         expect(result).toBeNull();
       });
 
+      it("should return ACTOR_UNAVAILABLE when the session was created for a different MCD domain", async () => {
+        // Defense-in-depth: Auth0Client.requestSessionTransferToken already enforces this via
+        // getSession() -> getSessionWithDomainCheck, but AuthClient.requestSessionTransferToken
+        // can be called directly, so it must not trust a session tagged for another domain.
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+        session.internal.mcd = {
+          domain: "brand-b.custom.example.com",
+          issuer: `https://brand-b.custom.example.com/`
+        };
+
+        const [error, result, refreshedSession] =
+          await authClient.requestSessionTransferToken(
+            {
+              subjectToken: "sub-token",
+              subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+            },
+            session
+          );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+        expect(refreshedSession).toBeNull();
+      });
+
+      it("should allow an explicit actor even when the session is tagged for a different MCD domain", async () => {
+        // An explicit actor bypasses the session entirely, so the cross-domain guard —
+        // which only protects session-sourced actors — must not apply to it.
+        const session = makeAgentSession(undefined);
+        session.internal.mcd = {
+          domain: "brand-b.custom.example.com",
+          issuer: `https://brand-b.custom.example.com/`
+        };
+        const explicitToken = await makeAgentIdToken();
+
+        server.use(
+          http.post(`https://${DEFAULT.domain}/oauth/token`, async () => {
+            return HttpResponse.json({
+              issued_token_type: STT_URN,
+              access_token: "stt_explicit_mcd",
+              token_type: "N_A",
+              expires_in: 60
+            });
+          })
+        );
+
+        const [error, result] = await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            actor: { token: explicitToken, type: TOKEN_TYPES.ID_TOKEN }
+          },
+          session
+        );
+
+        expect(error).toBeNull();
+        expect(result?.sessionTransferToken).toBe("stt_explicit_mcd");
+      });
+
       it("should return ACTOR_UNAVAILABLE when session ID token is expired", async () => {
         const expiredToken = await new jose.SignJWT({})
           .setProtectedHeader({ alg: DEFAULT.alg })
@@ -1220,6 +1334,153 @@ describe("Custom Token Exchange", () => {
           CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
         );
         expect(result).toBeNull();
+      });
+
+      it("should refresh the session ID token when expired and a refresh token is present, then use the refreshed token as actor", async () => {
+        const expiredToken = await new jose.SignJWT({})
+          .setProtectedHeader({ alg: DEFAULT.alg })
+          .setSubject("agent|expired")
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+          .setIssuer(`https://${DEFAULT.domain}`)
+          .setAudience(DEFAULT.clientId)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+          .sign(keyPair.privateKey);
+
+        const refreshedIdToken = await makeAgentIdToken();
+
+        let capturedActorToken = "";
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              const grantType = params.get("grant_type");
+
+              if (grantType === "refresh_token") {
+                return HttpResponse.json({
+                  token_type: "Bearer",
+                  access_token: "at_agent_refreshed",
+                  refresh_token: "rt_agent_rotated",
+                  id_token: refreshedIdToken,
+                  expires_in: 3600,
+                  scope: "openid profile email offline_access"
+                });
+              }
+
+              // STT exchange — capture the actor_token used
+              capturedActorToken = params.get("actor_token") ?? "";
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_refreshed_actor",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        const session = makeAgentSession(expiredToken, "rt_agent_original");
+        const [error, result, refreshedSession] =
+          await authClient.requestSessionTransferToken(
+            {
+              subjectToken: "sub-token",
+              subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+            },
+            session
+          );
+
+        expect(error).toBeNull();
+        expect(result?.sessionTransferToken).toBe("stt_refreshed_actor");
+        expect(capturedActorToken).toBe(refreshedIdToken);
+        // The refreshed token set must be returned so the caller can persist it —
+        // refresh token rotation invalidates the old refresh token in the session cookie.
+        expect(refreshedSession?.tokenSet.refreshToken).toBe(
+          "rt_agent_rotated"
+        );
+        expect(refreshedSession?.tokenSet.idToken).toBe(refreshedIdToken);
+        // session.user must reflect the claims of the *new* ID token, not the expired one —
+        // otherwise the persisted session would carry stale claims (e.g. old auth_time/sub).
+        expect(refreshedSession?.user.sub).toBe("agent|support-007");
+      });
+
+      it("should surface MfaRequiredError when the refresh grant requires step-up, instead of collapsing to ACTOR_UNAVAILABLE", async () => {
+        const expiredToken = await new jose.SignJWT({})
+          .setProtectedHeader({ alg: DEFAULT.alg })
+          .setSubject("agent|expired")
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+          .setIssuer(`https://${DEFAULT.domain}`)
+          .setAudience(DEFAULT.clientId)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+          .sign(keyPair.privateKey);
+
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              const params = new URLSearchParams(await request.text());
+              if (params.get("grant_type") === "refresh_token") {
+                return HttpResponse.json(
+                  {
+                    error: "mfa_required",
+                    error_description:
+                      "Multi-factor authentication is required.",
+                    mfa_token: "mfa_tok_abc"
+                  },
+                  { status: 403 }
+                );
+              }
+              return HttpResponse.json(
+                { error: "unsupported_grant_type" },
+                { status: 400 }
+              );
+            }
+          )
+        );
+
+        const session = makeAgentSession(expiredToken, "rt_agent_original");
+        const [error, result, refreshedSession] =
+          await authClient.requestSessionTransferToken(
+            {
+              subjectToken: "sub-token",
+              subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+            },
+            session
+          );
+
+        expect(error).toBeInstanceOf(MfaRequiredError);
+        // mfa_token is encrypted (with audience/scope context) before being handed back,
+        // so it won't match the raw server value — just confirm one was produced.
+        expect((error as MfaRequiredError).mfa_token).toBeTruthy();
+        expect(result).toBeNull();
+        expect(refreshedSession).toBeNull();
+      });
+
+      it("should return ACTOR_UNAVAILABLE when session ID token is expired and there is no refresh token", async () => {
+        const expiredToken = await new jose.SignJWT({})
+          .setProtectedHeader({ alg: DEFAULT.alg })
+          .setSubject("agent|expired")
+          .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+          .setIssuer(`https://${DEFAULT.domain}`)
+          .setAudience(DEFAULT.clientId)
+          .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+          .sign(keyPair.privateKey);
+
+        const session = makeAgentSession(expiredToken); // no refreshToken
+        const [error, result, refreshedSession] =
+          await authClient.requestSessionTransferToken(
+            {
+              subjectToken: "sub-token",
+              subjectTokenType: STT_SUBJECT_TOKEN_TYPE
+            },
+            session
+          );
+
+        expect(error).not.toBeNull();
+        expect(error?.code).toBe(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE
+        );
+        expect(result).toBeNull();
+        expect(refreshedSession).toBeNull();
       });
     });
 
@@ -1428,6 +1689,46 @@ describe("Custom Token Exchange", () => {
         // Managed params win — the injected overrides are ignored.
         expect(capturedAudience).toBe(`urn:${DEFAULT.domain}:session_transfer`);
         expect(capturedActorToken).toBe(idToken);
+      });
+
+      it("should NOT duplicate organization or reason when also passed via additionalParameters", async () => {
+        const idToken = await makeAgentIdToken();
+        const session = makeAgentSession(idToken);
+
+        let capturedParams: URLSearchParams | undefined;
+        server.use(
+          http.post(
+            `https://${DEFAULT.domain}/oauth/token`,
+            async ({ request }) => {
+              capturedParams = new URLSearchParams(await request.text());
+              return HttpResponse.json({
+                issued_token_type: STT_URN,
+                access_token: "stt_abc",
+                token_type: "N_A",
+                expires_in: 60
+              });
+            }
+          )
+        );
+
+        await authClient.requestSessionTransferToken(
+          {
+            subjectToken: "sub-token",
+            subjectTokenType: STT_SUBJECT_TOKEN_TYPE,
+            organization: "org_legit",
+            reason: "legit reason",
+            additionalParameters: {
+              organization: "org_injected",
+              reason: "injected reason"
+            }
+          },
+          session
+        );
+
+        // Each managed param must appear exactly once, with the SDK-set value —
+        // additionalParameters must not be able to append a second, conflicting copy.
+        expect(capturedParams?.getAll("organization")).toEqual(["org_legit"]);
+        expect(capturedParams?.getAll("reason")).toEqual(["legit reason"]);
       });
 
       // MCD: the audience must be built from the domain the request is served on,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -45,3 +45,16 @@ export type {
   DiscoveryCacheOptions,
   MCDMetadata
 } from "../types/mcd.js";
+
+// Session Transfer Token (CTE Phase 2) types
+export {
+  TOKEN_TYPES,
+  SessionTransferTokenOptions,
+  SessionTransferTokenResult
+} from "../types/token-vault.js";
+
+// Session Transfer Token error codes (extends CustomTokenExchangeErrorCode)
+export {
+  CustomTokenExchangeError,
+  CustomTokenExchangeErrorCode
+} from "../errors/oauth-errors.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,7 +230,10 @@ export {
   CustomTokenExchangeOptions,
   CustomTokenExchangeResponse,
   GRANT_TYPE_CUSTOM_TOKEN_EXCHANGE,
-  SUBJECT_TOKEN_TYPES
+  SessionTransferTokenOptions,
+  SessionTransferTokenResult,
+  SUBJECT_TOKEN_TYPES,
+  TOKEN_TYPES
 } from "./token-vault.js";
 export { ConnectAccountOptions, RESPONSE_TYPES } from "./connected-accounts.js";
 export type { ChallengeWithPopupOptions } from "../client/mfa/index.js";

--- a/src/types/token-vault.ts
+++ b/src/types/token-vault.ts
@@ -211,8 +211,9 @@ export interface SessionTransferTokenOptions {
 
   /**
    * Explicit actor override. Omit to use the agent session's ID token.
-   * The ID token must be unexpired — fails with `ACTOR_UNAVAILABLE` if expired; no automatic refresh.
-   * Precedence: explicit `actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
+   * If the session ID token is expired but a refresh token is available the SDK refreshes it first.
+   * Fails with `ACTOR_UNAVAILABLE` only when no usable token can be resolved.
+   * Precedence: explicit `actor` → session ID token (refreshed if stale) → throws `ACTOR_UNAVAILABLE`.
    */
   actor?: {
     token: string;
@@ -237,7 +238,7 @@ export interface SessionTransferTokenResult {
   /** The Session Transfer Token. One-shot, ~60s. Pass to `buildSessionTransferRedirect`. */
   sessionTransferToken: string;
   /** Always `TOKEN_TYPES.SESSION_TRANSFER_TOKEN`. Branch on this, not `tokenType`. */
-  issuedTokenType: string;
+  issuedTokenType: TOKEN_TYPES.SESSION_TRANSFER_TOKEN | string;
   /** Token lifetime in seconds (~60). */
   expiresIn: number;
   /** `"N_A"` — informational only. Never branch on this. */

--- a/src/types/token-vault.ts
+++ b/src/types/token-vault.ts
@@ -1,3 +1,28 @@
+/**
+ * Token type URNs for Custom Token Exchange and Session Transfer flows (RFC 8693).
+ */
+export enum TOKEN_TYPES {
+  /**
+   * OAuth 2.0 ID token.
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8693#section-3-3.6 RFC 8693 Section 3-3.6}
+   */
+  ID_TOKEN = "urn:ietf:params:oauth:token-type:id_token",
+
+  /**
+   * OAuth 2.0 access token.
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8693#section-3-3.2 RFC 8693 Section 3-3.2}
+   */
+  ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token",
+
+  /**
+   * Session Transfer Token issued by Auth0 (Phase 2 CTE).
+   * When `issued_token_type` equals this value, the `access_token` in the response
+   * is a one-shot STT — not a usable API bearer token. Pass it to
+   * `buildSessionTransferRedirect` to start the impersonation redirect.
+   */
+  SESSION_TRANSFER_TOKEN = "urn:auth0:params:oauth:token-type:session_transfer_token"
+}
+
 export enum SUBJECT_TOKEN_TYPES {
   /**
    * Indicates that the token is an OAuth 2.0 refresh token issued by the given authorization server.
@@ -141,6 +166,81 @@ export interface ActClaim {
   /** Nested actor claim representing a delegation chain. */
   act?: ActClaim;
   [key: string]: unknown;
+}
+
+/**
+ * Options for requesting a Session Transfer Token (STT).
+ *
+ * The SDK fills in `audience`, `grant_type`, `actor_token`, and `actor_token_type`
+ * automatically. You supply `subjectToken` and `subjectTokenType` — your own proof
+ * of which customer to impersonate, validated by your Action.
+ */
+export interface SessionTransferTokenOptions {
+  /**
+   * Your proof of which customer to impersonate.
+   * Opaque to Auth0 — validated only by your CTE Action via `setUserById`.
+   * The SDK never produces this value.
+   */
+  subjectToken: string;
+
+  /**
+   * Your CTE Profile ID that routes the exchange to your Action.
+   * Same validation rules as `CustomTokenExchangeOptions.subjectTokenType` (10–100 chars, valid URI).
+   */
+  subjectTokenType: string;
+
+  /**
+   * Reason for impersonation. Forwarded to the token endpoint as a body param
+   * and readable by your Action at `event.request.body.reason`.
+   * Must be included in `setActor(...)` by your Action for it to appear as `act.reason`.
+   */
+  reason?: string;
+
+  /**
+   * Organization ID or name. Forwarded to `/authorize` by `buildSessionTransferRedirect`.
+   * Required when the STT is issued in an org context.
+   */
+  organization?: string;
+
+  /**
+   * Scopes for the impersonation session tokens.
+   * Merged with SDK default scopes (openid, profile, email).
+   * Note: `offline_access` is silently suppressed by Auth0 for impersonation sessions.
+   */
+  scope?: string;
+
+  /**
+   * Explicit actor override. Omit to use the agent session's ID token (refreshed if expired).
+   * Precedence: explicit `actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
+   */
+  actor?: {
+    token: string;
+    type: TOKEN_TYPES | string;
+  };
+
+  /**
+   * Additional custom parameters forwarded to the token endpoint.
+   * Accessible in your Action via `event.request.body`.
+   */
+  additionalParameters?: Record<string, unknown>;
+}
+
+/**
+ * Result from `requestSessionTransferToken`.
+ *
+ * Branch on `issuedTokenType`, never `tokenType`.
+ * The `sessionTransferToken` is one-shot (~60s) — pass it directly to
+ * `buildSessionTransferRedirect`. Never cache or store it.
+ */
+export interface SessionTransferTokenResult {
+  /** The Session Transfer Token. One-shot, ~60s. Pass to `buildSessionTransferRedirect`. */
+  sessionTransferToken: string;
+  /** Always `TOKEN_TYPES.SESSION_TRANSFER_TOKEN`. Branch on this, not `tokenType`. */
+  issuedTokenType: string;
+  /** Token lifetime in seconds (~60). */
+  expiresIn: number;
+  /** `"N_A"` — informational only. Never branch on this. */
+  tokenType?: string;
 }
 
 /**

--- a/src/types/token-vault.ts
+++ b/src/types/token-vault.ts
@@ -212,7 +212,8 @@ export interface SessionTransferTokenOptions {
   /**
    * Explicit actor override. Omit to use the agent session's ID token.
    * If the session ID token is expired but a refresh token is available the SDK refreshes it first.
-   * Fails with `ACTOR_UNAVAILABLE` only when no usable token can be resolved.
+   * Fails with `ACTOR_UNAVAILABLE` only when no usable token can be resolved. If that refresh
+   * itself requires MFA step-up, an `MfaRequiredError` is thrown instead.
    * Precedence: explicit `actor` → session ID token (refreshed if stale) → throws `ACTOR_UNAVAILABLE`.
    */
   actor?: {

--- a/src/types/token-vault.ts
+++ b/src/types/token-vault.ts
@@ -210,7 +210,8 @@ export interface SessionTransferTokenOptions {
   scope?: string;
 
   /**
-   * Explicit actor override. Omit to use the agent session's ID token (refreshed if expired).
+   * Explicit actor override. Omit to use the agent session's ID token.
+   * The ID token must be unexpired — fails with `ACTOR_UNAVAILABLE` if expired; no automatic refresh.
    * Precedence: explicit `actor` → session ID token → throws `ACTOR_UNAVAILABLE`.
    */
   actor?: {

--- a/src/types/token-vault.ts
+++ b/src/types/token-vault.ts
@@ -239,8 +239,8 @@ export interface SessionTransferTokenResult {
   sessionTransferToken: string;
   /** Always `TOKEN_TYPES.SESSION_TRANSFER_TOKEN`. Branch on this, not `tokenType`. */
   issuedTokenType: TOKEN_TYPES.SESSION_TRANSFER_TOKEN | string;
-  /** Token lifetime in seconds (~60). */
-  expiresIn: number;
+  /** Token lifetime in seconds as reported by the server. Undefined when the server omits it. */
+  expiresIn?: number;
   /** `"N_A"` — informational only. Never branch on this. */
   tokenType?: string;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,6 +10,13 @@ export const DEFAULT_SCOPES = [
 ].join(" ");
 
 /**
+ * Default scopes for Session Transfer Token exchanges — same as {@link DEFAULT_SCOPES}
+ * minus `offline_access`. Auth0 silently drops `offline_access` for STT-issued
+ * impersonation sessions, so requesting it here would just be a scope the server ignores.
+ */
+export const DEFAULT_STT_SCOPES = ["openid", "profile", "email"].join(" ");
+
+/**
  * Default clock skew in seconds for DPoP proof validation.
  *
  * Clock skew adjusts the assumed current time when validating DPoP proofs.

--- a/src/utils/session-transfer-helpers.test.ts
+++ b/src/utils/session-transfer-helpers.test.ts
@@ -8,6 +8,7 @@ import {
 import { SessionData, TOKEN_TYPES } from "../types/index.js";
 import {
   buildSessionTransferAudience,
+  buildSessionTransferRedirectUrl,
   mapSttServerError,
   parseSessionTransferTokenResponse,
   resolveActorFromSession
@@ -202,7 +203,140 @@ describe("resolveActorFromSession", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3: parseSessionTransferTokenResponse
+// 3: buildSessionTransferRedirectUrl
+// ---------------------------------------------------------------------------
+
+describe("buildSessionTransferRedirectUrl", () => {
+  it("should build a redirect URL for an https target", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "https://app.example.com/auth/login",
+      "stt_abc"
+    );
+
+    expect(url).toBe(
+      "https://app.example.com/auth/login?session_transfer_token=stt_abc"
+    );
+  });
+
+  it("should allow http for localhost", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "http://localhost:3000/auth/login",
+      "stt_abc"
+    );
+
+    expect(url).toContain("session_transfer_token=stt_abc");
+  });
+
+  it("should allow http for 127.0.0.1", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "http://127.0.0.1:3000/auth/login",
+      "stt_abc"
+    );
+
+    expect(url).toContain("session_transfer_token=stt_abc");
+  });
+
+  it("should allow http for the [::1] IPv6 loopback address", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "http://[::1]:3000/auth/login",
+      "stt_abc"
+    );
+
+    expect(url).toContain("session_transfer_token=stt_abc");
+  });
+
+  it("should reject a non-loopback http target", () => {
+    expect(() =>
+      buildSessionTransferRedirectUrl(
+        "http://app.example.com/auth/login",
+        "stt_abc"
+      )
+    ).toThrow(CustomTokenExchangeError);
+    expect(() =>
+      buildSessionTransferRedirectUrl(
+        "http://app.example.com/auth/login",
+        "stt_abc"
+      )
+    ).toThrow(/must use https/);
+  });
+
+  it("should reject a javascript: scheme target", () => {
+    expect(() =>
+      buildSessionTransferRedirectUrl("javascript:alert(1)", "stt_abc")
+    ).toThrow(CustomTokenExchangeError);
+  });
+
+  it("should reject a data: scheme target", () => {
+    expect(() =>
+      buildSessionTransferRedirectUrl(
+        "data:text/html,<script></script>",
+        "stt_abc"
+      )
+    ).toThrow(CustomTokenExchangeError);
+  });
+
+  it("should reject a non-absolute URL", () => {
+    expect(() =>
+      buildSessionTransferRedirectUrl("/auth/login", "stt_abc")
+    ).toThrow(CustomTokenExchangeError);
+    expect(() =>
+      buildSessionTransferRedirectUrl("/auth/login", "stt_abc")
+    ).toThrow(/not an absolute URL/);
+  });
+
+  it("should reject a malformed URL", () => {
+    expect(() =>
+      buildSessionTransferRedirectUrl("not a url at all", "stt_abc")
+    ).toThrow(CustomTokenExchangeError);
+  });
+
+  it("should throw CustomTokenExchangeError with EXCHANGE_FAILED code on rejection", () => {
+    try {
+      buildSessionTransferRedirectUrl(
+        "http://app.example.com/auth/login",
+        "stt_abc"
+      );
+      expect.fail("expected buildSessionTransferRedirectUrl to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CustomTokenExchangeError);
+      expect((err as CustomTokenExchangeError).code).toBe(
+        CustomTokenExchangeErrorCode.EXCHANGE_FAILED
+      );
+    }
+  });
+
+  it("should append organization when provided", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "https://app.example.com/auth/login",
+      "stt_abc",
+      { organization: "org_globex" }
+    );
+
+    expect(url).toContain("organization=org_globex");
+  });
+
+  it("should not append organization when not provided", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "https://app.example.com/auth/login",
+      "stt_abc"
+    );
+
+    expect(url).not.toContain("organization");
+  });
+
+  it("should preserve an existing query string on the target URL", () => {
+    const url = buildSessionTransferRedirectUrl(
+      "https://app.example.com/auth/login?returnTo=/home",
+      "stt_abc"
+    );
+
+    expect(url).toContain("returnTo=%2Fhome");
+    expect(url).toContain("session_transfer_token=stt_abc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4: parseSessionTransferTokenResponse
 // ---------------------------------------------------------------------------
 
 describe("parseSessionTransferTokenResponse", () => {
@@ -264,7 +398,7 @@ describe("parseSessionTransferTokenResponse", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4: mapSttServerError
+// 5: mapSttServerError
 // ---------------------------------------------------------------------------
 
 describe("mapSttServerError", () => {

--- a/src/utils/session-transfer-helpers.test.ts
+++ b/src/utils/session-transfer-helpers.test.ts
@@ -1,0 +1,301 @@
+import * as jose from "jose";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  CustomTokenExchangeError,
+  CustomTokenExchangeErrorCode
+} from "../errors/index.js";
+import { SessionData } from "../types/index.js";
+import { TOKEN_TYPES } from "../types/token-vault.js";
+import {
+  buildSessionTransferAudience,
+  mapSttServerError,
+  parseSessionTransferTokenResponse,
+  resolveActorFromSession
+} from "./session-transfer-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ALG = "RS256" as const;
+let keyPair: jose.GenerateKeyPairResult;
+
+beforeAll(async () => {
+  keyPair = await jose.generateKeyPair(ALG);
+});
+
+afterAll(() => {});
+
+async function makeIdToken(opts: {
+  expiresIn?: string;
+  sub?: string;
+}): Promise<string> {
+  return new jose.SignJWT({})
+    .setProtectedHeader({ alg: ALG })
+    .setSubject(opts.sub ?? "agent|123")
+    .setIssuedAt()
+    .setIssuer("https://test.auth0.local/")
+    .setAudience("test_client")
+    .setExpirationTime(opts.expiresIn ?? "2h")
+    .sign(keyPair.privateKey);
+}
+
+function makeSession(idToken?: string): SessionData {
+  return {
+    user: { sub: "agent|123" },
+    tokenSet: {
+      accessToken: "at_agent",
+      idToken,
+      expiresAt: Math.floor(Date.now() / 1000) + 3600
+    },
+    internal: {
+      sid: "sid_123",
+      createdAt: Math.floor(Date.now() / 1000)
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1: buildSessionTransferAudience
+// ---------------------------------------------------------------------------
+
+describe("buildSessionTransferAudience", () => {
+  it("should build the correct STT audience URN for a given domain", () => {
+    const audience = buildSessionTransferAudience("example.us.auth0.com");
+    expect(audience).toBe("urn:example.us.auth0.com:session_transfer");
+  });
+
+  it("should use the exact domain string passed in", () => {
+    const audience = buildSessionTransferAudience("myapp.auth0.com");
+    expect(audience).toBe("urn:myapp.auth0.com:session_transfer");
+  });
+
+  it("should handle custom domain strings", () => {
+    const audience = buildSessionTransferAudience("auth.northwind.com");
+    expect(audience).toBe("urn:auth.northwind.com:session_transfer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2: resolveActorFromSession
+// ---------------------------------------------------------------------------
+
+describe("resolveActorFromSession", () => {
+  describe("explicit actor override", () => {
+    it("should return the explicit actor when provided", async () => {
+      const idToken = await makeIdToken({});
+      const session = makeSession(idToken);
+      const [error, actor] = resolveActorFromSession(session, {
+        token: "explicit-token",
+        type: TOKEN_TYPES.ID_TOKEN
+      });
+
+      expect(error).toBeNull();
+      expect(actor?.token).toBe("explicit-token");
+      expect(actor?.type).toBe(TOKEN_TYPES.ID_TOKEN);
+    });
+
+    it("should return the explicit actor even when session has no ID token", () => {
+      const session = makeSession(undefined);
+      const [error, actor] = resolveActorFromSession(session, {
+        token: "explicit-fallback",
+        type: TOKEN_TYPES.ID_TOKEN
+      });
+
+      expect(error).toBeNull();
+      expect(actor?.token).toBe("explicit-fallback");
+    });
+
+    it("should return ACTOR_UNAVAILABLE when explicit actor token is empty", () => {
+      const session = makeSession(undefined);
+      const [error, actor] = resolveActorFromSession(session, {
+        token: "",
+        type: TOKEN_TYPES.ID_TOKEN
+      });
+
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(actor).toBeNull();
+    });
+
+    it("should return ACTOR_UNAVAILABLE when explicit actor token is whitespace", () => {
+      const [error, actor] = resolveActorFromSession(null, {
+        token: "   ",
+        type: TOKEN_TYPES.ID_TOKEN
+      });
+
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(actor).toBeNull();
+    });
+  });
+
+  describe("session ID token sourcing", () => {
+    it("should use the session ID token as the actor when no explicit actor is given", async () => {
+      const idToken = await makeIdToken({});
+      const session = makeSession(idToken);
+      const [error, actor] = resolveActorFromSession(session);
+
+      expect(error).toBeNull();
+      expect(actor?.token).toBe(idToken);
+      expect(actor?.type).toBe(TOKEN_TYPES.ID_TOKEN);
+    });
+
+    it("should return ACTOR_UNAVAILABLE when session has no ID token", () => {
+      const session = makeSession(undefined);
+      const [error, actor] = resolveActorFromSession(session);
+
+      expect(error).not.toBeNull();
+      expect(error).toBeInstanceOf(CustomTokenExchangeError);
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(error?.message).toContain("no ID token");
+      expect(actor).toBeNull();
+    });
+
+    it("should return ACTOR_UNAVAILABLE when session is null", () => {
+      const [error, actor] = resolveActorFromSession(null);
+
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(actor).toBeNull();
+    });
+
+    it("should return ACTOR_UNAVAILABLE when session ID token has expired", async () => {
+      // Sign with a negative expiry so it is already expired
+      const expiredToken = await new jose.SignJWT({})
+        .setProtectedHeader({ alg: ALG })
+        .setSubject("agent|expired")
+        .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+        .setIssuer("https://test.auth0.local/")
+        .setAudience("test_client")
+        .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+        .sign(keyPair.privateKey);
+
+      const session = makeSession(expiredToken);
+      const [error, actor] = resolveActorFromSession(session);
+
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(error?.message).toContain("expired");
+      expect(actor).toBeNull();
+    });
+
+    it("should return ACTOR_UNAVAILABLE when session ID token is malformed", () => {
+      const session = makeSession("not.a.valid.jwt");
+      const [error, actor] = resolveActorFromSession(session);
+
+      expect(error).not.toBeNull();
+      expect(error?.code).toBe(CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE);
+      expect(actor).toBeNull();
+    });
+
+    it("should accept a valid non-expired session ID token", async () => {
+      const idToken = await makeIdToken({ expiresIn: "1h" });
+      const session = makeSession(idToken);
+      const [error, actor] = resolveActorFromSession(session);
+
+      expect(error).toBeNull();
+      expect(actor?.token).toBe(idToken);
+      expect(actor?.type).toBe(TOKEN_TYPES.ID_TOKEN);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3: parseSessionTransferTokenResponse
+// ---------------------------------------------------------------------------
+
+describe("parseSessionTransferTokenResponse", () => {
+  it("should map raw token endpoint fields to camelCase result", () => {
+    const result = parseSessionTransferTokenResponse({
+      access_token: "stt_opaque_token_abc",
+      issued_token_type:
+        "urn:auth0:params:oauth:token-type:session_transfer_token",
+      expires_in: 60,
+      token_type: "N_A"
+    });
+
+    expect(result.sessionTransferToken).toBe("stt_opaque_token_abc");
+    expect(result.issuedTokenType).toBe(
+      "urn:auth0:params:oauth:token-type:session_transfer_token"
+    );
+    expect(result.expiresIn).toBe(60);
+    expect(result.tokenType).toBe("N_A");
+  });
+
+  it("should default expiresIn to 60 when absent", () => {
+    const result = parseSessionTransferTokenResponse({
+      access_token: "stt_abc",
+      issued_token_type: TOKEN_TYPES.SESSION_TRANSFER_TOKEN
+    });
+
+    expect(result.expiresIn).toBe(60);
+  });
+
+  it("should leave tokenType undefined when absent", () => {
+    const result = parseSessionTransferTokenResponse({
+      access_token: "stt_abc",
+      issued_token_type: TOKEN_TYPES.SESSION_TRANSFER_TOKEN
+    });
+
+    expect(result.tokenType).toBeUndefined();
+  });
+
+  it("should not include any access_token field under that name", () => {
+    const result = parseSessionTransferTokenResponse({
+      access_token: "stt_abc",
+      issued_token_type: TOKEN_TYPES.SESSION_TRANSFER_TOKEN,
+      expires_in: 60
+    });
+
+    expect(result).not.toHaveProperty("access_token");
+    expect(result).not.toHaveProperty("issued_token_type");
+  });
+
+  it("should match the SESSION_TRANSFER_TOKEN constant", () => {
+    const result = parseSessionTransferTokenResponse({
+      access_token: "stt_xyz",
+      issued_token_type: TOKEN_TYPES.SESSION_TRANSFER_TOKEN,
+      expires_in: 60
+    });
+
+    expect(result.issuedTokenType).toBe(TOKEN_TYPES.SESSION_TRANSFER_TOKEN);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4: mapSttServerError
+// ---------------------------------------------------------------------------
+
+describe("mapSttServerError", () => {
+  it("should map setactor_required to SETACTOR_REQUIRED", () => {
+    expect(mapSttServerError("setactor_required")).toBe(
+      CustomTokenExchangeErrorCode.SETACTOR_REQUIRED
+    );
+  });
+
+  it("should map server errors containing setactor (case-insensitive) to SETACTOR_REQUIRED", () => {
+    expect(mapSttServerError("SETACTOR_IS_REQUIRED")).toBe(
+      CustomTokenExchangeErrorCode.SETACTOR_REQUIRED
+    );
+  });
+
+  it("should map session_transfer_disabled to SESSION_TRANSFER_DISABLED", () => {
+    expect(mapSttServerError("session_transfer_disabled")).toBe(
+      CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED
+    );
+  });
+
+  it("should map errors containing session_transfer (case-insensitive)", () => {
+    expect(
+      mapSttServerError("Session_Transfer_Tokens_Cannot_Be_Requested")
+    ).toBe(CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED);
+  });
+
+  it("should return null for unrelated error codes", () => {
+    expect(mapSttServerError("invalid_grant")).toBeNull();
+    expect(mapSttServerError("server_error")).toBeNull();
+    expect(mapSttServerError("unknown_error")).toBeNull();
+  });
+});

--- a/src/utils/session-transfer-helpers.test.ts
+++ b/src/utils/session-transfer-helpers.test.ts
@@ -5,8 +5,7 @@ import {
   CustomTokenExchangeError,
   CustomTokenExchangeErrorCode
 } from "../errors/index.js";
-import { SessionData } from "../types/index.js";
-import { TOKEN_TYPES } from "../types/token-vault.js";
+import { SessionData, TOKEN_TYPES } from "../types/index.js";
 import {
   buildSessionTransferAudience,
   mapSttServerError,

--- a/src/utils/session-transfer-helpers.test.ts
+++ b/src/utils/session-transfer-helpers.test.ts
@@ -223,13 +223,13 @@ describe("parseSessionTransferTokenResponse", () => {
     expect(result.tokenType).toBe("N_A");
   });
 
-  it("should default expiresIn to 60 when absent", () => {
+  it("should leave expiresIn undefined when absent", () => {
     const result = parseSessionTransferTokenResponse({
       access_token: "stt_abc",
       issued_token_type: TOKEN_TYPES.SESSION_TRANSFER_TOKEN
     });
 
-    expect(result.expiresIn).toBe(60);
+    expect(result.expiresIn).toBeUndefined();
   });
 
   it("should leave tokenType undefined when absent", () => {
@@ -274,10 +274,8 @@ describe("mapSttServerError", () => {
     );
   });
 
-  it("should map server errors containing setactor (case-insensitive) to SETACTOR_REQUIRED", () => {
-    expect(mapSttServerError("SETACTOR_IS_REQUIRED")).toBe(
-      CustomTokenExchangeErrorCode.SETACTOR_REQUIRED
-    );
+  it("should return null for codes that merely contain setactor but are not the exact code", () => {
+    expect(mapSttServerError("SETACTOR_IS_REQUIRED")).toBeNull();
   });
 
   it("should map session_transfer_disabled to SESSION_TRANSFER_DISABLED", () => {
@@ -286,10 +284,10 @@ describe("mapSttServerError", () => {
     );
   });
 
-  it("should map errors containing session_transfer (case-insensitive)", () => {
+  it("should return null for codes that merely contain session_transfer but are not the exact code", () => {
     expect(
       mapSttServerError("Session_Transfer_Tokens_Cannot_Be_Requested")
-    ).toBe(CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED);
+    ).toBeNull();
   });
 
   it("should return null for unrelated error codes", () => {

--- a/src/utils/session-transfer-helpers.test.ts
+++ b/src/utils/session-transfer-helpers.test.ts
@@ -298,4 +298,13 @@ describe("mapSttServerError", () => {
     expect(mapSttServerError("server_error")).toBeNull();
     expect(mapSttServerError("unknown_error")).toBeNull();
   });
+
+  // Per the SDK requirements, the SDK keys off the machine `error` code only and does
+  // NOT remap based on `error_description` text. Today the server returns a generic
+  // `invalid_request` for these failures, so they fall through to EXCHANGE_FAILED
+  // (with the raw message surfaced); the mapping fires the day Auth0 emits a
+  // machine-readable code.
+  it("should return null for the generic invalid_request the server sends today", () => {
+    expect(mapSttServerError("invalid_request")).toBeNull();
+  });
 });

--- a/src/utils/session-transfer-helpers.ts
+++ b/src/utils/session-transfer-helpers.ts
@@ -96,7 +96,7 @@ export function resolveActorFromSession(
  * query parameters. Pure string builder — no network call, nothing persisted.
  *
  * Throws `CustomTokenExchangeError(EXCHANGE_FAILED)` if `targetLoginUrl` is not a
- * valid absolute URL. `targetLoginUrl` must be a trusted, app-controlled value.
+ * valid absolute `http`/`https` URL. `targetLoginUrl` must be a trusted, app-controlled value.
  *
  * Shared by both the core `AuthClient` and the `Auth0Client` wrapper (including its
  * resolver-mode fallback) so the STT query-param logic and URL guard live in one place.
@@ -116,12 +116,21 @@ export function buildSessionTransferRedirectUrl(
         "Pass a trusted, app-controlled absolute login URL (e.g. https://app.example.com/auth/login)."
     );
   }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new CustomTokenExchangeError(
+      CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+      `Invalid targetLoginUrl: "${targetLoginUrl}" must use http or https.`
+    );
+  }
   url.searchParams.set("session_transfer_token", sessionTransferToken);
   if (opts?.organization) {
     url.searchParams.set("organization", opts.organization);
   }
   return url.toString();
 }
+
+// Auth0 issues STTs with a ~60s lifetime; used as the fallback when expires_in is absent.
+const DEFAULT_STT_EXPIRES_IN_SECONDS = 60;
 
 /**
  * Maps the raw token endpoint response to a `SessionTransferTokenResult`.
@@ -138,7 +147,7 @@ export function parseSessionTransferTokenResponse(raw: {
   return {
     sessionTransferToken: raw.access_token,
     issuedTokenType: raw.issued_token_type,
-    expiresIn: Number(raw.expires_in ?? 60),
+    expiresIn: Number(raw.expires_in ?? DEFAULT_STT_EXPIRES_IN_SECONDS),
     tokenType: raw.token_type
   };
 }

--- a/src/utils/session-transfer-helpers.ts
+++ b/src/utils/session-transfer-helpers.ts
@@ -1,0 +1,133 @@
+import * as jose from "jose";
+
+import {
+  CustomTokenExchangeError,
+  CustomTokenExchangeErrorCode
+} from "../errors/oauth-errors.js";
+import {
+  SessionData,
+  SessionTransferTokenResult,
+  TOKEN_TYPES
+} from "../types/index.js";
+
+/**
+ * Builds the `audience` value for a Session Transfer Token exchange.
+ * The audience is always `urn:{domain}:session_transfer` — the switch that
+ * makes Auth0 return an STT instead of a regular access token.
+ *
+ * Uses the SDK's effective domain so that Multiple Custom Domain tenants
+ * get the correct per-domain audience rather than the static configured domain.
+ */
+export function buildSessionTransferAudience(domain: string): string {
+  return `urn:${domain}:session_transfer`;
+}
+
+/**
+ * Resolves the actor token pair for an STT exchange.
+ *
+ * Precedence:
+ * 1. Explicit `actor` passed by the caller
+ * 2. Session ID token (must be unexpired — server rejects expired actor tokens)
+ * 3. `ACTOR_UNAVAILABLE` thrown client-side
+ *
+ * An actor is mandatory for an STT. Without one the exchange fails server-side
+ * with `setActor is required`, and without a recorded actor it is not auditable
+ * impersonation.
+ */
+export function resolveActorFromSession(
+  session: SessionData | null,
+  explicitActor?: { token: string; type: TOKEN_TYPES | string }
+): [CustomTokenExchangeError, null] | [null, { token: string; type: string }] {
+  if (explicitActor) {
+    if (!explicitActor.token || explicitActor.token.trim() === "") {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+          "The explicit actor token is empty."
+        ),
+        null
+      ];
+    }
+    return [null, { token: explicitActor.token, type: explicitActor.type }];
+  }
+
+  const idToken = session?.tokenSet?.idToken;
+  if (!idToken) {
+    return [
+      new CustomTokenExchangeError(
+        CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+        "No actor could be resolved: no explicit actor was provided and the agent session has no ID token. " +
+          "Ensure the agent is authenticated, or pass an explicit actor."
+      ),
+      null
+    ];
+  }
+
+  // Guard against expired ID tokens — the server validates exp on the actor_token
+  // and rejects with "Invalid actor token: 'exp' claim timestamp check failed".
+  try {
+    const { exp } = jose.decodeJwt(idToken);
+    if (typeof exp === "number" && exp < Math.floor(Date.now() / 1000)) {
+      return [
+        new CustomTokenExchangeError(
+          CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+          "The agent session ID token has expired. Refresh the session before requesting a Session Transfer Token, " +
+            "or pass a fresh actor token explicitly."
+        ),
+        null
+      ];
+    }
+  } catch {
+    return [
+      new CustomTokenExchangeError(
+        CustomTokenExchangeErrorCode.ACTOR_UNAVAILABLE,
+        "The agent session ID token could not be decoded."
+      ),
+      null
+    ];
+  }
+
+  return [null, { token: idToken, type: TOKEN_TYPES.ID_TOKEN }];
+}
+
+/**
+ * Maps the raw token endpoint response to a `SessionTransferTokenResult`.
+ *
+ * The server signals an STT via `issued_token_type`; the `access_token` field
+ * holds the opaque STT rather than a usable API bearer token.
+ */
+export function parseSessionTransferTokenResponse(raw: {
+  access_token: string;
+  issued_token_type: string;
+  expires_in?: number;
+  token_type?: string;
+}): SessionTransferTokenResult {
+  return {
+    sessionTransferToken: raw.access_token,
+    issuedTokenType: raw.issued_token_type,
+    expiresIn: Number(raw.expires_in ?? 60),
+    tokenType: raw.token_type
+  };
+}
+
+/**
+ * Maps a server 400 error code to a typed `CustomTokenExchangeErrorCode` for STT failures.
+ * Returns `null` when the error code is not STT-specific (caller should fall through to EXCHANGE_FAILED).
+ */
+export function mapSttServerError(
+  errorCode: string
+): CustomTokenExchangeErrorCode | null {
+  if (
+    errorCode === "setactor_required" ||
+    errorCode.toLowerCase().includes("setactor")
+  ) {
+    return CustomTokenExchangeErrorCode.SETACTOR_REQUIRED;
+  }
+  if (
+    errorCode === "session_transfer_disabled" ||
+    errorCode.toLowerCase().includes("session_transfer")
+  ) {
+    return CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED;
+  }
+  return null;
+}

--- a/src/utils/session-transfer-helpers.ts
+++ b/src/utils/session-transfer-helpers.ts
@@ -27,7 +27,8 @@ export function buildSessionTransferAudience(domain: string): string {
  *
  * Precedence:
  * 1. Explicit `actor` passed by the caller
- * 2. Session ID token (must be unexpired — server rejects expired actor tokens)
+ * 2. Session ID token (must be unexpired — server rejects expired actor tokens;
+ *    this function does NOT refresh it, it fails when the token is already expired)
  * 3. `ACTOR_UNAVAILABLE` thrown client-side
  *
  * An actor is mandatory for an STT. Without one the exchange fails server-side
@@ -91,6 +92,38 @@ export function resolveActorFromSession(
 }
 
 /**
+ * Builds the target login URL carrying the STT (and optional `organization`) as
+ * query parameters. Pure string builder — no network call, nothing persisted.
+ *
+ * Throws `CustomTokenExchangeError(EXCHANGE_FAILED)` if `targetLoginUrl` is not a
+ * valid absolute URL. `targetLoginUrl` must be a trusted, app-controlled value.
+ *
+ * Shared by both the core `AuthClient` and the `Auth0Client` wrapper (including its
+ * resolver-mode fallback) so the STT query-param logic and URL guard live in one place.
+ */
+export function buildSessionTransferRedirectUrl(
+  targetLoginUrl: string,
+  sessionTransferToken: string,
+  opts?: { organization?: string }
+): string {
+  let url: URL;
+  try {
+    url = new URL(targetLoginUrl);
+  } catch {
+    throw new CustomTokenExchangeError(
+      CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
+      `Invalid targetLoginUrl: "${targetLoginUrl}" is not an absolute URL. ` +
+        "Pass a trusted, app-controlled absolute login URL (e.g. https://app.example.com/auth/login)."
+    );
+  }
+  url.searchParams.set("session_transfer_token", sessionTransferToken);
+  if (opts?.organization) {
+    url.searchParams.set("organization", opts.organization);
+  }
+  return url.toString();
+}
+
+/**
  * Maps the raw token endpoint response to a `SessionTransferTokenResult`.
  *
  * The server signals an STT via `issued_token_type`; the `access_token` field
@@ -111,21 +144,27 @@ export function parseSessionTransferTokenResponse(raw: {
 }
 
 /**
- * Maps a server 400 error code to a typed `CustomTokenExchangeErrorCode` for STT failures.
- * Returns `null` when the error code is not STT-specific (caller should fall through to EXCHANGE_FAILED).
+ * Maps a server STT failure to a typed `CustomTokenExchangeErrorCode`, keyed off the
+ * machine-readable `error` code only.
+ *
+ * Per the SDK requirements, the SDK does NOT match against `error_description` text to
+ * remap failures. Today Auth0 returns these failures with a generic `error`
+ * (`invalid_request`) and the detail in `error_description`, so this returns `null` and
+ * the caller surfaces the raw `error`/`error_description` as `EXCHANGE_FAILED`. These
+ * named constants exist for documentation and for the day the platform returns a
+ * machine-readable code (`setactor_required` / `session_transfer_disabled`), at which
+ * point this mapping starts firing without any further change.
  */
 export function mapSttServerError(
   errorCode: string
 ): CustomTokenExchangeErrorCode | null {
-  if (
-    errorCode === "setactor_required" ||
-    errorCode.toLowerCase().includes("setactor")
-  ) {
+  const code = errorCode.toLowerCase();
+  if (code === "setactor_required" || code.includes("setactor")) {
     return CustomTokenExchangeErrorCode.SETACTOR_REQUIRED;
   }
   if (
-    errorCode === "session_transfer_disabled" ||
-    errorCode.toLowerCase().includes("session_transfer")
+    code === "session_transfer_disabled" ||
+    code.includes("session_transfer")
   ) {
     return CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED;
   }

--- a/src/utils/session-transfer-helpers.ts
+++ b/src/utils/session-transfer-helpers.ts
@@ -116,10 +116,14 @@ export function buildSessionTransferRedirectUrl(
         "Pass a trusted, app-controlled absolute login URL (e.g. https://app.example.com/auth/login)."
     );
   }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
+  const isLocalhost =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalhost)) {
     throw new CustomTokenExchangeError(
       CustomTokenExchangeErrorCode.EXCHANGE_FAILED,
-      `Invalid targetLoginUrl: "${targetLoginUrl}" must use http or https.`
+      `Invalid targetLoginUrl: "${targetLoginUrl}" must use https (or http for localhost).`
     );
   }
   url.searchParams.set("session_transfer_token", sessionTransferToken);
@@ -128,9 +132,6 @@ export function buildSessionTransferRedirectUrl(
   }
   return url.toString();
 }
-
-// Auth0 issues STTs with a ~60s lifetime; used as the fallback when expires_in is absent.
-const DEFAULT_STT_EXPIRES_IN_SECONDS = 60;
 
 /**
  * Maps the raw token endpoint response to a `SessionTransferTokenResult`.
@@ -147,7 +148,8 @@ export function parseSessionTransferTokenResponse(raw: {
   return {
     sessionTransferToken: raw.access_token,
     issuedTokenType: raw.issued_token_type,
-    expiresIn: Number(raw.expires_in ?? DEFAULT_STT_EXPIRES_IN_SECONDS),
+    expiresIn:
+      raw.expires_in !== undefined ? Number(raw.expires_in) : undefined,
     tokenType: raw.token_type
   };
 }
@@ -168,13 +170,10 @@ export function mapSttServerError(
   errorCode: string
 ): CustomTokenExchangeErrorCode | null {
   const code = errorCode.toLowerCase();
-  if (code === "setactor_required" || code.includes("setactor")) {
+  if (code === "setactor_required") {
     return CustomTokenExchangeErrorCode.SETACTOR_REQUIRED;
   }
-  if (
-    code === "session_transfer_disabled" ||
-    code.includes("session_transfer")
-  ) {
+  if (code === "session_transfer_disabled") {
     return CustomTokenExchangeErrorCode.SESSION_TRANSFER_DISABLED;
   }
   return null;


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

  ### 📋 Changes

Implements CTE Phase 2 — Session Transfer Token (STT). An authenticated agent can now request a short-lived, one-shot token that lets them establish a web session **as a customer** in a target app, without the customer's password.

  **New methods on `Auth0Client`:**
  - `requestSessionTransferToken(options)` — exchanges a subject token for an STT via `POST /oauth/token` with
  `audience=urn:{domain}:session_transfer`. The actor defaults to the agent session's ID token (checked for expiry); an
  explicit `actor` override is also supported.
  - `buildSessionTransferRedirect(targetLoginUrl, result, opts?)` — pure URL builder returning a `NextResponse.redirect` with `?session_transfer_token=<stt>` appended.

  **New types exported from `@auth0/nextjs-auth0/server` and `@auth0/nextjs-auth0/types`:**
  - `SessionTransferTokenOptions` / `SessionTransferTokenResult`
  - `TOKEN_TYPES` enum (`ID_TOKEN`, `ACCESS_TOKEN`, `SESSION_TRANSFER_TOKEN`)

  **New error codes on `CustomTokenExchangeErrorCode`:**
  - `ACTOR_UNAVAILABLE` — no usable actor token (client-side, before network call)
  - `SETACTOR_REQUIRED` — server requires an actor to be set via `api.authentication.setActor()`
  - `SESSION_TRANSFER_DISABLED` — tenant feature flag not enabled

  **Implementation notes:**
  - `oauth4webapi`'s `processGenericTokenEndpointResponse` rejects `token_type: "N_A"` (returned by the STT endpoint). The implementation bypasses it by calling `genericTokenEndpointRequest` directly and parsing the raw JSON body.
  - STT-specific pure functions are extracted to `src/utils/session-transfer-helpers.ts` to keep `auth-client.ts` manageable.
  - No middleware change needed — `handleLogin()` already forwards all query params to `/authorize`, so
  `session_transfer_token` passes through transparently on the target app side.

  ### 📎 References

  - CTE Phase 2 / Session Transfer Token spec (internal Confluence)

  ### 🎯 Testing

  - 36 new unit tests in `src/server/custom-token-exchange.test.ts` (section 5) covering result shape, actor resolution, wire
  parameters, STT not persisted to session, server error mapping, input validation, `buildSessionTransferRedirect`, and
  backward compatibility.
  - 23 unit tests in `src/utils/session-transfer-helpers.test.ts` covering all 4 helper functions.
  - All 1739 tests pass, TypeScript clean, zero new console warnings from the STT code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Session Transfer Token (STT) support with new request and redirect helpers for one-shot session transfer.
  * Exposed STT option/result types, token-type constants, and STT-related OAuth error codes.
* **Bug Fixes**
  * Improved STT actor validation/resolution and safer handling of STT-specific token responses, including typed server error mapping.
* **Documentation**
  * Added STT documentation to the Custom Token Exchange guide, including flow, error behavior, and limitations.
* **Tests**
  * Added unit and end-to-end coverage for STT request/response contracts, redirect URL encoding, and query forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->