### PR TITLE
feat: add revokeRefreshToken() and revoke refresh token on logout for…

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1577,12 +1577,12 @@ This ensures that the token you send is guaranteed to be valid for at least the 
 
 ## Revoking tokens
 
-`revokeRefreshToken()` revokes the session's refresh token at Auth0's `/oauth/revoke` endpoint ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). Per RFC 7009, revoking a refresh token also invalidates the other tokens issued under the same authorization grant. Client authentication (`clientSecret`, Private Key JWT, or mTLS) is applied automatically from your `Auth0Client` configuration.
+`revokeRefreshToken()` revokes the refresh token stored in the current session at Auth0's `/oauth/revoke` endpoint ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). Auth0 will also invalidate all access tokens issued under the same authorization grant — any subsequent API calls using those tokens will fail. Client authentication (`clientSecret`, Private Key JWT, or mTLS) is applied automatically from your `Auth0Client` configuration.
 
 > [!NOTE]
-> Logging out revokes the session's refresh token automatically — `auth0.middleware` / the `/auth/logout` route revokes before clearing the session. `revokeRefreshToken()` is for explicit revocation outside the logout flow, e.g. a "sign out everywhere" action that invalidates the grant without redirecting the user.
+> Logging out revokes the session's refresh token automatically — `auth0.middleware` / the `/auth/logout` route revokes before clearing the session. `revokeRefreshToken()` is for explicit revocation outside the logout flow, for example revoking a user's access without redirecting them.
 
-`revokeRefreshToken()` reads the refresh token from the current session and revokes it. It does **not** clear the local session.
+`revokeRefreshToken()` reads the refresh token from the current session and revokes it. The local session cookie is not cleared — call `handleLogout` for a full logout that also clears the session.
 
 **App Router (Server Actions, Route Handlers):**
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1575,6 +1575,55 @@ This ensures that the token you send is guaranteed to be valid for at least the 
 > [!IMPORTANT]
 > This strategy is **not** a solution for long-running operations that take longer than the token's total validity period (e.g., 10 minutes). In those cases, the token will still expire mid-operation. The correct approach for long-running tasks is to call `getAccessToken()` immediately before the operation that requires it, ensuring you have a fresh token. The buffer is only for mitigating latency-related failures in short-lived requests.
 
+## Revoking tokens
+
+`revokeRefreshToken()` revokes the session's refresh token at Auth0's `/oauth/revoke` endpoint ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)). Per RFC 7009, revoking a refresh token also invalidates the other tokens issued under the same authorization grant. Client authentication (`clientSecret`, Private Key JWT, or mTLS) is applied automatically from your `Auth0Client` configuration.
+
+> [!NOTE]
+> Logging out revokes the session's refresh token automatically — `auth0.middleware` / the `/auth/logout` route revokes before clearing the session. `revokeRefreshToken()` is for explicit revocation outside the logout flow, e.g. a "sign out everywhere" action that invalidates the grant without redirecting the user.
+
+`revokeRefreshToken()` reads the refresh token from the current session and revokes it. It does **not** clear the local session.
+
+**App Router (Server Actions, Route Handlers):**
+
+```typescript
+// app/api/revoke/route.ts
+import { auth0 } from "@/lib/auth0";
+
+export async function POST() {
+  try {
+    await auth0.revokeRefreshToken();
+    return Response.json({ revoked: true });
+  } catch (error) {
+    console.error("Failed to revoke refresh token:", error);
+    return Response.json({ error: "Failed to revoke" }, { status: 500 });
+  }
+}
+```
+
+**Pages Router:** pass the incoming request via `options.req`:
+
+```typescript
+// pages/api/revoke.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+import { auth0 } from "@/lib/auth0";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    await auth0.revokeRefreshToken({ req });
+    res.status(200).json({ revoked: true });
+  } catch (error) {
+    console.error("Failed to revoke refresh token:", error);
+    res.status(500).json({ error: "Failed to revoke" });
+  }
+}
+```
+
+If there is no active session or the session has no refresh token, a `TokenRevocationError` is thrown.
+
 ## Multi-Factor Authentication (MFA)
 
 ### Step-up Authentication

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -17,7 +17,9 @@ export {
   AccessTokenForConnectionError,
   AccessTokenForConnectionErrorCode,
   CustomTokenExchangeError,
-  CustomTokenExchangeErrorCode
+  CustomTokenExchangeErrorCode,
+  TokenRevocationError,
+  TokenRevocationErrorCode
 } from "./oauth-errors.js";
 
 export { DPoPError, DPoPErrorCode } from "./dpop-errors.js";

--- a/src/errors/oauth-errors.ts
+++ b/src/errors/oauth-errors.ts
@@ -195,6 +195,57 @@ export class AccessTokenForConnectionError extends SdkError {
 }
 
 /**
+ * Error codes for refresh token revocation errors.
+ */
+export enum TokenRevocationErrorCode {
+  /**
+   * No session exists for the current request.
+   */
+  MISSING_SESSION = "missing_session",
+
+  /**
+   * The session (or request) has no refresh token to revoke.
+   */
+  MISSING_REFRESH_TOKEN = "missing_refresh_token",
+
+  /**
+   * The revocation request to Auth0 failed.
+   */
+  FAILED_TO_REVOKE = "failed_to_revoke"
+}
+
+/**
+ * Error class representing a refresh token revocation error.
+ * Extends the `SdkError` class.
+ *
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7009 RFC 7009 Token Revocation}
+ */
+export class TokenRevocationError extends SdkError {
+  /**
+   * The error code associated with the revocation error.
+   */
+  public code: string;
+  /**
+   * The underlying OAuth2 error that caused this error (if applicable).
+   */
+  public cause?: OAuth2Error;
+
+  /**
+   * Constructs a new `TokenRevocationError` instance.
+   *
+   * @param code - The error code.
+   * @param message - The error message.
+   * @param cause - The OAuth2 cause of the error.
+   */
+  constructor(code: string, message: string, cause?: OAuth2Error) {
+    super(message);
+    this.name = "TokenRevocationError";
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+/**
  * Error codes for Custom Token Exchange errors.
  */
 export enum CustomTokenExchangeErrorCode {

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -4055,6 +4055,62 @@ ca/T0LLtgmbMmxSv/MmzIg==
         const params = new URLSearchParams(body);
         expect(params.get("token")).toEqual(DEFAULT.refreshToken);
       });
+
+      it("should not block logout if revocation fails and should warn", async () => {
+        const secret = await generateSecret(32);
+        const transactionStore = new TransactionStore({ secret });
+        const sessionStore = new StatelessSessionStore({ secret });
+
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const authClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          secret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          routes: getDefaultRoutes(),
+          fetch: getMockAuthorizationServer({
+            revocationErrorResponse: new Response(
+              JSON.stringify({ error: "server_error" }),
+              { status: 500 }
+            )
+          })
+        });
+
+        const session: SessionData = {
+          user: { sub: DEFAULT.sub },
+          tokenSet: {
+            accessToken: DEFAULT.accessToken,
+            refreshToken: DEFAULT.refreshToken,
+            expiresAt: 123456
+          },
+          internal: {
+            sid: DEFAULT.sid,
+            createdAt: Math.floor(Date.now() / 1000)
+          }
+        };
+        const expiration = Math.floor(Date.now() / 1000 + 3600);
+        const sessionCookie = await encrypt(session, secret, expiration);
+        const headers = new Headers();
+        headers.append("cookie", `__session=${sessionCookie}`);
+
+        const request = new NextRequest(
+          new URL("/auth/logout", DEFAULT.appBaseUrl),
+          { method: "GET", headers }
+        );
+
+        const response = await authClient.handleLogout(request);
+        expect(response.status).toEqual(307);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("[nextjs-auth0]"),
+          expect.anything()
+        );
+
+        warnSpy.mockRestore();
+      });
     });
   });
 
@@ -11475,7 +11531,34 @@ ykwV8CV22wKDubrDje1vchfTL/ygX6p27RKpJm8eAH7k3EwVeg3NDfNVzQ==
       const [error, result] = await authClient.revokeToken("");
 
       expect(error).toBeInstanceOf(TokenRevocationError);
-      expect(error?.code).toBe(TokenRevocationErrorCode.FAILED_TO_REVOKE);
+      expect(error?.code).toBe(TokenRevocationErrorCode.MISSING_REFRESH_TOKEN);
+      expect(result).toBeNull();
+    });
+
+    it("should return a TokenRevocationError when the token is whitespace only", async () => {
+      const authClient = await createAuthClient(getMockAuthorizationServer());
+
+      const [error, result] = await authClient.revokeToken("   ");
+
+      expect(error).toBeInstanceOf(TokenRevocationError);
+      expect(error?.code).toBe(TokenRevocationErrorCode.MISSING_REFRESH_TOKEN);
+      expect(result).toBeNull();
+    });
+
+    it("should return the original discovery error when discovery fails", async () => {
+      const authClient = await createAuthClient(
+        getMockAuthorizationServer({
+          discoveryResponse: new Response(null, { status: 500 })
+        })
+      );
+
+      const [error, result] = await authClient.revokeToken(
+        DEFAULT.refreshToken,
+        "refresh_token"
+      );
+
+      expect(error).not.toBeNull();
+      expect(error).not.toBeInstanceOf(TokenRevocationError);
       expect(result).toBeNull();
     });
 
@@ -11498,8 +11581,11 @@ ykwV8CV22wKDubrDje1vchfTL/ygX6p27RKpJm8eAH7k3EwVeg3NDfNVzQ==
       );
 
       expect(error).toBeInstanceOf(TokenRevocationError);
-      expect(error?.code).toBe(TokenRevocationErrorCode.FAILED_TO_REVOKE);
-      expect(error?.cause?.code).toBe("invalid_request");
+      const revocationError = error as TokenRevocationError;
+      expect(revocationError.code).toBe(
+        TokenRevocationErrorCode.FAILED_TO_REVOKE
+      );
+      expect(revocationError.cause?.code).toBe("invalid_request");
       expect(result).toBeNull();
     });
   });

--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -19,7 +19,9 @@ import {
   ConnectAccountError,
   ConnectAccountErrorCodes,
   InvalidConfigurationError,
-  MyAccountApiError
+  MyAccountApiError,
+  TokenRevocationError,
+  TokenRevocationErrorCode
 } from "../errors/index.js";
 import { getDefaultRoutes } from "../test/defaults.js";
 import { generateSecret } from "../test/utils.js";
@@ -4000,6 +4002,58 @@ ca/T0LLtgmbMmxSv/MmzIg==
         expect(response.status).toEqual(307);
         const cookie = response.cookies.get("__session");
         expect(cookie?.maxAge).toEqual(0);
+      });
+
+      it("should call revocation endpoint on logout when session has a refresh token", async () => {
+        const secret = await generateSecret(32);
+        const transactionStore = new TransactionStore({ secret });
+        const sessionStore = new StatelessSessionStore({ secret });
+
+        const onRevocationRequest = vi.fn(
+          async () => {}
+        ) as unknown as MockedFunction<(request: Request) => Promise<void>>;
+
+        const authClient = new AuthClient({
+          transactionStore,
+          sessionStore,
+          domain: DEFAULT.domain,
+          clientId: DEFAULT.clientId,
+          clientSecret: DEFAULT.clientSecret,
+          secret,
+          appBaseUrl: DEFAULT.appBaseUrl,
+          routes: getDefaultRoutes(),
+          fetch: getMockAuthorizationServer({ onRevocationRequest })
+        });
+
+        const session: SessionData = {
+          user: { sub: DEFAULT.sub },
+          tokenSet: {
+            accessToken: DEFAULT.accessToken,
+            refreshToken: DEFAULT.refreshToken,
+            expiresAt: 123456
+          },
+          internal: {
+            sid: DEFAULT.sid,
+            createdAt: Math.floor(Date.now() / 1000)
+          }
+        };
+        const expiration = Math.floor(Date.now() / 1000 + 3600);
+        const sessionCookie = await encrypt(session, secret, expiration);
+        const headers = new Headers();
+        headers.append("cookie", `__session=${sessionCookie}`);
+
+        const request = new NextRequest(
+          new URL("/auth/logout", DEFAULT.appBaseUrl),
+          { method: "GET", headers }
+        );
+
+        const response = await authClient.handleLogout(request);
+        expect(response.status).toEqual(307);
+        expect(onRevocationRequest).toHaveBeenCalledOnce();
+
+        const body = await onRevocationRequest.mock.calls[0][0].clone().text();
+        const params = new URLSearchParams(body);
+        expect(params.get("token")).toEqual(DEFAULT.refreshToken);
       });
     });
   });
@@ -11355,6 +11409,98 @@ ykwV8CV22wKDubrDje1vchfTL/ygX6p27RKpJm8eAH7k3EwVeg3NDfNVzQ==
 
       expect((fetcher as any).config.dpopHandle).toBeUndefined();
       expect((fetcher as any).hooks.isDpopEnabled()).toBe(false);
+    });
+  });
+
+  describe("revokeToken", () => {
+    async function createAuthClient(
+      fetch: ReturnType<typeof getMockAuthorizationServer>
+    ) {
+      const secret = await generateSecret(32);
+      return new AuthClient({
+        transactionStore: new TransactionStore({ secret }),
+        sessionStore: new StatelessSessionStore({ secret }),
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+        routes: getDefaultRoutes(),
+        fetch
+      });
+    }
+
+    it("should revoke a token and forward client credentials", async () => {
+      let capturedBody: URLSearchParams | undefined;
+      const authClient = await createAuthClient(
+        getMockAuthorizationServer({
+          onRevocationRequest: async (request) => {
+            capturedBody = new URLSearchParams(await request.text());
+          }
+        })
+      );
+
+      const [error, result] = await authClient.revokeToken(
+        DEFAULT.refreshToken,
+        "refresh_token"
+      );
+
+      expect(error).toBeNull();
+      expect(result).toBeUndefined();
+      expect(capturedBody?.get("token")).toBe(DEFAULT.refreshToken);
+      expect(capturedBody?.get("token_type_hint")).toBe("refresh_token");
+      expect(capturedBody?.get("client_id")).toBe(DEFAULT.clientId);
+      expect(capturedBody?.get("client_secret")).toBe(DEFAULT.clientSecret);
+    });
+
+    it("should omit token_type_hint when not provided", async () => {
+      let capturedBody: URLSearchParams | undefined;
+      const authClient = await createAuthClient(
+        getMockAuthorizationServer({
+          onRevocationRequest: async (request) => {
+            capturedBody = new URLSearchParams(await request.text());
+          }
+        })
+      );
+
+      const [error] = await authClient.revokeToken(DEFAULT.refreshToken);
+
+      expect(error).toBeNull();
+      expect(capturedBody?.has("token_type_hint")).toBe(false);
+    });
+
+    it("should return a TokenRevocationError when the token is empty", async () => {
+      const authClient = await createAuthClient(getMockAuthorizationServer());
+
+      const [error, result] = await authClient.revokeToken("");
+
+      expect(error).toBeInstanceOf(TokenRevocationError);
+      expect(error?.code).toBe(TokenRevocationErrorCode.FAILED_TO_REVOKE);
+      expect(result).toBeNull();
+    });
+
+    it("should return a TokenRevocationError when the request fails", async () => {
+      const authClient = await createAuthClient(
+        getMockAuthorizationServer({
+          revocationErrorResponse: Response.json(
+            {
+              error: "invalid_request",
+              error_description: "bad token"
+            },
+            { status: 400 }
+          )
+        })
+      );
+
+      const [error, result] = await authClient.revokeToken(
+        DEFAULT.refreshToken,
+        "refresh_token"
+      );
+
+      expect(error).toBeInstanceOf(TokenRevocationError);
+      expect(error?.code).toBe(TokenRevocationErrorCode.FAILED_TO_REVOKE);
+      expect(error?.cause?.code).toBe("invalid_request");
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -45,7 +45,9 @@ import {
   PasswordlessDbGetTokenError,
   PasswordlessStartError,
   PasswordlessVerifyError,
-  SdkError
+  SdkError,
+  TokenRevocationError,
+  TokenRevocationErrorCode
 } from "../errors/index.js";
 import {
   IssuerValidationError,
@@ -1095,14 +1097,18 @@ export class AuthClient {
     // Revoke the refresh token before clearing the session so it cannot be
     // replayed after logout (e.g. from a stolen session cookie). Errors are
     // swallowed — a failed revocation must never block the logout redirect.
-    if (this.useMtls && session?.tokenSet.refreshToken && !hasDomainMismatch) {
+    if (session?.tokenSet.refreshToken && !hasDomainMismatch) {
       try {
-        await this.revokeRefreshToken(
+        await this.performTokenRevocation(
           authorizationServerMetadata,
-          session.tokenSet.refreshToken
+          session.tokenSet.refreshToken,
+          "refresh_token"
         );
-      } catch {
-        // intentionally ignored
+      } catch (e) {
+        console.warn(
+          "[nextjs-auth0] Failed to revoke refresh token during logout (logout will still proceed):",
+          e
+        );
       }
     }
 
@@ -2982,19 +2988,101 @@ export class AuthClient {
     return as;
   }
 
-  private async revokeRefreshToken(
+  /**
+   * Low-level revocation call against the authorization server's
+   * `/oauth/revoke` endpoint. Callers must supply the discovered metadata.
+   *
+   * @param as The discovered authorization server metadata.
+   * @param token The token to revoke.
+   * @param tokenTypeHint Optional `token_type_hint` per RFC 7009.
+   */
+  private async performTokenRevocation(
     as: oauth.AuthorizationServer,
-    refreshToken: string
+    token: string,
+    tokenTypeHint?: "refresh_token" | "access_token"
   ): Promise<void> {
     const clientAuth = await this.getClientAuth();
     const response = await oauth.revocationRequest(
       as,
       this.clientMetadata,
       clientAuth,
-      refreshToken,
-      { [oauth.customFetch]: this.fetch, ...this.httpOptions() }
+      token,
+      {
+        [oauth.customFetch]: this.fetch,
+        ...this.httpOptions(),
+        ...(tokenTypeHint
+          ? { additionalParameters: { token_type_hint: tokenTypeHint } }
+          : {})
+      }
     );
     await oauth.processRevocationResponse(response);
+  }
+
+  /**
+   * Revokes a token at the Auth0 `/oauth/revoke` endpoint (RFC 7009).
+   *
+   * Per RFC 7009, revoking a refresh token also invalidates the other tokens
+   * issued under the same authorization grant. Client authentication
+   * (`client_secret`, Private Key JWT, or mTLS) is applied automatically based
+   * on the configured client credentials.
+   *
+   * @param token The token to revoke.
+   * @param tokenTypeHint Optional `token_type_hint` (`refresh_token` or `access_token`).
+   * @returns A tuple of `[error, null]` on failure or `[null, undefined]` on success.
+   */
+  async revokeToken(
+    token: string,
+    tokenTypeHint?: "refresh_token" | "access_token"
+  ): Promise<[TokenRevocationError, null] | [null, undefined]> {
+    if (!token || token.trim() === "") {
+      return [
+        new TokenRevocationError(
+          TokenRevocationErrorCode.FAILED_TO_REVOKE,
+          "A token is required to perform revocation."
+        ),
+        null
+      ];
+    }
+
+    const [discoveryError, authorizationServerMetadata] =
+      await this.discoverAuthorizationServerMetadata();
+
+    if (discoveryError) {
+      return [
+        new TokenRevocationError(
+          TokenRevocationErrorCode.FAILED_TO_REVOKE,
+          "Failed to discover authorization server metadata.",
+          new OAuth2Error({
+            code: "discovery_error",
+            message: discoveryError.message
+          })
+        ),
+        null
+      ];
+    }
+
+    try {
+      await this.performTokenRevocation(
+        authorizationServerMetadata,
+        token,
+        tokenTypeHint
+      );
+    } catch (e) {
+      return [
+        new TokenRevocationError(
+          TokenRevocationErrorCode.FAILED_TO_REVOKE,
+          "An error occurred while trying to revoke the token.",
+          new OAuth2Error({
+            code:
+              e instanceof oauth.ResponseBodyError ? e.error : "revoke_failed",
+            message: e instanceof Error ? e.message : String(e)
+          })
+        ),
+        null
+      ];
+    }
+
+    return [null, undefined];
   }
 
   private warnIfNotCertificateBound(accessToken: string): void {

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3009,6 +3009,7 @@ export class AuthClient {
       token,
       {
         [oauth.customFetch]: this.fetch,
+        [oauth.allowInsecureRequests]: this.allowInsecureRequests,
         ...this.httpOptions(),
         ...(tokenTypeHint
           ? { additionalParameters: { token_type_hint: tokenTypeHint } }

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -3034,11 +3034,11 @@ export class AuthClient {
   async revokeToken(
     token: string,
     tokenTypeHint?: "refresh_token" | "access_token"
-  ): Promise<[TokenRevocationError, null] | [null, undefined]> {
+  ): Promise<[SdkError, null] | [null, undefined]> {
     if (!token || token.trim() === "") {
       return [
         new TokenRevocationError(
-          TokenRevocationErrorCode.FAILED_TO_REVOKE,
+          TokenRevocationErrorCode.MISSING_REFRESH_TOKEN,
           "A token is required to perform revocation."
         ),
         null
@@ -3049,17 +3049,7 @@ export class AuthClient {
       await this.discoverAuthorizationServerMetadata();
 
     if (discoveryError) {
-      return [
-        new TokenRevocationError(
-          TokenRevocationErrorCode.FAILED_TO_REVOKE,
-          "Failed to discover authorization server metadata.",
-          new OAuth2Error({
-            code: "discovery_error",
-            message: discoveryError.message
-          })
-        ),
-        null
-      ];
+      return [discoveryError, null];
     }
 
     try {

--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   DomainResolutionError,
-  InvalidConfigurationError
+  InvalidConfigurationError,
+  TokenRevocationErrorCode
 } from "../errors/index.js";
 import { SessionData } from "../types/index.js";
 import { Auth0Client } from "./client.js";
@@ -569,6 +570,80 @@ describe("Auth0Client", () => {
         expect.any(Object),
         mockRes
       );
+    });
+  });
+
+  describe("revokeRefreshToken", () => {
+    let client: Auth0Client;
+
+    const sessionWithRefreshToken: SessionData = {
+      user: { sub: "user123" },
+      tokenSet: {
+        accessToken: "at_123",
+        refreshToken: "rt_session",
+        expiresAt: Date.now() / 1000 + 3600
+      },
+      internal: { sid: "sid_123", createdAt: Date.now() / 1000 }
+    };
+
+    beforeEach(() => {
+      process.env[ENV_VARS.DOMAIN] = "test.auth0.com";
+      process.env[ENV_VARS.CLIENT_ID] = "test_client_id";
+      process.env[ENV_VARS.CLIENT_SECRET] = "test_client_secret";
+      process.env[ENV_VARS.APP_BASE_URL] = "https://myapp.test";
+      process.env[ENV_VARS.SECRET] = "test_secret";
+      client = new Auth0Client();
+    });
+
+    it("should revoke the refresh token from the session", async () => {
+      const revokeToken = vi.fn().mockResolvedValue([null, undefined]);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi.fn().mockResolvedValue({
+          session: sessionWithRefreshToken,
+          error: null
+        }),
+        revokeToken
+      });
+
+      const req = new NextRequest("https://myapp.test/api/test");
+      await expect(client.revokeRefreshToken({ req })).resolves.toBeUndefined();
+      expect(revokeToken).toHaveBeenCalledWith("rt_session", "refresh_token");
+    });
+
+    it("should throw a MISSING_SESSION error when there is no session", async () => {
+      const revokeToken = vi.fn();
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi
+          .fn()
+          .mockResolvedValue({ session: null, error: null }),
+        revokeToken
+      });
+
+      const req = new NextRequest("https://myapp.test/api/test");
+      await expect(client.revokeRefreshToken({ req })).rejects.toMatchObject({
+        code: TokenRevocationErrorCode.MISSING_SESSION
+      });
+      expect(revokeToken).not.toHaveBeenCalled();
+    });
+
+    it("should throw a MISSING_REFRESH_TOKEN error when the session has no refresh token", async () => {
+      const revokeToken = vi.fn();
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi.fn().mockResolvedValue({
+          session: {
+            ...sessionWithRefreshToken,
+            tokenSet: { accessToken: "at_123", expiresAt: 9999999999 }
+          },
+          error: null
+        }),
+        revokeToken
+      });
+
+      const req = new NextRequest("https://myapp.test/api/test");
+      await expect(client.revokeRefreshToken({ req })).rejects.toMatchObject({
+        code: TokenRevocationErrorCode.MISSING_REFRESH_TOKEN
+      });
+      expect(revokeToken).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DomainResolutionError,
   InvalidConfigurationError,
+  TokenRevocationError,
   TokenRevocationErrorCode
 } from "../errors/index.js";
 import { SessionData } from "../types/index.js";
@@ -644,6 +645,26 @@ describe("Auth0Client", () => {
         code: TokenRevocationErrorCode.MISSING_REFRESH_TOKEN
       });
       expect(revokeToken).not.toHaveBeenCalled();
+    });
+
+    it("should re-throw the error returned by revokeToken", async () => {
+      const revocationError = new TokenRevocationError(
+        TokenRevocationErrorCode.FAILED_TO_REVOKE,
+        "Revocation request failed."
+      );
+      const revokeToken = vi.fn().mockResolvedValue([revocationError, null]);
+      vi.spyOn(client["provider"] as any, "forRequest").mockResolvedValue({
+        getSessionWithDomainCheck: vi.fn().mockResolvedValue({
+          session: sessionWithRefreshToken,
+          error: null
+        }),
+        revokeToken
+      });
+
+      const req = new NextRequest("https://myapp.test/api/test");
+      await expect(client.revokeRefreshToken({ req })).rejects.toMatchObject({
+        code: TokenRevocationErrorCode.FAILED_TO_REVOKE
+      });
     });
   });
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1274,7 +1274,7 @@ export class Auth0Client {
       );
     }
 
-    if (!session.tokenSet.refreshToken) {
+    if (!session.tokenSet.refreshToken?.trim()) {
       throw new TokenRevocationError(
         TokenRevocationErrorCode.MISSING_REFRESH_TOKEN,
         "The session does not contain a refresh token to revoke."

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -12,7 +12,9 @@ import {
   ConnectAccountError,
   ConnectAccountErrorCodes,
   InvalidConfigurationError,
-  MfaRequiredError
+  MfaRequiredError,
+  TokenRevocationError,
+  TokenRevocationErrorCode
 } from "../errors/index.js";
 import { DpopKeyPair, DpopOptions } from "../types/dpop.js";
 import {
@@ -1236,6 +1238,57 @@ export class Auth0Client {
     }
 
     return response;
+  }
+
+  /**
+   * Revokes the refresh token stored in the current session at the Auth0
+   * `/oauth/revoke` endpoint (RFC 7009).
+   *
+   * Per RFC 7009, revoking a refresh token also invalidates the other tokens
+   * issued under the same authorization grant. Note that this does **not**
+   * clear the local session — use `handleLogout` (which already revokes on
+   * logout) for a full logout.
+   *
+   * @param options For the Pages Router, pass the request object so the session can be read.
+   *
+   * @throws {TokenRevocationError} If no session or refresh token exists, or the revocation request fails.
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc7009 RFC 7009 Token Revocation}
+   */
+  async revokeRefreshToken(options?: {
+    req?: PagesRouterRequest | NextRequest;
+  }): Promise<void> {
+    const { authClient, normalizedReq } = await this.resolveRequestContext(
+      options?.req
+    );
+
+    const session = await this.getSessionFromAuthClient(
+      authClient,
+      normalizedReq
+    );
+
+    if (!session) {
+      throw new TokenRevocationError(
+        TokenRevocationErrorCode.MISSING_SESSION,
+        "The user does not have an active session."
+      );
+    }
+
+    if (!session.tokenSet.refreshToken) {
+      throw new TokenRevocationError(
+        TokenRevocationErrorCode.MISSING_REFRESH_TOKEN,
+        "The session does not contain a refresh token to revoke."
+      );
+    }
+
+    const [error] = await authClient.revokeToken(
+      session.tokenSet.refreshToken,
+      "refresh_token"
+    );
+
+    if (error !== null) {
+      throw error;
+    }
   }
 
   /**

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1244,10 +1244,10 @@ export class Auth0Client {
    * Revokes the refresh token stored in the current session at the Auth0
    * `/oauth/revoke` endpoint (RFC 7009).
    *
-   * Per RFC 7009, revoking a refresh token also invalidates the other tokens
-   * issued under the same authorization grant. Note that this does **not**
-   * clear the local session — use `handleLogout` (which already revokes on
-   * logout) for a full logout.
+   * Auth0 will also invalidate all access tokens issued under the same
+   * authorization grant — any subsequent API calls using those tokens will
+   * fail. The local session cookie is not cleared — use `handleLogout`
+   * (which already revokes on logout) for a full logout.
    *
    * @param options For the Pages Router, pass the request object so the session can be read.
    *

--- a/src/server/mtls.test.ts
+++ b/src/server/mtls.test.ts
@@ -331,48 +331,6 @@ describe("mTLS AuthClient", () => {
       expect((clientArg as oauth.Client).use_mtls_endpoint_aliases).toBe(true);
       expect(tokenArg).toBe("rt_mtls_123");
     });
-
-    it("does not call oauth.revocationRequest when useMtls=false", async () => {
-      const { transactionStore, sessionStore } = makeStores(secret);
-
-      const authClient = new AuthClient({
-        transactionStore,
-        sessionStore,
-        domain: DOMAIN,
-        clientId: CLIENT_ID,
-        clientSecret: "some-secret",
-        secret,
-        appBaseUrl: "https://example.com",
-        routes: getDefaultRoutes(),
-        fetch: vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
-      });
-
-      const session: SessionData = {
-        user: { sub: "user_123" },
-        tokenSet: {
-          accessToken: "at_123",
-          refreshToken: "rt_plain_123",
-          expiresAt: 9999999999
-        },
-        internal: {
-          sid: "sid_123",
-          createdAt: Math.floor(Date.now() / 1000)
-        }
-      };
-      const expiration = Math.floor(Date.now() / 1000 + 3600);
-      const sessionCookie = await encrypt(session, secret, expiration);
-      const headers = new Headers();
-      headers.append("cookie", `__session=${sessionCookie}`);
-
-      const request = new NextRequest(
-        new URL("/auth/logout", "https://example.com"),
-        { method: "GET", headers }
-      );
-
-      await authClient.handleLogout(request);
-
-      expect(oauth.revocationRequest).not.toHaveBeenCalled();
-    });
   });
 
   describe("discovery guard — mtls_endpoint_aliases missing", () => {


### PR DESCRIPTION
  - [x] All new/changed/fixed functionality is covered by tests
  - [x] I have added documentation for all new/changed functionality

  ### 📋 Changes

  Adds refresh token revocation support (RFC 7009) to `Auth0Client` and extends logout to revoke the session's refresh
  token for all clients.

  **New public API — `revokeRefreshToken(options?)`**

  Revokes the refresh token stored in the current session at Auth0's `/oauth/revoke` endpoint. Auth0 will also invalidate
  all access tokens issued under the same authorization grant when the refresh token is revoked — any subsequent API
  calls using those tokens will fail. Note that the local session cookie is not cleared; call `handleLogout` for a full
  logout that also clears the session.

  ```ts
  // App Router
  await auth0.revokeRefreshToken();

  // Pages Router
  await auth0.revokeRefreshToken({ req });
```

  Throws TokenRevocationError (exported from the package) if there is no active session, the session has no refresh
  token, or the revocation request fails. The error carries a code field (missing_session, missing_refresh_token,
  failed_to_revoke) for programmatic handling.

  Logout revocation — now applies to all clients

  Previously, the logout flow only revoked the refresh token when mTLS was in use. This change revokes the refresh token
  on every logout when a refresh token is present in the session, regardless of the client authentication method. A
  failed revocation emits a console.warn and does not block the logout redirect.

  Client authentication and mTLS

  clientSecret, Private Key JWT, and mTLS authentication are all handled automatically from the existing Auth0Client
  configuration. For mTLS clients, oauth4webapi transparently routes the revocation request to
  mtls_endpoint_aliases.revocation_endpoint from the discovery document — no additional configuration is required.

  📎 References

  - https://datatracker.ietf.org/doc/html/rfc7009

  🎯 Testing

  Unit tests cover:

  - AuthClient.revokeToken — success with client credentials forwarded, token_type_hint omitted when not provided, empty
  token guard, error response from Auth0
  - Auth0Client.revokeRefreshToken — happy path, MISSING_SESSION, MISSING_REFRESH_TOKEN
  - Logout revocation — non-mTLS clients now call the revocation endpoint on logout
  - mTLS — revocation endpoint alias routing continues to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `revokeRefreshToken` to explicitly revoke refresh tokens at the authorization server (RFC 7009), supporting both App Router and Pages Router request contexts.
  * Added `TokenRevocationError` and `TokenRevocationErrorCode` for handling missing session/refresh token and revocation failures (including typed causes).
  * Logout now attempts refresh-token revocation when available, but never blocks the redirect; failures are handled gracefully.
* **Documentation**
  * Expanded “Revoking tokens” docs with endpoint details, usage examples, and documented error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->