### PR TITLE
fix: generate and store nonce in magic-link transaction for ID token …

### DIFF
--- a/src/server/auth-client.test.ts
+++ b/src/server/auth-client.test.ts
@@ -4346,6 +4346,67 @@ ca/T0LLtgmbMmxSv/MmzIg==
       expect(transactionCookie!.maxAge).toEqual(0);
     });
 
+    it("should reject the callback when the ID token's nonce does not match the transaction's stored nonce", async () => {
+      const state = "transaction-state";
+      const code = "auth-code";
+
+      const secret = await generateSecret(32);
+      const transactionStore = new TransactionStore({ secret });
+      const sessionStore = new StatelessSessionStore({ secret });
+      const authClient = new AuthClient({
+        transactionStore,
+        sessionStore,
+
+        domain: DEFAULT.domain,
+        clientId: DEFAULT.clientId,
+        clientSecret: DEFAULT.clientSecret,
+
+        secret,
+        appBaseUrl: DEFAULT.appBaseUrl,
+
+        routes: getDefaultRoutes(),
+
+        // The mock token endpoint returns an ID token signed with a nonce
+        // that differs from the one stored in the transaction below —
+        // this is what a magic-link ID token replay would look like.
+        fetch: getMockAuthorizationServer({ nonce: "attacker-supplied-nonce" })
+      });
+
+      const url = new URL("/auth/callback", DEFAULT.appBaseUrl);
+      url.searchParams.set("code", code);
+      url.searchParams.set("state", state);
+
+      const headers = new Headers();
+      const transactionState: TransactionState = {
+        nonce: "nonce-value",
+        codeVerifier: "code-verifier",
+        responseType: RESPONSE_TYPES.CODE,
+        state: state,
+        returnTo: "/dashboard"
+      };
+      const maxAge = 60 * 60;
+      const expiration = Math.floor(Date.now() / 1000 + maxAge);
+      headers.set(
+        "cookie",
+        `__txn_${state}=${await encrypt(transactionState, secret, expiration)}`
+      );
+      const request = new NextRequest(url, {
+        method: "GET",
+        headers
+      });
+
+      const response = await authClient.handleCallback(request);
+
+      // oauth4webapi's expectedNonce check fails and throws; the SDK
+      // surfaces this as a 500 AuthorizationCodeGrantError, matching the
+      // max_age mismatch case below. No session cookie should be set.
+      expect(response.status).toEqual(500);
+      expect(await response.text()).toEqual(
+        "An error occurred while trying to exchange the authorization code."
+      );
+      expect(response.cookies.get("__session")).toBeUndefined();
+    });
+
     it("should reject at login when session_expiry is already in the past — no session cookie, no redirect to returnTo", async () => {
       // IPSIE: if the upstream IdP asserts a ceiling that is already expired at
       // the moment of login, handleCallback must not persist the session.

--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -5327,6 +5327,7 @@ export class AuthClient {
         appBaseUrl
       ).toString();
       const state = oauth.generateRandomState();
+      const nonce = oauth.generateRandomNonce();
 
       // Preserve tenant-level authorizationParameters (org, acr_values, etc.)
       // but exclude PKCE and fields we set explicitly.
@@ -5359,6 +5360,7 @@ export class AuthClient {
           response_type: RESPONSE_TYPES.CODE,
           scope,
           state,
+          nonce,
           ...(audience && { audience })
         }
       };
@@ -5366,6 +5368,7 @@ export class AuthClient {
       magicLinkTransactionState = {
         responseType: RESPONSE_TYPES.CODE,
         state,
+        nonce,
         returnTo: this.signInReturnToPath,
         scope,
         audience: this.authorizationParameters.audience as string | undefined,

--- a/src/server/passwordless-server.flow.test.ts
+++ b/src/server/passwordless-server.flow.test.ts
@@ -15,7 +15,7 @@ import type { SessionData } from "../types/index.js";
 import { generateDpopKeyPair } from "../utils/dpopRetry.js";
 import { AuthClientProvider } from "./auth-client-provider.js";
 import { AuthClient } from "./auth-client.js";
-import { encrypt } from "./cookies.js";
+import { decrypt, encrypt } from "./cookies.js";
 import { ServerPasswordlessClient } from "./passwordless/server-passwordless-client.js";
 import { StatelessSessionStore } from "./session/stateless-session-store.js";
 import { TransactionStore } from "./transaction-store.js";
@@ -238,6 +238,41 @@ describe("AuthClient passwordless methods", () => {
       expect(authParams.state).toBeTruthy();
       expect(authParams.redirect_uri).toContain("/auth/callback");
       expect(authParams.response_type).toBe("code");
+    });
+
+    it("includes nonce in authParams sent to Auth0 and stores matching nonce in transaction cookie", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `https://${DEFAULT.domain}/passwordless/start`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({}, { status: 200 });
+          }
+        )
+      );
+
+      const headers = new Headers();
+      const resCookies = new ResponseCookies(headers);
+      await authClient.passwordlessStart(
+        { connection: "email", email: DEFAULT.email, send: "link" },
+        resCookies
+      );
+
+      const authParams = capturedBody.authParams as Record<string, string>;
+      expect(authParams.nonce).toBeTruthy();
+
+      // The transaction cookie must carry the same nonce so the callback can
+      // verify the ID token's nonce claim and prevent replay attacks.
+      const state = authParams.state as string;
+      const txnCookie = resCookies.get(`__txn_${state}`);
+      expect(txnCookie).toBeDefined();
+      const { payload } = (await decrypt(
+        txnCookie!.value,
+        secret
+      )) as jose.JWTDecryptResult;
+      expect(payload.nonce).toBe(authParams.nonce);
     });
 
     it("writes a transaction cookie to resCookies after a successful start", async () => {


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Magic-link passwordless flows (`send: 'link'`) now generate a nonce alongside `state` when building the authorization request. The nonce is:
  - included in `authParams` forwarded to Auth0 in the `/passwordless/start` request body, so Auth0 embeds it in the magic     link's authorization URL
  - stored in the transaction cookie alongside `state`

When the magic link is followed and the callback completes the authorization code exchange, `processAuthorizationCodeResponse` receives the stored nonce as `expectedNonce` and verifies it matches the `nonce` claim in the returned ID token. Without this fix, `expectedNonce` was `undefined` and the check was silently skipped, an attacker who extracted an ID token from a completed magic-link flow could replay it in a different session.

  OTP flows (`send: 'code'`) are not affected — they do not use an authorization code callback and are not impacted by this change.

  ### 📎 References

  - Identified during cross-review of auth0/auth0-server-python#134
  - RFC 3986 / OpenID Connect Core §3.3 nonce binding requirement

  ### 🎯 Testing

  New unit test in `passwordless-server.flow.test.ts`:
  - Asserts `nonce` is present in `authParams` sent to Auth0
  - Decrypts the transaction cookie and asserts the stored `nonce` matches the value forwarded to Auth0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magic-link sign-in security by including a nonce in the sign-in request and validating it during callback processing.
  * If the returned ID token nonce doesn’t match the expected value, the flow now fails safely without creating a session cookie.
* **Tests**
  * Added/extended coverage to verify the nonce is present in the `/passwordless/start` payload, stored in transaction state, and correctly enforced during callback nonce mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->