### PR TITLE
fix: preserve ports for insecure issuer URLs

### DIFF
--- a/src/utils/normalize.test.ts
+++ b/src/utils/normalize.test.ts
@@ -282,6 +282,16 @@ describe("normalize.ts", () => {
         });
       });
 
+      it("should preserve ports for insecure issuer URLs", () => {
+        const result = normalizeDomain("http://localhost:8085/realm", {
+          allowInsecureRequests: true
+        });
+        expect(result).toEqual({
+          domain: "localhost",
+          issuer: "http://localhost:8085/realm"
+        });
+      });
+
       it("should accept URLs with paths (e.g. Okta custom auth servers) without adding trailing slash", () => {
         // RFC 8414 does not require a trailing slash. Path-based issuers must be
         // preserved verbatim so they match the provider's discovery document exactly.

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -164,6 +164,7 @@ export function normalizeDomain(
   let hostname: string;
   let scheme = "https";
   let urlPath = "/";
+  let port = "";
 
   try {
     // Try to parse as a URL (case-insensitive scheme detection)
@@ -172,6 +173,7 @@ export function normalizeDomain(
       const url = new URL(trimmed);
       hostname = url.hostname;
       scheme = url.protocol.replace(":", "");
+      port = url.port;
 
       // Reject query strings and fragments; paths are allowed for providers like
       // Okta custom authorization servers (e.g. myorg.okta.com/oauth2/default)
@@ -212,7 +214,8 @@ export function normalizeDomain(
     issuer = normalizeIssuer(options.issuerHint);
   } else {
     const protocol = options?.allowInsecureRequests ? scheme : "https";
-    const rawIssuer = `${protocol}://${normalizedHostname}${urlPath}`;
+    const portSuffix = options?.allowInsecureRequests && port ? `:${port}` : "";
+    const rawIssuer = `${protocol}://${normalizedHostname}${portSuffix}${urlPath}`;
     // For root-path issuers (hostname only), add a trailing slash to match
     // Auth0's canonical issuer format (https://tenant.auth0.com/).
     // For path-based issuers (e.g. Okta /oauth2/default, IBM /oidc/endpoint/default),


### PR DESCRIPTION
Fixes #2777

`URL.hostname` excludes the port, so `normalizeDomain()` previously rebuilt a full insecure issuer URL without its explicitly supplied non-standard port.

Capture `URL.port` during parsing and append it only when `allowInsecureRequests` is enabled. This preserves the existing production behavior while allowing local issuer URLs such as `http://localhost:8085/realm`.

Tested with `pnpm test:unit` (81 files, 1,836 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom ports in issuer URLs when insecure requests are enabled.
  * Improved local development connectivity for issuers using non-standard ports.
* **Tests**
  * Added coverage verifying that issuer ports remain intact during URL normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->