### PR TITLE
fix(server): sanitize returnTo in handleLogout via toSafeRedirect

### DIFF
--- a/src/server/auth-client.ts
+++ b/src/server/auth-client.ts
@@ -1067,7 +1067,13 @@ export class AuthClient {
     }
 
     const appBaseUrl = resolveAppBaseUrl(this.appBaseUrl, req);
-    const returnTo = req.nextUrl.searchParams.get("returnTo") || appBaseUrl;
+    const rawReturnTo = req.nextUrl.searchParams.get("returnTo");
+    const safeReturnTo = rawReturnTo
+      ? toSafeRedirect(rawReturnTo, new URL(appBaseUrl))
+      : null;
+    const returnTo: string = safeReturnTo
+      ? (rawReturnTo as string)
+      : appBaseUrl;
     const logoutState = req.nextUrl.searchParams.get("state");
     const federated = req.nextUrl.searchParams.has("federated");
 

--- a/src/server/logout-strategy.flow.test.ts
+++ b/src/server/logout-strategy.flow.test.ts
@@ -769,7 +769,7 @@ describe("Logout Strategy Flow Tests", () => {
     });
 
     it("should work with federated parameter and custom returnTo", async () => {
-      const customReturnTo = "https://example.com/custom-logout";
+      const customReturnTo = "http://localhost:3000/custom-logout";
       const authClient = new AuthClient({
         domain: DEFAULT.domain,
         clientId: DEFAULT.clientId,


### PR DESCRIPTION
Logout was accepting `?returnTo=` without checking where it points.

`GET /auth/logout?returnTo=https://evil.com` got passed straight into `returnTo` and `post_logout_redirect_uri`. Login already checks `returnTo` with `toSafeRedirect` and falls back to `appBaseUrl`, logout did not. That is the gap.

This patch makes logout use the same check. If `returnTo` is not same-origin it falls back to `appBaseUrl`. `https://evil.com`, `//evil.com` and `javascript:` are now blocked, `/dashboard` still works.

Changed:
- `src/server/auth-client.ts:1070` uses `toSafeRedirect` now
- `src/server/logout-strategy.flow.test.ts:772` uses a same-origin URL

Base is `963aa38`. I tested on `bugcrowd-1233`: with `Allowed Logout URLs` set to `https://evil.com`, `v2/logout?returnTo=https://evil.com` returned 302 to evil.com. After clearing the list it returned 400.

Tests: `pnpm test:unit` 1963 passed.
