### PR TITLE
feat: add session.rollingThreshold to reduce redundant rolling-session Set-Cookie writes

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -3847,6 +3847,7 @@ export const auth0 = new Auth0Client({
 | Option             | Type      | Description                                                                                                                                                                                                                                   |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | rolling            | `boolean` | When enabled, the session will continue to be extended as long as it is used within the inactivity duration. Once the upper bound, set via the `absoluteDuration`, has been reached, the session will no longer be extended. Default: `true`. |
+| rollingThreshold   | `number`  | Minimum number of seconds that must elapse between rolling-session cookie writes. When set, a request that arrives before the threshold has elapsed since the session was last rolled skips the `Set-Cookie` write entirely, instead of rolling on every eligible request. Useful to avoid re-issuing the session cookie (and invalidating the Next.js Router Cache) when several Server Actions fire in quick succession. The value must be specified in seconds. Default: `0` (no threshold). |
 | absoluteDuration   | `number`  | The absolute duration after which the session will expire. The value must be specified in seconds. Default: `3 days`.                                                                                                                         |
 | inactivityDuration | `number`  | The duration of inactivity after which the session will expire. The value must be specified in seconds. Default: `1 day`.                                                                                                                     |
 
@@ -3884,6 +3885,38 @@ export const config = {
 
 > [!WARNING]
 > Disabling rolling sessions changes the user experience significantly. Users will be logged out after the absolute duration regardless of their activity level, requiring manual re-authentication.
+
+### Reducing rolling-session `Set-Cookie` frequency
+
+Because rolling sessions extend the cookie's lifetime on every eligible request, `auth0.middleware()` sends a `Set-Cookie` header on every request that isn't otherwise handled — including Server Action invocations. A `Set-Cookie` on a Server Action response makes Next.js invalidate the Router Cache and re-fetch RSC data, which can look like the page reloading itself on every action call (or even loop, if the action is triggered from a `useEffect`).
+
+Two options let you cut down on these redundant cookie writes without disabling rolling sessions entirely:
+
+- **`session.rollingThreshold`** — skips the roll (and the `Set-Cookie` write) if the session was already rolled within the last `N` seconds, regardless of route. This is the simplest fix for bursts of Server Action calls happening close together:
+
+  ```ts
+  export const auth0 = new Auth0Client({
+    session: {
+      rollingThreshold: 60 // don't re-roll more than once per minute
+    }
+  });
+  ```
+
+- **`session.beforeSessionRolled`** — a predicate you control per request, useful when you only want to skip rolling for a specific route:
+
+  ```ts
+  export const auth0 = new Auth0Client({
+    session: {
+      beforeSessionRolled: async (req) => {
+        const isServerAction = req.headers.get("Next-Action") !== null;
+        const isAffectedPage = req.nextUrl.pathname === "/your-page";
+        return !(isServerAction && isAffectedPage);
+      }
+    }
+  });
+  ```
+
+Both options are safe from a security standpoint: `getSession()` and all access-control checks are unaffected — you are only choosing not to extend the cookie's expiry on every single request. See [#2124](https://github.com/auth0/nextjs-auth0/issues/2124) for the full discussion.
 
 ## Cookie Configuration
 

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -3,6 +3,8 @@ import type { NextRequest } from "next/server.js";
 import type { SessionData, SessionDataStore } from "../../types/index.js";
 import {
   CookieOptions,
+  decrypt,
+  getChunkedCookie,
   ReadonlyRequestCookies,
   RequestCookies,
   ResponseCookies
@@ -85,6 +87,28 @@ export interface SessionConfiguration {
    */
   beforeSessionRolled?: BeforeSessionRolledHook;
   /**
+   * Minimum number of seconds that must elapse between two rolling-session
+   * cookie writes. Only consulted when `rolling` is enabled, and applies to
+   * the middleware's passive session-touch path — the same path `beforeSessionRolled`
+   * guards.
+   *
+   * A request that arrives before the threshold has elapsed since the session
+   * cookie was last (re)issued skips the write entirely: no `Set-Cookie` header
+   * is sent and the backing store (for stateful sessions) is not touched. This
+   * is a route-agnostic complement to `beforeSessionRolled` for cutting down
+   * on redundant `Set-Cookie` headers — e.g. when a page fires several Server
+   * Actions in quick succession, each of which would otherwise re-roll the
+   * session and invalidate the Next.js Router Cache.
+   *
+   * The check only reads the `exp` claim off the existing session cookie (no
+   * backing-store read for stateful sessions), so it is cheap even when the
+   * threshold is not met.
+   *
+   * Default: `0` (no threshold; every eligible request rolls the session,
+   * matching prior behavior).
+   */
+  rollingThreshold?: number;
+  /**
    * The absolute duration after which the session will expire. The value must be specified in seconds.
    *
    * Once the absolute duration has been reached, the session will no longer be extended.
@@ -122,6 +146,7 @@ export abstract class AbstractSessionStore {
 
   protected rolling: boolean;
   private beforeSessionRolled?: BeforeSessionRolledHook;
+  private rollingThreshold: number;
   private absoluteDuration: number;
   private inactivityDuration: number;
 
@@ -134,6 +159,7 @@ export abstract class AbstractSessionStore {
 
     rolling = true,
     beforeSessionRolled,
+    rollingThreshold = 0,
     absoluteDuration = 60 * 60 * 24 * 3, // 3 days in seconds
     inactivityDuration = 60 * 60 * 24 * 1, // 1 day in seconds
     store,
@@ -144,6 +170,7 @@ export abstract class AbstractSessionStore {
 
     this.rolling = rolling;
     this.beforeSessionRolled = beforeSessionRolled;
+    this.rollingThreshold = rollingThreshold > 0 ? rollingThreshold : 0;
     this.absoluteDuration = absoluteDuration;
     this.inactivityDuration = inactivityDuration;
     this.store = store;
@@ -213,6 +240,13 @@ export abstract class AbstractSessionStore {
       return false;
     }
 
+    if (
+      this.rollingThreshold > 0 &&
+      (await this.isWithinRollingThreshold(req.cookies as RequestCookies))
+    ) {
+      return false;
+    }
+
     if (!this.beforeSessionRolled) {
       return true;
     }
@@ -226,6 +260,37 @@ export abstract class AbstractSessionStore {
       );
       return true;
     }
+  }
+
+  /**
+   * Returns true when the existing session cookie still carries close to a
+   * full `inactivityDuration` of remaining validity, meaning it was rolled
+   * recently (within `rollingThreshold` seconds) and does not need to be
+   * re-issued yet.
+   *
+   * Only the outer session cookie's `exp` claim is decrypted here - for
+   * stateful sessions this deliberately avoids a backing-store round trip
+   * just to decide whether a roll is due.
+   */
+  private async isWithinRollingThreshold(
+    reqCookies: RequestCookies
+  ): Promise<boolean> {
+    const cookieValue = getChunkedCookie(this.sessionCookieName, reqCookies);
+    if (!cookieValue) {
+      return false;
+    }
+
+    const decrypted = await decrypt<Record<string, unknown>>(
+      cookieValue,
+      this.secret
+    );
+    const exp = decrypted?.payload.exp;
+    if (typeof exp !== "number") {
+      return false;
+    }
+
+    const remaining = exp - this.epoch();
+    return remaining >= this.inactivityDuration - this.rollingThreshold;
   }
 
   /**

--- a/src/server/session/abstract-session-store.ts
+++ b/src/server/session/abstract-session-store.ts
@@ -106,6 +106,10 @@ export interface SessionConfiguration {
    *
    * Default: `0` (no threshold; every eligible request rolls the session,
    * matching prior behavior).
+   *
+   * Must be smaller than `inactivityDuration`. Values greater than or equal to
+   * `inactivityDuration` are clamped down so the threshold can never make an
+   * active session appear "recently rolled" for its entire remaining lifetime.
    */
   rollingThreshold?: number;
   /**
@@ -170,9 +174,16 @@ export abstract class AbstractSessionStore {
 
     this.rolling = rolling;
     this.beforeSessionRolled = beforeSessionRolled;
-    this.rollingThreshold = rollingThreshold > 0 ? rollingThreshold : 0;
     this.absoluteDuration = absoluteDuration;
     this.inactivityDuration = inactivityDuration;
+    // Clamp to (0, inactivityDuration): a threshold >= inactivityDuration
+    // would make `inactivityDuration - rollingThreshold` non-positive, so
+    // `isWithinRollingThreshold` would consider every unexpired cookie
+    // "recently rolled" and the session would never actually be extended.
+    this.rollingThreshold =
+      rollingThreshold > 0
+        ? Math.min(rollingThreshold, inactivityDuration - 1)
+        : 0;
     this.store = store;
 
     this.sessionCookieName = cookieOptions?.name ?? SESSION_COOKIE_NAME;

--- a/src/server/session/stateful-session-store.ts
+++ b/src/server/session/stateful-session-store.ts
@@ -21,6 +21,7 @@ interface StatefulSessionStoreOptions {
 
   rolling?: boolean; // defaults to true
   beforeSessionRolled?: BeforeSessionRolledHook;
+  rollingThreshold?: number; // defaults to 0 (no threshold)
   absoluteDuration?: number; // defaults to 3 days
   inactivityDuration?: number; // defaults to 1 day
 
@@ -45,6 +46,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
     store,
     rolling,
     beforeSessionRolled,
+    rollingThreshold,
     absoluteDuration,
     inactivityDuration,
     cookieOptions
@@ -53,6 +55,7 @@ export class StatefulSessionStore extends AbstractSessionStore {
       secret,
       rolling,
       beforeSessionRolled,
+      rollingThreshold,
       absoluteDuration,
       inactivityDuration,
       cookieOptions

--- a/src/server/session/stateless-session-store.test.ts
+++ b/src/server/session/stateless-session-store.test.ts
@@ -133,6 +133,126 @@ describe("Stateless Session Store", async () => {
     });
   });
 
+  describe("shouldRollSession with rollingThreshold", async () => {
+    const buildRequest = () =>
+      new NextRequest("https://example.com/dashboard", { method: "GET" });
+
+    const buildRequestWithSessionExpiringIn = (
+      cookieValue: string
+    ): NextRequest => {
+      const headers = new Headers();
+      headers.append("cookie", `__session=${cookieValue}`);
+      return new NextRequest("https://example.com/dashboard", {
+        method: "GET",
+        headers
+      });
+    };
+
+    const encryptWithExp = async (secret: string, expiresInSeconds: number) =>
+      encrypt(
+        {
+          user: { sub: "user_123" },
+          tokenSet: { accessToken: "at_123", expiresAt: 123456 },
+          internal: {
+            sid: "auth0-sid",
+            createdAt: Math.floor(Date.now() / 1000)
+          }
+        } as unknown as SessionData,
+        secret,
+        Math.floor(Date.now() / 1000) + expiresInSeconds
+      );
+
+    it("should not roll when the session was rolled well within the threshold", async () => {
+      const secret = await generateSecret(32);
+      const inactivityDuration = 60 * 60 * 24; // 1 day
+      // Rolled ~5s ago: remaining is only slightly below a full inactivityDuration.
+      const cookieValue = await encryptWithExp(secret, inactivityDuration - 5);
+      const sessionStore = new StatelessSessionStore({
+        secret,
+        inactivityDuration,
+        rollingThreshold: 60
+      });
+
+      expect(
+        await sessionStore.shouldRollSession(
+          buildRequestWithSessionExpiringIn(cookieValue)
+        )
+      ).toBe(false);
+    });
+
+    it("should roll when the threshold has elapsed since the session was last rolled", async () => {
+      const secret = await generateSecret(32);
+      const inactivityDuration = 60 * 60 * 24; // 1 day
+      // Rolled 120s ago: past the 60s threshold.
+      const cookieValue = await encryptWithExp(
+        secret,
+        inactivityDuration - 120
+      );
+      const sessionStore = new StatelessSessionStore({
+        secret,
+        inactivityDuration,
+        rollingThreshold: 60
+      });
+
+      expect(
+        await sessionStore.shouldRollSession(
+          buildRequestWithSessionExpiringIn(cookieValue)
+        )
+      ).toBe(true);
+    });
+
+    it("should roll when there is no existing session cookie to compare against", async () => {
+      const secret = await generateSecret(32);
+      const sessionStore = new StatelessSessionStore({
+        secret,
+        rollingThreshold: 60
+      });
+
+      expect(await sessionStore.shouldRollSession(buildRequest())).toBe(true);
+    });
+
+    it("should skip consulting beforeSessionRolled when still within the threshold", async () => {
+      const secret = await generateSecret(32);
+      const inactivityDuration = 60 * 60 * 24;
+      const cookieValue = await encryptWithExp(secret, inactivityDuration - 5);
+      const beforeSessionRolled = vi.fn().mockReturnValue(true);
+      const sessionStore = new StatelessSessionStore({
+        secret,
+        inactivityDuration,
+        rollingThreshold: 60,
+        beforeSessionRolled
+      });
+
+      expect(
+        await sessionStore.shouldRollSession(
+          buildRequestWithSessionExpiringIn(cookieValue)
+        )
+      ).toBe(false);
+      expect(beforeSessionRolled).not.toHaveBeenCalled();
+    });
+
+    it("should still defer to beforeSessionRolled once the threshold has elapsed", async () => {
+      const secret = await generateSecret(32);
+      const inactivityDuration = 60 * 60 * 24;
+      const cookieValue = await encryptWithExp(
+        secret,
+        inactivityDuration - 120
+      );
+      const sessionStore = new StatelessSessionStore({
+        secret,
+        inactivityDuration,
+        rollingThreshold: 60,
+        beforeSessionRolled: () => false
+      });
+
+      expect(
+        await sessionStore.shouldRollSession(
+          buildRequestWithSessionExpiringIn(cookieValue)
+        )
+      ).toBe(false);
+    });
+  });
+
   describe("get", async () => {
     it("should return the decrypted session cookie if it exists", async () => {
       const secret = await generateSecret(32);

--- a/src/server/session/stateless-session-store.ts
+++ b/src/server/session/stateless-session-store.ts
@@ -46,6 +46,7 @@ interface StatelessSessionStoreOptions {
 
   rolling?: boolean; // defaults to true
   beforeSessionRolled?: BeforeSessionRolledHook;
+  rollingThreshold?: number; // defaults to 0 (no threshold)
   absoluteDuration?: number; // defaults to 3 days
   inactivityDuration?: number; // defaults to 1 day
 
@@ -59,6 +60,7 @@ export class StatelessSessionStore extends AbstractSessionStore {
     secret,
     rolling,
     beforeSessionRolled,
+    rollingThreshold,
     absoluteDuration,
     inactivityDuration,
     cookieOptions
@@ -67,6 +69,7 @@ export class StatelessSessionStore extends AbstractSessionStore {
       secret,
       rolling,
       beforeSessionRolled,
+      rollingThreshold,
       absoluteDuration,
       inactivityDuration,
       cookieOptions


### PR DESCRIPTION
Fixes #2124

## Problem

Rolling sessions emit a `Set-Cookie` header on *every* eligible request, including Server Action invocations. When a Server Action response carries a `Set-Cookie`, Next.js invalidates the Router Cache and triggers an RSC refetch — which surfaces as the whole page reloading on every action call, or looping when the action is fired from a `useEffect` (see the repro from @ik-southpole in the issue thread).

@Piyush-85 confirmed the root cause and, as an immediate workaround, pointed at the existing `beforeSessionRolled` hook (#2622) to skip rolling on specific affected routes, while noting a more general, route-agnostic SDK-level fix was in progress.

## Fix

Add an opt-in `session.rollingThreshold` (seconds). When set, the middleware's passive session-touch path skips re-issuing the session cookie (no `Set-Cookie`, no backing-store write for stateful sessions) if the session was already rolled within the threshold window:

```ts
export const auth0 = new Auth0Client({
  session: {
    rollingThreshold: 60 // don't re-roll more than once per minute
  }
});
```

This directly cuts down the Set-Cookie/Router-Cache-invalidation churn described in the issue for bursts of Server Action calls happening close together, without requiring per-route configuration.

Implementation notes:
- The "was this recently rolled?" check only decrypts the **outer** session cookie's `exp` claim (`getChunkedCookie` + `decrypt`) — for stateful sessions this deliberately avoids a backing-store round trip just to decide whether a roll is due, which is actually cheaper than today's unconditional touch path (see the existing `// TODO: we should try to avoid reading from the DB ... on every request` comment in `auth-client.ts`).
- No new persisted field: staleness is derived from the existing `exp` claim vs. `inactivityDuration`, so there's no `SessionData` shape change.
- `rollingThreshold` is checked before `beforeSessionRolled` in `shouldRollSession` — when the threshold hasn't elapsed, the hook isn't even invoked, and rolling proceeds exactly as before when unset (default `0`).
- Default is `0` (no threshold), so this is fully backward-compatible and opt-in.
- Documented in `EXAMPLES.md` alongside `beforeSessionRolled` (which wasn't yet documented there) as two complementary ways to reduce rolling-session cookie churn.

## Testing

- Added unit tests in `stateless-session-store.test.ts` covering: skip-when-fresh, roll-when-threshold-elapsed, roll-when-no-existing-cookie, and interaction with `beforeSessionRolled` (skipped entirely when within threshold; still consulted once the threshold elapses). The logic lives in the shared `AbstractSessionStore`, so these tests exercise the same code path used by `StatefulSessionStore`.
- `pnpm run build` — passes
- `pnpm run lint` (`tsc --noEmit` x2 + `eslint`) — passes
- `pnpm run test:unit` — 82 files / 1968 tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the optional `rollingThreshold` setting for rolling sessions to reduce redundant session-cookie rewrites.
  - Supports threshold configuration for both stateful and stateless sessions.
  - Route-specific controls remain available through existing session callbacks.

- **Documentation**
  - Added guidance on configuring `rollingThreshold` and reducing unnecessary `Set-Cookie` writes, including in Server Action scenarios.

- **Tests**
  - Added coverage for threshold timing, missing cookies, and callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->