### PR TITLE
fix: preserve multi-value query params in proxy URL builder

### DIFF
--- a/src/utils/proxy.test.ts
+++ b/src/utils/proxy.test.ts
@@ -367,11 +367,15 @@ describe("url", () => {
      */
     function createMockRequest(
       pathname: string,
-      searchParams: Record<string, string> = {}
+      searchParams: Record<string, string | string[]> = {}
     ): NextRequest {
       const url = new URL(`http://localhost${pathname}`);
       Object.entries(searchParams).forEach(([key, value]) => {
-        url.searchParams.set(key, value);
+        if (Array.isArray(value)) {
+          value.forEach((v) => url.searchParams.append(key, v));
+        } else {
+          url.searchParams.set(key, value);
+        }
       });
 
       return {
@@ -510,6 +514,47 @@ describe("url", () => {
         expect(result.toString()).toMatch(
           /https:\/\/issuer\/me\/v1\/profile\?.*includeMetadata=true/
         );
+      });
+
+      it("should preserve all values for repeated query parameter keys", () => {
+        const req = createMockRequest("/api/users", {
+          role: ["admin", "editor", "viewer"]
+        });
+        const options: ProxyOptions = {
+          proxyPath: "/api",
+          targetBaseUrl: "https://backend.example.com",
+          audience: "https://backend.example.com/",
+          scope: null
+        };
+
+        const result = transformTargetUrl(req, options);
+
+        expect(result.searchParams.getAll("role")).toEqual([
+          "admin",
+          "editor",
+          "viewer"
+        ]);
+      });
+
+      it("should preserve repeated keys mixed with single-value keys", () => {
+        const req = createMockRequest("/my-org/v1/members", {
+          filter: ["active", "pending"],
+          page: "1"
+        });
+        const options: ProxyOptions = {
+          proxyPath: "/my-org",
+          targetBaseUrl: "https://issuer/my-org",
+          audience: "https://issuer/my-org/",
+          scope: null
+        };
+
+        const result = transformTargetUrl(req, options);
+
+        expect(result.searchParams.getAll("filter")).toEqual([
+          "active",
+          "pending"
+        ]);
+        expect(result.searchParams.get("page")).toBe("1");
       });
     });
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -195,7 +195,7 @@ export function transformTargetUrl(
   const targetUrl = new URL(baseUrl.origin + finalPath);
 
   req.nextUrl.searchParams.forEach((value, key) => {
-    targetUrl.searchParams.set(key, value);
+    targetUrl.searchParams.append(key, value);
   });
 
   return targetUrl;


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)

### 📋 Changes

When a client passes repeated query parameters to the My Account or My Organization proxy (e.g. `?role=admin&role=editor`), only the last value was being forwarded to the upstream API. This happened because `URLSearchParams.set` overwrites earlier values when the same key appears more than once, so the upstream received a silently truncated query string.

Repeated keys are valid per RFC 3986 and are the standard way to pass arrays in a URL (OpenAPI 3.0 default). SDKs rely on this pattern for multi-value filters, so any call using them would lose data without any error or warning.

The fix switches `searchParams.set` to `searchParams.append` in the proxy URL builder, preserving all values for every key end-to-end. Single-value params are unaffected.

### 🎯 Testing

Added two unit tests to `src/utils/proxy.test.ts` covering the exact failure scenario: repeated keys forwarded intact, and repeated keys mixed with single-value keys. Also updated the `createMockRequest` test helper to accept `string[]` values so multi-value params can be expressed in future tests.

All 33 proxy unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved repeated query-parameter values when forwarding requests.
  - Ensured duplicate keys remain available alongside single-value parameters instead of being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->