### PR TITLE
fix: bind middleware to the Auth0Client instance

### DIFF
--- a/src/server/client.test.ts
+++ b/src/server/client.test.ts
@@ -3246,6 +3246,24 @@ describe("Auth0Client", () => {
       expect(handlerSpy).toHaveBeenCalledTimes(1);
       expect(result).toBeInstanceOf(NextResponse);
     });
+
+    it("should not throw when middleware is detached from the Auth0Client instance (e.g. `export default auth0.middleware` in proxy.ts/middleware.ts)", async () => {
+      const authClient = await client["provider"].forRequest(new Headers());
+      const handlerSpy = vi
+        .spyOn(authClient, "handler")
+        .mockResolvedValue(NextResponse.next());
+
+      // Simulate Next.js 16's `proxy.ts` convention of re-exporting the method
+      // directly as the default export, e.g. `export default auth0.middleware;`,
+      // which detaches it from the `client` instance.
+      const detachedMiddleware = client.middleware;
+
+      const req = new Request("https://myapp.test/", { method: "GET" });
+      const result = await detachedMiddleware(req as any);
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBeInstanceOf(NextResponse);
+    });
   });
 
   describe("Pages Router Set-Cookie header handling", () => {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -815,6 +815,16 @@ export class Auth0Client {
     if (staticClient) {
       staticClient.provider = this.provider;
     }
+
+    // Next.js 16's `proxy.ts` convention (and some `middleware.ts` setups) commonly
+    // re-export this method directly, e.g. `export default auth0.middleware;`, rather
+    // than wrapping it in a closure like `(req) => auth0.middleware(req)`. When the
+    // method is invoked that way, it is detached from the `Auth0Client` instance, so
+    // `this` is `undefined` inside the method body (per JS strict-mode semantics for
+    // unbound method calls), causing a `TypeError: Cannot read properties of
+    // undefined (reading 'provider')` on every request. Binding here makes
+    // `auth0.middleware` safe to pass around as a plain function reference.
+    this.middleware = this.middleware.bind(this);
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #2781.

`auth0.middleware()` throws `TypeError: Cannot read properties of undefined (reading 'provider')` when it is invoked detached from its `Auth0Client` instance — most notably when re-exported directly as the default export from Next.js 16's `proxy.ts`:

```ts
import { auth0 } from "./auth";
export default auth0.middleware; // detached reference
```

### Root cause

`Auth0Client.middleware` is a regular class method. When it's passed around as a plain function reference (as opposed to being called as `auth0.middleware(req)`), it loses its `this` binding. Under JS strict-mode semantics (which apply to ES module code, including the SDK's compiled output), calling an unbound method results in `this === undefined` inside the method body. The very first thing `middleware()` does is read `this.provider`, so the failure is:

```
TypeError: Cannot read properties of undefined (reading 'provider')
```

This exactly matches the reported crash, and I confirmed the mechanism with a minimal repro:

```js
"use strict";
class Foo {
  constructor() { this.provider = { x: 1 }; }
  async middleware(req) { console.log(this.provider); return "ok"; }
}
const foo = new Foo();
const mw = foo.middleware;
await mw({}); // TypeError: Cannot read properties of undefined (reading 'provider')
```

This is why the issue reporter saw the identical call succeed from a Route Handler (`auth0.middleware(req)`, bound) and crash from `proxy.ts` (`export default auth0.middleware`, unbound) — the discrepancy is about how the method is invoked, not the runtime (Edge vs Node) or Next.js version.

### Fix

Bind `middleware` to the `Auth0Client` instance at the end of the constructor:

```ts
this.middleware = this.middleware.bind(this);
```

This makes `auth0.middleware` safe to export/pass around as a plain function reference, matching how a number of users naturally try to wire it up (`export default auth0.middleware`), without requiring them to remember to wrap it in a closure.

The documented patterns in `README.md`/`V4_MIGRATION_GUIDE.md` (`export async function proxy(request) { return auth0.middleware(request); }`) already work correctly today because they call the method as `auth0.middleware(...)`; this fix simply makes the SDK robust to the other common calling convention too.

## Testing

- Added a regression test in `src/server/client.test.ts` that detaches `client.middleware` from the instance (simulating `export default auth0.middleware`) and calls it as a bare function, asserting it no longer throws and still dispatches to the SDK's request handler.
- `pnpm run test:unit` — all 1969 tests pass.
- `pnpm run lint` — passes (`tsc --noEmit` x2 + `eslint`).
- `pnpm run build` — passes.

## References

Fixes #2781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where authentication middleware could fail when exported or invoked without its original client context.
  * Middleware now works correctly with direct default exports in supported Next.js configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->