### PR TITLE
chore: add SCA scan workflow

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,36 @@
+name: SCA Scan
+
+# Example: invoke the reusable sca-scan workflow from auth0/devsecops-tooling.
+# Reusable workflows are called at job level via `uses:`.
+# Copy this job block into your .github/workflows/ file.
+#
+# Required org secrets (configured at org level in auth0/):
+#   SNYK_TOKEN            — Snyk organisation token
+#   SIGNAL_HANDLER_TOKEN  — scan-service telemetry auth
+#   SIGNAL_HANDLER_DOMAIN — scan-service endpoint domain
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── SCA / Snyk scan via reusable workflow ───────────────────────────────────
+  sca:
+    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@e29f26478db18ff0bcbe4bc447a8fbd54fbeec9e
+    with:
+      # All inputs are optional — defaults shown. Uncomment and override as needed.
+      # node-version:     '16'
+      # java-version:     '11'
+      # go-version:       '1.22'
+      # python-version:   '3.10'
+      # ruby-version:     '4.0'
+      # php-version:      '8.5'
+      # dotnet-version:   '6'
+      # dotnet-install-dir: '/usr/share/dotnet/'
+      # snyk-version:     'v1.1292.0'
+      # additional-arguments: ''   # extra Snyk CLI flags, e.g. '--severity-threshold=high'
+      # pre-scan-commands:    ''   # shell commands to run before Snyk (e.g. 'npm ci')
+      # runner:           'ubuntu-latest'
+    secrets: inherit


### PR DESCRIPTION
## ✏️ Changes

This pull request adds a security hardening workflow from the unified-pipeline-template (https://github.com/atko-cic/unified-pipeline-template/security). **No functional changes are introduced.**

### SCA Scan

This PR adds `.github/workflows/sca.yml` from the unified-pipeline-template. It uses okta approved sca workflow from auth0/devsecops-tooling : 'auth0/devsecops-tooling/.github/workflows/sca-scan.yml@e29f26478db18ff0bcbe4bc447a8fbd54fbeec9e'

> **⚠️ Before merging, review the added `.github/workflows/sca.yml` and make the changes described below, plus any other adjustments your CI environment requires.**

### Placeholders to fill in before merging

| Placeholder | Description |
|---|---|
| SHA in `uses:` | Replace "replace with tagged SHA" SHA with the current pinned SHA |

### Required org secrets (must be present)
- `SNYK_TOKEN`
- `SIGNAL_HANDLER_TOKEN`
- `SIGNAL_HANDLER_DOMAIN`



## 🔮 Type of Change

- [x] Standard

## 🔗 References

https://auth0team.atlassian.net/browse/SEPIO-1674

- [x] I added at least one link (task, slack thread, etc) to explain why this change is needed.

## 📖 Documentation

No user-facing changes have been introduced.

- [x] I reflected this change in the (internal and/or user-facing) documentation, or added an explanation for why no documentation update is needed.

## 🎯 Testing

This change adds a CI workflow only; validated by the workflow running on this PR.

- [x] This change has integration, unit, or performance test coverage, or I explained why not.

## 🚀 Deployment

- [x] This change can support multiple releases of the code serving traffic at the same time.

## 🔥 Rollback

Reverting this PR removes the added workflow file — no further action required.

- [x] I explained what the rollback for this change will look like.